### PR TITLE
Add birthday celebrations and holiday banners on dashboard

### DIFF
--- a/resources/js/components/common/CelebrationBanner.vue
+++ b/resources/js/components/common/CelebrationBanner.vue
@@ -1,0 +1,180 @@
+<template>
+  <!-- Birthday Banner — prominent, with confetti -->
+  <Transition name="celebration-slide">
+    <div
+      v-if="showBirthday && !birthdayDismissed"
+      class="relative mb-4 overflow-hidden rounded-2xl bg-gradient-to-r from-wisteria-500 via-pink-500 to-sand-400 dark:from-wisteria-700 dark:via-pink-700 dark:to-sand-600 p-4 md:p-5 shadow-lg"
+    >
+      <!-- Confetti overlay -->
+      <div class="absolute inset-0 pointer-events-none overflow-hidden">
+        <div
+          v-for="i in 40"
+          :key="'confetti-' + i"
+          class="celebration-confetti-piece"
+          :style="confettiStyle(i)"
+        ></div>
+      </div>
+
+      <!-- Content -->
+      <div class="relative z-10 flex items-center justify-between gap-3">
+        <div class="flex-1 min-w-0">
+          <p class="text-white text-lg md:text-xl font-bold leading-tight">
+            <template v-if="isMyBirthday">
+              Happy Birthday! The whole family celebrates you today!
+            </template>
+            <template v-else>
+              <span v-for="(member, idx) in birthdayMembers" :key="member.id">
+                <template v-if="idx > 0 && idx === birthdayMembers.length - 1"> &amp; </template>
+                <template v-else-if="idx > 0">, </template>
+                Today is {{ member.name.split(' ')[0] }}'s birthday!
+              </span>
+            </template>
+          </p>
+          <p class="text-white/80 text-sm mt-1">
+            <template v-if="isMyBirthday">
+              Enjoy your special day!
+            </template>
+            <template v-else>
+              Send them some love today!
+            </template>
+          </p>
+        </div>
+
+        <!-- Dismiss button -->
+        <button
+          @click="dismissBirthday"
+          class="flex-shrink-0 w-8 h-8 rounded-full bg-white/20 hover:bg-white/30 flex items-center justify-center transition-colors"
+          aria-label="Dismiss birthday banner"
+        >
+          <XMarkIcon class="w-5 h-5 text-white" />
+        </button>
+      </div>
+    </div>
+  </Transition>
+
+  <!-- Holiday Banner — subtle, smaller -->
+  <Transition name="celebration-slide">
+    <div
+      v-if="showHoliday && !holidayDismissed"
+      class="relative mb-4 overflow-hidden rounded-xl bg-lavender-100 dark:bg-prussian-700 border border-lavender-200 dark:border-prussian-600 px-4 py-3 shadow-sm"
+    >
+      <div class="flex items-center justify-between gap-3">
+        <p class="text-sm md:text-base font-semibold text-prussian-600 dark:text-lavender-200">
+          <span class="mr-1">{{ holiday.emoji }}</span>
+          {{ holiday.message }}
+        </p>
+
+        <button
+          @click="dismissHoliday"
+          class="flex-shrink-0 w-6 h-6 rounded-full hover:bg-lavender-200 dark:hover:bg-prussian-600 flex items-center justify-center transition-colors"
+          aria-label="Dismiss holiday banner"
+        >
+          <XMarkIcon class="w-4 h-4 text-prussian-400 dark:text-lavender-400" />
+        </button>
+      </div>
+    </div>
+  </Transition>
+</template>
+
+<script setup>
+import { ref } from 'vue'
+import { XMarkIcon } from '@heroicons/vue/24/outline'
+
+const props = defineProps({
+  /** Whether to show the birthday banner */
+  showBirthday: {
+    type: Boolean,
+    default: false,
+  },
+  /** Whether today is the current user's own birthday */
+  isMyBirthday: {
+    type: Boolean,
+    default: false,
+  },
+  /** Array of family members whose birthday is today */
+  birthdayMembers: {
+    type: Array,
+    default: () => [],
+  },
+  /** Whether to show the holiday banner */
+  showHoliday: {
+    type: Boolean,
+    default: false,
+  },
+  /** Holiday object { emoji, message, name } */
+  holiday: {
+    type: Object,
+    default: null,
+  },
+})
+
+// Session-based dismissal (resets on page reload / new session)
+const birthdayDismissed = ref(false)
+const holidayDismissed = ref(false)
+
+const dismissBirthday = () => {
+  birthdayDismissed.value = true
+}
+
+const dismissHoliday = () => {
+  holidayDismissed.value = true
+}
+
+// Confetti style generator — reuses the same approach as EasterEggs.vue
+const confettiColors = ['#ffffff', '#FFD700', '#FF6B6B', '#4ECDC4', '#FF69B4', '#00CED1', '#FFA500', '#7B68EE']
+const confettiStyle = (i) => {
+  const color = confettiColors[i % confettiColors.length]
+  const left = Math.random() * 100
+  const delay = Math.random() * 3
+  const duration = 3 + Math.random() * 3
+  const size = 5 + Math.random() * 5
+  const rotation = Math.random() * 360
+  return {
+    '--cel-color': color,
+    left: `${left}%`,
+    width: `${size}px`,
+    height: `${size * 0.6}px`,
+    animationDelay: `${delay}s`,
+    animationDuration: `${duration}s`,
+    transform: `rotate(${rotation}deg)`,
+  }
+}
+</script>
+
+<style scoped>
+/* Confetti falling animation */
+@keyframes celebration-confetti-fall {
+  0% {
+    transform: translateY(-20px) rotate(0deg);
+    opacity: 1;
+  }
+  100% {
+    transform: translateY(200px) rotate(720deg);
+    opacity: 0;
+  }
+}
+
+.celebration-confetti-piece {
+  position: absolute;
+  top: -10px;
+  background: var(--cel-color);
+  border-radius: 2px;
+  animation: celebration-confetti-fall linear infinite;
+}
+
+/* Banner slide transition */
+.celebration-slide-enter-active {
+  transition: all 0.4s ease-out;
+}
+.celebration-slide-leave-active {
+  transition: all 0.3s ease-in;
+}
+.celebration-slide-enter-from {
+  opacity: 0;
+  transform: translateY(-20px);
+}
+.celebration-slide-leave-to {
+  opacity: 0;
+  transform: translateY(-20px);
+}
+</style>

--- a/resources/js/composables/useCelebrations.js
+++ b/resources/js/composables/useCelebrations.js
@@ -1,0 +1,84 @@
+import { computed } from 'vue'
+import { DateTime } from 'luxon'
+import { useAuthStore } from '@/stores/auth'
+import { storeToRefs } from 'pinia'
+
+/**
+ * Fixed-date US holidays for MVP.
+ *
+ * TODO: Variable-date holidays (Mother's Day, Father's Day, Thanksgiving, Easter)
+ * are intentionally skipped — they require date calculation logic and differ
+ * between US/UK/EU. Could be added later with a locale-aware holiday library
+ * or manual nth-weekday-of-month helpers.
+ */
+const FIXED_HOLIDAYS = [
+  { month: 1, day: 1, name: "New Year's Day", emoji: '🎆', message: 'Happy New Year!' },
+  { month: 2, day: 14, name: "Valentine's Day", emoji: '💝', message: "Happy Valentine's Day!" },
+  { month: 7, day: 4, name: 'Independence Day', emoji: '🇺🇸', message: 'Happy 4th of July!' },
+  { month: 10, day: 31, name: 'Halloween', emoji: '🎃', message: 'Happy Halloween!' },
+  { month: 12, day: 25, name: 'Christmas', emoji: '🎄', message: 'Merry Christmas!' },
+]
+
+/**
+ * Composable that detects birthdays and holidays for the current day.
+ *
+ * Returns reactive data about:
+ * - Which family members have a birthday today
+ * - Whether today is the current user's birthday
+ * - Whether today is a known holiday
+ */
+export function useCelebrations() {
+  const authStore = useAuthStore()
+  const { currentUser, familyMembers } = storeToRefs(authStore)
+
+  const today = DateTime.now()
+  const todayMonth = today.month
+  const todayDay = today.day
+
+  /**
+   * Family members whose birthday is today (month+day match only).
+   */
+  const birthdayMembers = computed(() => {
+    if (!familyMembers.value || familyMembers.value.length === 0) return []
+
+    return familyMembers.value.filter((member) => {
+      if (!member.date_of_birth) return false
+      const dob = DateTime.fromISO(member.date_of_birth)
+      return dob.month === todayMonth && dob.day === todayDay
+    })
+  })
+
+  /**
+   * Whether any family member has a birthday today.
+   */
+  const hasBirthdays = computed(() => birthdayMembers.value.length > 0)
+
+  /**
+   * Whether today is the current user's own birthday.
+   */
+  const isMyBirthday = computed(() => {
+    if (!currentUser.value?.date_of_birth) return false
+    const dob = DateTime.fromISO(currentUser.value.date_of_birth)
+    return dob.month === todayMonth && dob.day === todayDay
+  })
+
+  /**
+   * Today's holiday (if any), or null.
+   */
+  const todayHoliday = computed(() => {
+    return FIXED_HOLIDAYS.find((h) => h.month === todayMonth && h.day === todayDay) || null
+  })
+
+  /**
+   * Whether today is a known holiday.
+   */
+  const isHoliday = computed(() => todayHoliday.value !== null)
+
+  return {
+    birthdayMembers,
+    hasBirthdays,
+    isMyBirthday,
+    todayHoliday,
+    isHoliday,
+  }
+}

--- a/resources/js/views/dashboard/DashboardView.vue
+++ b/resources/js/views/dashboard/DashboardView.vue
@@ -11,6 +11,15 @@
       <p class="text-sand-600 dark:text-sand-400">{{ dateMessage }}</p>
     </div>
 
+    <!-- Celebration Banners (birthdays & holidays) -->
+    <CelebrationBanner
+      :show-birthday="hasBirthdays"
+      :is-my-birthday="isMyBirthday"
+      :birthday-members="birthdayMembers"
+      :show-holiday="isHoliday"
+      :holiday="todayHoliday"
+    />
+
     <!-- Featured Events -->
     <FeaturedEventsSection
       v-if="featuredEventsStore.upcomingEvents.length > 0 || isParent"
@@ -267,6 +276,8 @@ import FeaturedRewards from '@/components/points/FeaturedRewards.vue'
 import BadgeShowcase from '@/components/badges/BadgeShowcase.vue'
 import FeaturedEventsSection from '@/components/featured-events/FeaturedEventsSection.vue'
 import CountdownBanner from '@/components/featured-events/CountdownBanner.vue'
+import CelebrationBanner from '@/components/common/CelebrationBanner.vue'
+import { useCelebrations } from '@/composables/useCelebrations'
 import {
   ArrowPathIcon,
   CalendarIcon,
@@ -291,6 +302,9 @@ const featuredEventsStore = useFeaturedEventsStore()
 const { currentUser, isParent, enabledModules } = storeToRefs(authStore)
 const { todayEvents } = storeToRefs(calendarStore)
 const { tasks } = storeToRefs(tasksStore)
+
+// Celebration detection (birthdays & holidays)
+const { birthdayMembers, hasBirthdays, isMyBirthday, todayHoliday, isHoliday } = useCelebrations()
 
 // My Tasks: assigned specifically to me, incomplete
 const myTasks = computed(() => {


### PR DESCRIPTION
## Summary
- Fixes #8
- New `useCelebrations` composable that detects family member birthdays (month+day match on `date_of_birth`) and fixed-date US holidays (New Year's, Valentine's, July 4th, Halloween, Christmas)
- New `CelebrationBanner` component with confetti animation for birthdays and a subtle badge for holidays
- Personalized birthday messages: "Happy Birthday!" if it's your own, "[Name]'s birthday!" for other family members
- Both banners are dismissible per session (reappear on next visit)
- Dark mode and mobile-first compatible
- Variable-date holidays (Mother's Day, Father's Day, Thanksgiving, Easter) noted as future enhancement with comment explaining locale complexity

## Test plan
- [ ] Birthday banner shows when a family member's `date_of_birth` month+day matches today
- [ ] Confetti animation plays on the birthday banner
- [ ] Banner shows personalized message for own birthday vs other member's birthday
- [ ] Banner is dismissible (hidden for the session, reappears on reload)
- [ ] Holiday banner shows on fixed holiday dates (test by temporarily changing date in composable)
- [ ] Dark mode renders correctly for both banners
- [ ] Mobile layout works (banners stack properly, text doesn't overflow)
- [ ] No banners show when there are no birthdays or holidays
- [ ] Build passes cleanly (`npx vite build` — verified: 803 modules, 0 errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)