### PR TITLE
Fix mobile new task button not responding

### DIFF
--- a/resources/js/components/tasks/TaskQuickAdd.vue
+++ b/resources/js/components/tasks/TaskQuickAdd.vue
@@ -130,6 +130,8 @@ const startEditing = async () => {
   inputRef.value?.focus()
 }
 
+defineExpose({ startEditing })
+
 const cancel = () => {
   isEditing.value = false
   title.value = ''

--- a/resources/js/views/tasks/TasksView.vue
+++ b/resources/js/views/tasks/TasksView.vue
@@ -68,9 +68,9 @@
     </div>
 
     <!-- Tasks -->
-    <div v-else class="flex-1 overflow-y-auto pb-32 md:pb-6">
+    <div v-else ref="scrollContainerRef" class="flex-1 overflow-y-auto pb-32 md:pb-6">
       <!-- Quick add -->
-      <TaskQuickAdd :tags="tags" @add="handleQuickAdd" />
+      <TaskQuickAdd ref="quickAddRef" :tags="tags" @add="handleQuickAdd" />
 
       <!-- Incomplete tasks -->
       <div v-if="filteredIncompleteTasks.length > 0" class="mt-2">
@@ -289,6 +289,8 @@ const showTagManager = ref(false)
 const editingTag = ref(null)
 const newTagName = ref('')
 const newTagColor = ref('wisteria')
+const scrollContainerRef = ref(null)
+const quickAddRef = ref(null)
 
 const tagColorOptions = ['wisteria', 'prussian', 'sand', 'red', 'green', 'pink']
 const colorMap = {
@@ -415,7 +417,8 @@ const handleDeleteTag = async (tag) => {
 }
 
 const focusQuickAdd = () => {
-  window.scrollTo({ top: 0, behavior: 'smooth' })
+  scrollContainerRef.value?.scrollTo({ top: 0, behavior: 'smooth' })
+  quickAddRef.value?.startEditing()
 }
 
 onMounted(async () => {


### PR DESCRIPTION
## Summary
- Fixes #23
- The floating action button (+ circle) on the mobile task screen was calling `window.scrollTo()`, which had no effect because the task list scrolls inside a nested `overflow-y-auto` container, not the window itself. The function also never actually opened the quick-add input for task creation.
- Fixed by scrolling the correct container element and calling `TaskQuickAdd.startEditing()` so the quick-add input appears and receives focus when the FAB is tapped.

## Test plan
- [ ] Open app on mobile viewport
- [ ] Navigate to tasks view
- [ ] Tap the floating action button (+ circle)
- [ ] Verify the task list scrolls to top and the quick-add input appears with focus
- [ ] Verify new task creation flow works end-to-end
- [ ] Verify button also works on desktop (FAB is hidden on desktop via `md:hidden`, but the quick-add is always visible)

🤖 Generated with [Claude Code](https://claude.com/claude-code)