### PR TITLE
Add settings access on mobile layout

### DIFF
--- a/resources/js/App.vue
+++ b/resources/js/App.vue
@@ -11,9 +11,18 @@
       <!-- Mobile Header -->
       <div v-if="!isAuthPage" class="md:hidden bg-white dark:bg-prussian-800 px-4 py-2.5 flex items-center justify-between border-b border-lavender-200 dark:border-prussian-700">
         <p class="text-sm font-semibold text-prussian-500 dark:text-lavender-200">{{ familyName }}</p>
-        <RouterLink to="/settings" class="flex items-center gap-2">
-          <UserAvatar :user="currentUser" size="sm" class="ring-2 ring-lavender-300 dark:ring-prussian-600" />
-        </RouterLink>
+        <div class="flex items-center gap-2">
+          <RouterLink
+            to="/settings"
+            class="p-1.5 rounded-lg text-lavender-500 dark:text-lavender-400 hover:bg-lavender-100 dark:hover:bg-prussian-700 transition-colors"
+            aria-label="Settings"
+          >
+            <Cog6ToothIcon class="w-5 h-5" />
+          </RouterLink>
+          <RouterLink to="/settings" class="flex items-center">
+            <UserAvatar :user="currentUser" size="sm" class="ring-2 ring-lavender-300 dark:ring-prussian-600" />
+          </RouterLink>
+        </div>
       </div>
 
       <!-- Main Area -->
@@ -78,6 +87,7 @@ import BottomNav from '@/components/layout/BottomNav.vue'
 import LoadingSpinner from '@/components/common/LoadingSpinner.vue'
 import UserAvatar from '@/components/common/UserAvatar.vue'
 import EasterEggs from '@/components/common/EasterEggs.vue'
+import { Cog6ToothIcon } from '@heroicons/vue/24/outline'
 import { useNotification } from '@/composables/useNotification'
 import { useDarkMode } from '@/composables/useDarkMode'
 


### PR DESCRIPTION
## Summary
- Fixes #7
- Added a gear/cog icon (`Cog6ToothIcon`) next to the user avatar in the mobile header bar in `App.vue`
- Tapping the gear icon navigates to `/settings`, giving mobile users access to the admin panel (family settings, module toggles, rewards management, badges, invites, etc.)
- The avatar link to `/settings` is preserved alongside the new icon
- No changes to the bottom nav or desktop layout
- Uses the same styling pattern as the dark mode toggle in `TopBar.vue` (hover states, dark mode colors)

## Test plan
- [ ] Mobile viewport (375px) shows gear icon next to avatar in the header
- [ ] Tapping gear icon navigates to Settings
- [ ] Both parents and children can access basic settings
- [ ] Admin-only sections in Settings still gated by role
- [ ] Dark mode styling works (icon uses `lavender-500`/`lavender-400`)
- [ ] Desktop layout unchanged (mobile header is `md:hidden`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)