### PR TITLE
Add countdown banner for pinned featured event

### DIFF
--- a/app/Http/Controllers/Api/V1/FeaturedEventController.php
+++ b/app/Http/Controllers/Api/V1/FeaturedEventController.php
@@ -115,6 +115,66 @@ class FeaturedEventController extends Controller
     }
 
     /**
+     * Get the current countdown event for the family.
+     */
+    public function countdown(Request $request): JsonResponse
+    {
+        $family = $request->user()->currentFamily()->firstOrFail();
+
+        $event = FeaturedEvent::where('family_id', $family->id)
+            ->where('is_active', true)
+            ->where('is_countdown', true)
+            ->with('creator:id,name,avatar')
+            ->first();
+
+        if (!$event) {
+            return response()->json(['countdown_event' => null]);
+        }
+
+        // Compute next occurrence for recurring events
+        $event->computed_next_date = $event->next_occurrence;
+
+        return response()->json([
+            'countdown_event' => new FeaturedEventResource($event),
+        ]);
+    }
+
+    /**
+     * Set an event as the countdown event (parent only). Unsets any other countdown.
+     */
+    public function setCountdown(Request $request, FeaturedEvent $featuredEvent): JsonResponse
+    {
+        if (!$request->user()->isParent()) {
+            return response()->json(['message' => 'Only parents can set the countdown event'], 403);
+        }
+
+        $family = $request->user()->currentFamily()->firstOrFail();
+        if ($featuredEvent->family_id !== $family->id) {
+            return response()->json(['message' => 'Not found'], 404);
+        }
+
+        // Unset any existing countdown for this family
+        FeaturedEvent::where('family_id', $family->id)
+            ->where('is_countdown', true)
+            ->update(['is_countdown' => false]);
+
+        // Toggle: if this event was already the countdown, just unset it
+        if ($featuredEvent->is_countdown) {
+            $featuredEvent->refresh();
+            return response()->json([
+                'featured_event' => new FeaturedEventResource($featuredEvent),
+            ]);
+        }
+
+        // Set this event as the countdown
+        $featuredEvent->update(['is_countdown' => true]);
+
+        return response()->json([
+            'featured_event' => new FeaturedEventResource($featuredEvent),
+        ]);
+    }
+
+    /**
      * Delete a featured event (parent only).
      */
     public function destroy(Request $request, FeaturedEvent $featuredEvent): JsonResponse

--- a/app/Http/Resources/FeaturedEventResource.php
+++ b/app/Http/Resources/FeaturedEventResource.php
@@ -21,6 +21,7 @@ class FeaturedEventResource extends JsonResource
             'recurrence' => $this->recurrence,
             'recurrence_label' => $this->recurrence_label,
             'is_active' => $this->is_active,
+            'is_countdown' => $this->is_countdown,
             'creator' => UserResource::make($this->whenLoaded('creator')),
             'created_at' => $this->created_at,
             'updated_at' => $this->updated_at,

--- a/app/Models/FeaturedEvent.php
+++ b/app/Models/FeaturedEvent.php
@@ -22,6 +22,7 @@ class FeaturedEvent extends Model
         'color',
         'recurrence',
         'is_active',
+        'is_countdown',
     ];
 
     protected function casts(): array
@@ -30,6 +31,7 @@ class FeaturedEvent extends Model
             'event_date' => 'date',
             'event_time' => 'datetime:H:i',
             'is_active' => 'boolean',
+            'is_countdown' => 'boolean',
         ];
     }
 

--- a/database/migrations/2026_03_22_120000_add_is_countdown_to_featured_events_table.php
+++ b/database/migrations/2026_03_22_120000_add_is_countdown_to_featured_events_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('featured_events', function (Blueprint $table) {
+            $table->boolean('is_countdown')->default(false)->after('is_active');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('featured_events', function (Blueprint $table) {
+            $table->dropColumn('is_countdown');
+        });
+    }
+};

--- a/resources/js/components/featured-events/CountdownBanner.vue
+++ b/resources/js/components/featured-events/CountdownBanner.vue
@@ -1,0 +1,200 @@
+<template>
+  <transition
+    enter-active-class="transition duration-300 ease-out"
+    enter-from-class="opacity-0 -translate-y-2"
+    enter-to-class="opacity-100 translate-y-0"
+    leave-active-class="transition duration-200 ease-in"
+    leave-from-class="opacity-100 translate-y-0"
+    leave-to-class="opacity-0 -translate-y-2"
+  >
+    <div
+      v-if="countdownEvent && !isDismissed"
+      class="relative overflow-hidden rounded-2xl p-4 md:p-5 mb-4 md:mb-6"
+      :style="bannerStyle"
+    >
+      <!-- Background shimmer effect -->
+      <div class="absolute inset-0 opacity-20 pointer-events-none">
+        <div class="absolute inset-0 bg-gradient-to-r from-transparent via-white/30 to-transparent animate-shimmer" />
+      </div>
+
+      <div class="relative flex items-center gap-3 md:gap-4">
+        <!-- Event icon -->
+        <div
+          class="flex-shrink-0 w-12 h-12 md:w-14 md:h-14 rounded-xl flex items-center justify-center text-2xl md:text-3xl bg-white/20 backdrop-blur-sm shadow-sm"
+          :class="{ 'animate-bounce-gentle': isToday }"
+        >
+          {{ countdownEvent.icon }}
+        </div>
+
+        <!-- Countdown content -->
+        <div class="flex-1 min-w-0">
+          <p class="text-sm md:text-base font-bold text-white truncate">
+            {{ countdownEvent.title }}
+          </p>
+          <p class="text-lg md:text-xl font-extrabold text-white/95 leading-tight">
+            <template v-if="isToday">
+              {{ countdownEvent.title }} is TODAY!
+            </template>
+            <template v-else-if="isPast">
+              {{ countdownEvent.title }} has passed
+            </template>
+            <template v-else>
+              {{ countdownText }}
+            </template>
+          </p>
+        </div>
+
+        <!-- Celebration particles for today -->
+        <div v-if="isToday" class="flex-shrink-0 text-2xl md:text-3xl animate-bounce-gentle">
+          &#127881;
+        </div>
+
+        <!-- Dismiss button -->
+        <button
+          @click="dismiss"
+          class="flex-shrink-0 p-1.5 rounded-full bg-white/20 hover:bg-white/30 backdrop-blur-sm transition-colors text-white/80 hover:text-white"
+          aria-label="Dismiss countdown"
+        >
+          <XMarkIcon class="w-4 h-4" />
+        </button>
+      </div>
+
+      <!-- Date line below countdown -->
+      <div class="relative mt-1 ml-[60px] md:ml-[72px]">
+        <p class="text-xs text-white/70">
+          {{ formatEventDate(countdownEvent.event_date) }}
+          <span v-if="countdownEvent.event_time"> at {{ formatTime(countdownEvent.event_time) }}</span>
+        </p>
+      </div>
+    </div>
+  </transition>
+</template>
+
+<script setup>
+import { ref, computed, onMounted, onUnmounted } from 'vue'
+import { DateTime } from 'luxon'
+import { XMarkIcon } from '@heroicons/vue/24/outline'
+
+const props = defineProps({
+  countdownEvent: {
+    type: Object,
+    default: null,
+  },
+})
+
+const isDismissed = ref(false)
+const now = ref(DateTime.now())
+let intervalId = null
+
+onMounted(() => {
+  // Update every 60 seconds for the live countdown
+  intervalId = setInterval(() => {
+    now.value = DateTime.now()
+  }, 60_000)
+})
+
+onUnmounted(() => {
+  if (intervalId) {
+    clearInterval(intervalId)
+  }
+})
+
+const targetDateTime = computed(() => {
+  if (!props.countdownEvent) return null
+  const date = DateTime.fromISO(props.countdownEvent.event_date)
+  if (props.countdownEvent.event_time) {
+    const [h, m] = props.countdownEvent.event_time.split(':')
+    return date.set({ hour: parseInt(h), minute: parseInt(m), second: 0 })
+  }
+  // No time set — count down to midnight (start of the day)
+  return date.startOf('day')
+})
+
+const isToday = computed(() => {
+  if (!targetDateTime.value) return false
+  return targetDateTime.value.hasSame(now.value, 'day')
+})
+
+const isPast = computed(() => {
+  if (!targetDateTime.value) return false
+  return targetDateTime.value < now.value && !isToday.value
+})
+
+const countdownText = computed(() => {
+  if (!targetDateTime.value) return ''
+  const diff = targetDateTime.value.diff(now.value, ['days', 'hours', 'minutes']).toObject()
+  const days = Math.floor(diff.days || 0)
+  const hours = Math.floor(diff.hours || 0)
+  const minutes = Math.max(0, Math.floor(diff.minutes || 0))
+
+  const parts = []
+  if (days > 0) parts.push(`${days} day${days !== 1 ? 's' : ''}`)
+  if (hours > 0) parts.push(`${hours} hr${hours !== 1 ? 's' : ''}`)
+  if (days === 0 && minutes > 0) parts.push(`${minutes} min${minutes !== 1 ? 's' : ''}`)
+  // If only days remain, still show hours for more detail
+  if (parts.length === 0) parts.push('less than a minute')
+
+  return parts.join(', ') + ' to go!'
+})
+
+const bannerStyle = computed(() => {
+  const color = props.countdownEvent?.color || '#8B5CF6'
+  return {
+    background: `linear-gradient(135deg, ${color}, ${adjustColor(color, -30)})`,
+  }
+})
+
+const dismiss = () => {
+  isDismissed.value = true
+}
+
+const formatEventDate = (dateStr) => {
+  return DateTime.fromISO(dateStr).toFormat('EEEE, MMMM d, yyyy')
+}
+
+const formatTime = (timeStr) => {
+  const [h, m] = timeStr.split(':')
+  return DateTime.fromObject({ hour: parseInt(h), minute: parseInt(m) }).toFormat('h:mm a')
+}
+
+/**
+ * Darken or lighten a hex color by an amount.
+ */
+function adjustColor(hex, amount) {
+  let r = parseInt(hex.slice(1, 3), 16)
+  let g = parseInt(hex.slice(3, 5), 16)
+  let b = parseInt(hex.slice(5, 7), 16)
+  r = Math.max(0, Math.min(255, r + amount))
+  g = Math.max(0, Math.min(255, g + amount))
+  b = Math.max(0, Math.min(255, b + amount))
+  return `#${r.toString(16).padStart(2, '0')}${g.toString(16).padStart(2, '0')}${b.toString(16).padStart(2, '0')}`
+}
+</script>
+
+<style scoped>
+@keyframes shimmer {
+  0% {
+    transform: translateX(-100%);
+  }
+  100% {
+    transform: translateX(100%);
+  }
+}
+
+.animate-shimmer {
+  animation: shimmer 3s ease-in-out infinite;
+}
+
+@keyframes bounce-gentle {
+  0%, 100% {
+    transform: translateY(0);
+  }
+  50% {
+    transform: translateY(-4px);
+  }
+}
+
+.animate-bounce-gentle {
+  animation: bounce-gentle 2s ease-in-out infinite;
+}
+</style>

--- a/resources/js/components/featured-events/FeaturedEventsSection.vue
+++ b/resources/js/components/featured-events/FeaturedEventsSection.vue
@@ -31,12 +31,22 @@
           : 'bg-lavender-50/50 dark:bg-prussian-700/50'"
       >
         <!-- Icon -->
-        <div
-          class="flex-shrink-0 w-10 h-10 rounded-xl flex items-center justify-center text-lg"
-          :class="isToday(event.event_date) ? 'shadow-md' : ''"
-          :style="{ backgroundColor: event.color + '20' }"
-        >
-          {{ event.icon }}
+        <div class="relative flex-shrink-0">
+          <div
+            class="w-10 h-10 rounded-xl flex items-center justify-center text-lg"
+            :class="isToday(event.event_date) ? 'shadow-md' : ''"
+            :style="{ backgroundColor: event.color + '20' }"
+          >
+            {{ event.icon }}
+          </div>
+          <!-- Countdown pin indicator -->
+          <div
+            v-if="event.is_countdown"
+            class="absolute -top-1 -right-1 w-4 h-4 rounded-full bg-sand-500 flex items-center justify-center"
+            title="Countdown event"
+          >
+            <ClockIcon class="w-2.5 h-2.5 text-white" />
+          </div>
         </div>
 
         <!-- Info -->
@@ -90,6 +100,13 @@
               Edit
             </button>
             <button
+              @click="toggleCountdown(event)"
+              class="w-full text-left px-3 py-1.5 text-sm text-prussian-500 dark:text-lavender-200 hover:bg-lavender-50 dark:hover:bg-prussian-700 flex items-center gap-1.5"
+            >
+              <ClockIcon class="w-3.5 h-3.5" />
+              {{ event.is_countdown ? 'Remove Countdown' : 'Set as Countdown' }}
+            </button>
+            <button
               @click="confirmDelete(event)"
               class="w-full text-left px-3 py-1.5 text-sm text-red-600 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-900/20"
             >
@@ -139,7 +156,7 @@ import EmptyState from '@/components/common/EmptyState.vue'
 import LoadingSpinner from '@/components/common/LoadingSpinner.vue'
 import ConfirmDialog from '@/components/common/ConfirmDialog.vue'
 import FeaturedEventModal from './FeaturedEventModal.vue'
-import { StarIcon, PlusIcon, EllipsisVerticalIcon, ArrowPathIcon } from '@heroicons/vue/24/outline'
+import { StarIcon, PlusIcon, EllipsisVerticalIcon, ArrowPathIcon, ClockIcon } from '@heroicons/vue/24/outline'
 
 const props = defineProps({
   isParent: Boolean,
@@ -189,6 +206,15 @@ const editEvent = (event) => {
   editingEvent.value = { ...event }
   showEditModal.value = true
   openMenuId.value = null
+}
+
+const toggleCountdown = async (event) => {
+  openMenuId.value = null
+  try {
+    await store.setCountdown(event.id)
+  } catch {
+    // error is set in the store
+  }
 }
 
 const confirmDelete = (event) => {

--- a/resources/js/stores/featuredEvents.js
+++ b/resources/js/stores/featuredEvents.js
@@ -5,6 +5,7 @@ import api from '@/services/api'
 
 export const useFeaturedEventsStore = defineStore('featuredEvents', () => {
   const events = ref([])
+  const countdownEvent = ref(null)
   const isLoading = ref(false)
   const error = ref(null)
 
@@ -87,20 +88,69 @@ export const useFeaturedEventsStore = defineStore('featuredEvents', () => {
     try {
       await api.delete(`/featured-events/${id}`)
       events.value = events.value.filter((e) => e.id !== id)
+      // If the deleted event was the countdown, clear it
+      if (countdownEvent.value?.id === id) {
+        countdownEvent.value = null
+      }
     } catch (err) {
       error.value = err.response?.data?.message || 'Failed to delete event'
       throw err
     }
   }
 
+  const fetchCountdown = async () => {
+    try {
+      const response = await api.get('/featured-events/countdown')
+      countdownEvent.value = response.data.countdown_event
+    } catch (err) {
+      console.error('Failed to fetch countdown event:', err)
+    }
+  }
+
+  const setCountdown = async (id) => {
+    error.value = null
+    try {
+      const response = await api.put(`/featured-events/${id}/countdown`)
+      const updatedEvent = response.data.featured_event
+
+      // Update the event in the events list
+      const index = events.value.findIndex((e) => e.id === id)
+      if (index !== -1) {
+        events.value[index] = updatedEvent
+      }
+
+      // Clear is_countdown on all other events in local state
+      events.value.forEach((e) => {
+        if (e.id !== id) {
+          e.is_countdown = false
+        }
+      })
+
+      // Update countdown event ref
+      if (updatedEvent.is_countdown) {
+        countdownEvent.value = updatedEvent
+      } else {
+        countdownEvent.value = null
+      }
+
+      return updatedEvent
+    } catch (err) {
+      error.value = err.response?.data?.message || 'Failed to set countdown'
+      throw err
+    }
+  }
+
   return {
     events,
+    countdownEvent,
     isLoading,
     error,
     upcomingEvents,
     todayEvents,
     getCountdown,
     fetchEvents,
+    fetchCountdown,
+    setCountdown,
     createEvent,
     updateEvent,
     deleteEvent,

--- a/resources/js/views/dashboard/DashboardView.vue
+++ b/resources/js/views/dashboard/DashboardView.vue
@@ -1,5 +1,8 @@
 <template>
   <div class="p-4 md:p-6 max-w-6xl">
+    <!-- Countdown Banner -->
+    <CountdownBanner :countdown-event="featuredEventsStore.countdownEvent" />
+
     <!-- Welcome Header -->
     <div class="mb-6">
       <h1 class="text-3xl font-bold text-prussian-500 dark:text-lavender-200">
@@ -263,6 +266,7 @@ import LeaderboardStrip from '@/components/points/LeaderboardStrip.vue'
 import FeaturedRewards from '@/components/points/FeaturedRewards.vue'
 import BadgeShowcase from '@/components/badges/BadgeShowcase.vue'
 import FeaturedEventsSection from '@/components/featured-events/FeaturedEventsSection.vue'
+import CountdownBanner from '@/components/featured-events/CountdownBanner.vue'
 import {
   ArrowPathIcon,
   CalendarIcon,
@@ -325,8 +329,9 @@ const formatDate = (dateStr) => {
 }
 
 onMounted(async () => {
-  // Fetch featured events
+  // Fetch featured events and countdown
   featuredEventsStore.fetchEvents()
+  featuredEventsStore.fetchCountdown()
 
   // Fetch today's events
   const endOfDay = now.endOf('day')

--- a/routes/api.php
+++ b/routes/api.php
@@ -136,8 +136,10 @@ Route::prefix('v1')->group(function () {
         // Featured Events
         Route::prefix('/featured-events')->group(function () {
             Route::get('/', [FeaturedEventController::class, 'index']);
+            Route::get('/countdown', [FeaturedEventController::class, 'countdown']);
             Route::post('/', [FeaturedEventController::class, 'store']);
             Route::put('/{featuredEvent}', [FeaturedEventController::class, 'update']);
+            Route::put('/{featuredEvent}/countdown', [FeaturedEventController::class, 'setCountdown']);
             Route::delete('/{featuredEvent}', [FeaturedEventController::class, 'destroy']);
         });
 


### PR DESCRIPTION
## Summary
- Fixes #10
- Adds `is_countdown` boolean field to the `featured_events` table so one event per family can be designated as THE countdown
- New `GET /api/v1/featured-events/countdown` and `PUT /api/v1/featured-events/{id}/countdown` endpoints
- New `CountdownBanner.vue` component renders a colorful gradient banner at the top of the dashboard with a live-ticking countdown (days, hours, minutes), using the event's color for the gradient
- "Set as Countdown" / "Remove Countdown" option added to the three-dot menu on each featured event (parent-only)
- Clock pin indicator on the active countdown event in the "Coming Up" list
- Dismiss button hides banner for the current session
- "TODAY!" celebration state with bounce animation when the day arrives

## Test plan
- [ ] Run migration successfully (`php artisan migrate`)
- [ ] Set an event as countdown via the 3-dot menu in "Coming Up"
- [ ] Countdown banner appears on dashboard with live ticking time
- [ ] Only one event can be countdown at a time (setting a new one unsets the old)
- [ ] Toggling countdown off removes the banner
- [ ] "Today!" celebration when countdown reaches the event day
- [ ] Dismiss button hides banner for the session
- [ ] Dark mode works
- [ ] Mobile layout works

🤖 Generated with [Claude Code](https://claude.com/claude-code)