### PR TITLE
Add recurring task label showing schedule

### DIFF
--- a/app/Http/Controllers/Api/V1/TaskController.php
+++ b/app/Http/Controllers/Api/V1/TaskController.php
@@ -71,7 +71,7 @@ class TaskController extends Controller
         }
 
         $tasks = $query
-            ->with(['creator', 'assignee', 'tags'])
+            ->with(['creator', 'assignee', 'tags', 'parentTask'])
             ->orderByRaw('completed_at IS NOT NULL')
             ->orderBy('due_date')
             ->orderBy('sort_order')
@@ -90,7 +90,7 @@ class TaskController extends Controller
         $this->authorize('view', $taskList);
 
         $tasks = $taskList->tasks()
-            ->with(['creator', 'assignee', 'tags'])
+            ->with(['creator', 'assignee', 'tags', 'parentTask'])
             ->orderBy('sort_order')
             ->get();
 

--- a/app/Http/Resources/TaskResource.php
+++ b/app/Http/Resources/TaskResource.php
@@ -29,6 +29,7 @@ class TaskResource extends JsonResource
             'points' => $this->points,
             'effective_points' => $this->getEffectivePoints(),
             'recurrence_rule' => $this->recurrence_rule,
+            'recurrence_label' => $this->recurrence_label,
             'recurrence_end' => $this->recurrence_end,
             'parent_task_id' => $this->parent_task_id,
             'creator' => UserResource::make($this->whenLoaded('creator')),

--- a/app/Models/Task.php
+++ b/app/Models/Task.php
@@ -225,4 +225,80 @@ class Task extends Model
     {
         return $this->recurrence_rule !== null && $this->parent_task_id === null;
     }
+
+    /**
+     * Get a human-readable label for the recurrence rule.
+     *
+     * Parses RRULE strings into friendly text like "Daily", "Every Tuesday",
+     * "Every Mon, Wed, Fri", or "Monthly on the 15th".
+     */
+    public function getRecurrenceLabelAttribute(): ?string
+    {
+        // Use the task's own rule, or inherit from parent template
+        $rule = $this->recurrence_rule ?? $this->parentTask?->recurrence_rule;
+
+        if (!$rule) {
+            return null;
+        }
+
+        // Parse RRULE parts into key-value pairs
+        $parts = [];
+        foreach (explode(';', $rule) as $part) {
+            $kv = explode('=', $part, 2);
+            if (count($kv) === 2) {
+                $parts[$kv[0]] = $kv[1];
+            }
+        }
+
+        $freq = $parts['FREQ'] ?? null;
+
+        if (!$freq) {
+            return null;
+        }
+
+        $dayNames = [
+            'MO' => 'Mon', 'TU' => 'Tue', 'WE' => 'Wed',
+            'TH' => 'Thu', 'FR' => 'Fri', 'SA' => 'Sat', 'SU' => 'Sun',
+        ];
+
+        $fullDayNames = [
+            'MO' => 'Monday', 'TU' => 'Tuesday', 'WE' => 'Wednesday',
+            'TH' => 'Thursday', 'FR' => 'Friday', 'SA' => 'Saturday', 'SU' => 'Sunday',
+        ];
+
+        switch ($freq) {
+            case 'DAILY':
+                return 'Daily';
+
+            case 'WEEKLY':
+                if (isset($parts['BYDAY'])) {
+                    $days = explode(',', $parts['BYDAY']);
+                    if (count($days) === 1) {
+                        return 'Every ' . ($fullDayNames[$days[0]] ?? $days[0]);
+                    }
+                    $labels = array_map(fn($d) => $dayNames[$d] ?? $d, $days);
+                    return 'Every ' . implode(', ', $labels);
+                }
+                return 'Weekly';
+
+            case 'MONTHLY':
+                if (isset($parts['BYMONTHDAY'])) {
+                    $day = (int) $parts['BYMONTHDAY'];
+                    $suffix = match (true) {
+                        $day === 1, $day === 21, $day === 31 => 'st',
+                        $day === 2, $day === 22 => 'nd',
+                        $day === 3, $day === 23 => 'rd',
+                        default => 'th',
+                    };
+                    return "Monthly on the {$day}{$suffix}";
+                }
+                return 'Monthly';
+
+            case 'YEARLY':
+                return 'Yearly';
+
+            default:
+                return 'Recurring';
+        }
+    }
 }

--- a/resources/js/components/tasks/TaskItem.vue
+++ b/resources/js/components/tasks/TaskItem.vue
@@ -75,9 +75,13 @@
           {{ task.effective_points }}pts
         </span>
 
-        <!-- Recurring indicator -->
-        <span v-if="task.recurrence_rule" class="text-xs text-lavender-400">
+        <!-- Recurring indicator with label -->
+        <span
+          v-if="task.recurrence_label || task.recurrence_rule"
+          class="inline-flex items-center gap-1 px-1.5 py-0.5 text-[10px] font-medium rounded-full bg-wisteria-100 text-wisteria-600 dark:bg-wisteria-900/30 dark:text-wisteria-400"
+        >
           <ArrowPathIcon class="w-3 h-3" />
+          {{ task.recurrence_label || 'Recurring' }}
         </span>
 
         <!-- Description indicator -->

--- a/resources/js/views/dashboard/DashboardView.vue
+++ b/resources/js/views/dashboard/DashboardView.vue
@@ -79,6 +79,13 @@
                 <span v-if="enabledModules.points && task.effective_points" class="text-xs text-wisteria-500 dark:text-wisteria-400 font-medium">
                   {{ task.effective_points }} pts
                 </span>
+                <span
+                  v-if="task.recurrence_label"
+                  class="inline-flex items-center gap-1 px-1.5 py-0.5 text-[10px] font-medium rounded-full bg-wisteria-100 text-wisteria-600 dark:bg-wisteria-900/30 dark:text-wisteria-400"
+                >
+                  <ArrowPathIcon class="w-3 h-3" />
+                  {{ task.recurrence_label }}
+                </span>
               </div>
             </div>
           </div>
@@ -217,6 +224,13 @@
                 <span v-if="enabledModules.points && task.effective_points" class="text-xs text-wisteria-500 dark:text-wisteria-400 font-medium">
                   {{ task.effective_points }} pts
                 </span>
+                <span
+                  v-if="task.recurrence_label"
+                  class="inline-flex items-center gap-1 px-1.5 py-0.5 text-[10px] font-medium rounded-full bg-wisteria-100 text-wisteria-600 dark:bg-wisteria-900/30 dark:text-wisteria-400"
+                >
+                  <ArrowPathIcon class="w-3 h-3" />
+                  {{ task.recurrence_label }}
+                </span>
               </div>
             </div>
           </div>
@@ -241,6 +255,7 @@ import LeaderboardStrip from '@/components/points/LeaderboardStrip.vue'
 import FeaturedRewards from '@/components/points/FeaturedRewards.vue'
 import BadgeShowcase from '@/components/badges/BadgeShowcase.vue'
 import {
+  ArrowPathIcon,
   CalendarIcon,
   CheckCircleIcon,
   SparklesIcon,


### PR DESCRIPTION
## Summary
- Fixes #24
- Adds a `recurrence_label` accessor on the Task model that parses RRULE strings into human-readable text (e.g., "Daily", "Every Tuesday", "Every Mon, Wed, Fri", "Monthly on the 15th")
- Includes `recurrence_label` in the TaskResource API response
- Displays the label as a subtle wisteria-colored pill badge with a repeat icon on TaskItem and Dashboard task lists
- Child task instances inherit the label from their parent template via the parentTask relation
- Supports light and dark mode

## Test plan
- [ ] Tasks with recurrence rules show a label (e.g., "Every Tuesday")
- [ ] Label appears on dashboard "My Tasks" and "Open Tasks" sections
- [ ] Label appears on task list view (TaskItem component)
- [ ] Non-recurring tasks don't show any label
- [ ] Dark mode styling works correctly
- [ ] Mobile layout isn't broken by the label
- [ ] Child instances of recurring templates show the parent's recurrence label

🤖 Generated with [Claude Code](https://claude.com/claude-code)