### PR TITLE
Block self-kudos and add optional kudos cost setting

### DIFF
--- a/app/Http/Controllers/Api/V1/PointsController.php
+++ b/app/Http/Controllers/Api/V1/PointsController.php
@@ -74,10 +74,20 @@ class PointsController extends Controller
         ]);
 
         $from = $request->user();
+
+        // Block self-kudos
+        if ($validated['user_id'] === $from->id) {
+            return response()->json(['message' => "You can't give kudos to yourself"], 422);
+        }
+
         $family = $from->currentFamily()->firstOrFail();
         $to = $family->members()->findOrFail($validated['user_id']);
 
-        $transaction = $this->pointsService->giveKudos($from, $to, $validated['reason']);
+        try {
+            $transaction = $this->pointsService->giveKudos($from, $to, $family, $validated['reason']);
+        } catch (\Exception $e) {
+            return response()->json(['message' => $e->getMessage()], 422);
+        }
 
         // Check for badges on the recipient
         $newBadges = $this->badgeService->checkAndAwardBadges($to);

--- a/app/Http/Controllers/Api/V1/SettingsController.php
+++ b/app/Http/Controllers/Api/V1/SettingsController.php
@@ -33,6 +33,7 @@ class SettingsController extends Controller
                 ],
                 'preferences' => $family->settings['preferences'] ?? [],
                 'leaderboard_period' => $family->settings['leaderboard_period'] ?? 'weekly',
+                'kudos_cost_enabled' => $family->settings['kudos_cost_enabled'] ?? false,
                 'default_points_low' => $family->settings['default_points_low'] ?? 5,
                 'default_points_medium' => $family->settings['default_points_medium'] ?? 10,
                 'default_points_high' => $family->settings['default_points_high'] ?? 20,
@@ -64,6 +65,7 @@ class SettingsController extends Controller
             'modules.badges' => 'nullable|boolean',
             'preferences' => 'nullable|array',
             'leaderboard_period' => 'nullable|string|in:daily,weekly,monthly',
+            'kudos_cost_enabled' => 'nullable|boolean',
             'default_points_low' => 'nullable|integer|min:0|max:1000',
             'default_points_medium' => 'nullable|integer|min:0|max:1000',
             'default_points_high' => 'nullable|integer|min:0|max:1000',
@@ -89,6 +91,10 @@ class SettingsController extends Controller
             $settings['leaderboard_period'] = $validated['leaderboard_period'];
         }
 
+        if ($request->has('kudos_cost_enabled')) {
+            $settings['kudos_cost_enabled'] = (bool) $validated['kudos_cost_enabled'];
+        }
+
         // Update default points per priority
         foreach (['default_points_low', 'default_points_medium', 'default_points_high'] as $key) {
             if ($request->has($key)) {
@@ -104,6 +110,7 @@ class SettingsController extends Controller
                 'name' => $family->name,
                 'modules' => $settings['modules'] ?? [],
                 'preferences' => $settings['preferences'] ?? [],
+                'kudos_cost_enabled' => $settings['kudos_cost_enabled'] ?? false,
                 'default_points_low' => $settings['default_points_low'] ?? 5,
                 'default_points_medium' => $settings['default_points_medium'] ?? 10,
                 'default_points_high' => $settings['default_points_high'] ?? 20,

--- a/app/Services/PointsService.php
+++ b/app/Services/PointsService.php
@@ -48,9 +48,28 @@ class PointsService
 
     /**
      * Give kudos from one user to another (+1 point).
+     * If kudos_cost_enabled is on, deduct 1 point from the giver.
      */
-    public function giveKudos(User $from, User $to, string $reason): PointTransaction
+    public function giveKudos(User $from, User $to, Family $family, string $reason): PointTransaction
     {
+        $kudosCostEnabled = $family->settings['kudos_cost_enabled'] ?? false;
+
+        if ($kudosCostEnabled && !$from->hasSufficientPoints(1)) {
+            throw new \Exception('Not enough points to give kudos');
+        }
+
+        // Deduct from giver if cost is enabled
+        if ($kudosCostEnabled) {
+            PointTransaction::create([
+                'family_id' => $from->family_id,
+                'user_id' => $from->id,
+                'type' => PointTransactionType::Deduction,
+                'points' => -1,
+                'description' => "Kudos cost: gave kudos to {$to->name}",
+                'awarded_by' => $from->id,
+            ]);
+        }
+
         return PointTransaction::create([
             'family_id' => $to->family_id,
             'user_id' => $to->id,

--- a/resources/js/components/points/KudosInput.vue
+++ b/resources/js/components/points/KudosInput.vue
@@ -5,7 +5,7 @@
       class="input-base text-sm py-2 flex-shrink-0 w-32"
     >
       <option value="">Select...</option>
-      <option v-for="member in members" :key="member.id" :value="member.id">
+      <option v-for="member in otherMembers" :key="member.id" :value="member.id">
         {{ member.name }}
       </option>
     </select>
@@ -29,14 +29,22 @@
 </template>
 
 <script setup>
-import { ref } from 'vue'
+import { ref, computed } from 'vue'
+import { useAuthStore } from '@/stores/auth'
 
-defineProps({
+const props = defineProps({
   members: {
     type: Array,
     default: () => [],
   },
 })
+
+const authStore = useAuthStore()
+
+// Filter out the current user so they can't give kudos to themselves
+const otherMembers = computed(() =>
+  props.members.filter(m => m.id !== authStore.currentUser?.id)
+)
 
 const emit = defineEmits(['kudos'])
 

--- a/resources/js/views/settings/SettingsView.vue
+++ b/resources/js/views/settings/SettingsView.vue
@@ -491,6 +491,30 @@
         <p class="text-xs text-lavender-600 dark:text-lavender-400 mt-1">
           How often the leaderboard resets. Does not affect point balances.
         </p>
+
+        <!-- Kudos Cost Toggle -->
+        <div class="flex items-center justify-between mt-4 p-4 bg-lavender-50 dark:bg-prussian-800 rounded-lg">
+          <div class="flex-1 mr-4">
+            <p class="font-medium text-prussian-500 dark:text-lavender-200">Kudos cost points</p>
+            <p class="text-xs text-lavender-700 dark:text-lavender-400 mt-0.5">
+              Giving kudos deducts 1 point from the giver's bank. Prevents trading kudos back and forth.
+            </p>
+          </div>
+          <button
+            @click="kudosCostEnabled = !kudosCostEnabled"
+            :class="[
+              'relative inline-flex h-7 w-12 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-wisteria-400 focus:ring-offset-2',
+              kudosCostEnabled ? 'bg-wisteria-500' : 'bg-lavender-300 dark:bg-prussian-600',
+            ]"
+          >
+            <span
+              :class="[
+                'pointer-events-none inline-block h-6 w-6 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out',
+                kudosCostEnabled ? 'translate-x-5' : 'translate-x-0',
+              ]"
+            />
+          </button>
+        </div>
       </div>
 
       <div class="flex gap-3 justify-end pt-4 border-t border-lavender-200 dark:border-prussian-700 mt-4">
@@ -738,6 +762,7 @@ const moduleToggles = reactive({
   calendar: true, tasks: true, vault: true, chat: true, points: true, badges: true,
 })
 const leaderboardPeriod = ref('weekly')
+const kudosCostEnabled = ref(false)
 
 // Default task points
 const savingDefaultPoints = ref(false)
@@ -1099,6 +1124,7 @@ const saveModuleSettings = async () => {
     await api.put('/settings', {
       modules: { ...moduleToggles },
       leaderboard_period: leaderboardPeriod.value,
+      kudos_cost_enabled: kudosCostEnabled.value,
     })
     await authStore.fetchUser()
     success('Preferences saved!')
@@ -1139,6 +1165,7 @@ onMounted(async () => {
   moduleToggles.points = modules.points !== false
   moduleToggles.badges = modules.badges !== false
   leaderboardPeriod.value = settings.leaderboard_period || 'weekly'
+  kudosCostEnabled.value = settings.kudos_cost_enabled ?? false
 
   // Initialize default task points
   defaultPoints.low = settings.default_points_low ?? 5


### PR DESCRIPTION
## Summary
- Fixes #45
- **Bug fix:** API now rejects self-kudos with a 422 error ("You can't give kudos to yourself"), and the KudosInput dropdown filters out the current user so they cannot select themselves
- **Feature:** New `kudos_cost_enabled` family setting (default: off). When enabled by a parent, giving kudos deducts 1 point from the giver's bank. If the giver has 0 points, the API rejects with "Not enough points to give kudos"
- Toggle added to Settings under Feature Toggles > Points section, styled consistently with existing toggles and dark mode

## Test plan
- [ ] Cannot give kudos to yourself (API rejects with 422)
- [ ] Frontend prevents selecting yourself in kudos dropdown
- [ ] New "Kudos cost points" toggle in Settings (parent-only, under Points section)
- [ ] When enabled, giving kudos deducts 1 point from giver
- [ ] When enabled, giver with 0 points can't give kudos
- [ ] When disabled, kudos are free (default behavior)
- [ ] Dark mode works for new UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)