### PR TITLE
Add granular per-user feature access control

### DIFF
--- a/app/Http/Controllers/Api/V1/AuthController.php
+++ b/app/Http/Controllers/Api/V1/AuthController.php
@@ -155,6 +155,7 @@ class AuthController extends Controller
                 'name' => $user->family->name,
                 'invite_code' => $user->isParent() ? $user->family->invite_code : null,
                 'settings' => $user->family->settings ?? [],
+                'module_access' => $user->family->getAllModuleAccess(),
                 'members' => $user->family->members->map(fn ($m) => [
                     'id' => $m->id,
                     'name' => $m->name,

--- a/app/Http/Controllers/Api/V1/SettingsController.php
+++ b/app/Http/Controllers/Api/V1/SettingsController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers\Api\V1;
 
 use App\Http\Controllers\Controller;
+use App\Models\Family;
 use App\Models\User;
 use App\Services\ChatbotService;
 use Illuminate\Http\JsonResponse;
@@ -34,6 +35,7 @@ class SettingsController extends Controller
                     'points' => true,
                     'badges' => true,
                 ],
+                'module_access' => $family->getAllModuleAccess(),
                 'preferences' => $settings['preferences'] ?? [],
                 'leaderboard_period' => $settings['leaderboard_period'] ?? 'weekly',
                 'kudos_cost_enabled' => $settings['kudos_cost_enabled'] ?? false,
@@ -71,6 +73,13 @@ class SettingsController extends Controller
             'modules.chat' => 'nullable|boolean',
             'modules.points' => 'nullable|boolean',
             'modules.badges' => 'nullable|boolean',
+            'module_access' => 'nullable|array',
+            'module_access.*' => 'nullable|array',
+            'module_access.*.mode' => 'required_with:module_access.*|string|in:all,off,roles,users',
+            'module_access.*.roles' => 'nullable|array',
+            'module_access.*.roles.*' => 'string|in:parent,child',
+            'module_access.*.users' => 'nullable|array',
+            'module_access.*.users.*' => 'string|uuid',
             'preferences' => 'nullable|array',
             'leaderboard_period' => 'nullable|string|in:daily,weekly,monthly',
             'kudos_cost_enabled' => 'nullable|boolean',
@@ -89,6 +98,25 @@ class SettingsController extends Controller
                 $settings['modules'] ?? [],
                 $validated['modules']
             );
+        }
+
+        // Granular module_access — replaces legacy boolean modules when present
+        if ($request->filled('module_access')) {
+            $allowed = Family::MODULES;
+            $existing = $settings['module_access'] ?? [];
+
+            foreach ($validated['module_access'] as $module => $rule) {
+                if (! in_array($module, $allowed, true)) {
+                    continue;
+                }
+                $existing[$module] = $rule;
+
+                // Keep the legacy modules key in sync for backward compat
+                $settings['modules'] = $settings['modules'] ?? [];
+                $settings['modules'][$module] = ($rule['mode'] ?? 'all') !== 'off';
+            }
+
+            $settings['module_access'] = $existing;
         }
 
         if ($request->filled('preferences')) {
@@ -140,6 +168,7 @@ class SettingsController extends Controller
                 'id' => $family->id,
                 'name' => $family->name,
                 'modules' => $settings['modules'] ?? [],
+                'module_access' => $family->getAllModuleAccess(),
                 'preferences' => $settings['preferences'] ?? [],
                 'leaderboard_period' => $settings['leaderboard_period'] ?? 'weekly',
                 'kudos_cost_enabled' => $settings['kudos_cost_enabled'] ?? false,

--- a/app/Http/Middleware/CheckModuleAccess.php
+++ b/app/Http/Middleware/CheckModuleAccess.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class CheckModuleAccess
+{
+    /**
+     * Handle an incoming request.
+     *
+     * Usage in routes:  ->middleware('module:tasks')
+     *
+     * Parents always have access unless the module is globally disabled ('off').
+     */
+    public function handle(Request $request, Closure $next, string $module): Response
+    {
+        $user = $request->user();
+
+        if (! $user) {
+            return response()->json(['message' => 'Unauthenticated.'], 401);
+        }
+
+        $family = $user->family;
+
+        if (! $family) {
+            return response()->json(['message' => 'No family found.'], 403);
+        }
+
+        if (! $family->userHasModuleAccess($module, $user)) {
+            return response()->json([
+                'message' => 'You do not have access to this feature.',
+                'module' => $module,
+            ], 403);
+        }
+
+        return $next($request);
+    }
+}

--- a/app/Models/Family.php
+++ b/app/Models/Family.php
@@ -108,11 +108,93 @@ class Family extends Model
     }
 
     /**
-     * Get enabled modules.
+     * Get enabled modules (legacy helper — returns module names that are globally enabled).
      */
     public function getEnabledModules(): array
     {
         return $this->settings['enabled_modules'] ?? ['calendar', 'tasks', 'vault', 'chat', 'points', 'badges'];
+    }
+
+    /**
+     * All module names the system supports.
+     */
+    public const MODULES = ['calendar', 'tasks', 'vault', 'chat', 'points', 'badges'];
+
+    /**
+     * Get the module_access config for a given module.
+     *
+     * Returns the granular access rule if set, otherwise falls back to the
+     * legacy `settings.modules` boolean toggle (true → 'all', false → 'off').
+     *
+     * @return array{mode: string, roles?: string[], users?: string[]}
+     */
+    public function getModuleAccess(string $module): array
+    {
+        $settings = $this->settings ?? [];
+
+        // Check for granular module_access first
+        if (isset($settings['module_access'][$module])) {
+            return $settings['module_access'][$module];
+        }
+
+        // Fall back to legacy boolean toggle
+        $legacy = $settings['modules'][$module] ?? true;
+
+        return ['mode' => $legacy === false ? 'off' : 'all'];
+    }
+
+    /**
+     * Check whether a specific user has access to a module.
+     *
+     * Parents always have access to every module (except when mode is 'off').
+     */
+    public function userHasModuleAccess(string $module, User $user): bool
+    {
+        $access = $this->getModuleAccess($module);
+        $mode = $access['mode'] ?? 'all';
+
+        // Module completely disabled — nobody can access it
+        if ($mode === 'off') {
+            return false;
+        }
+
+        // Module open to everyone
+        if ($mode === 'all') {
+            return true;
+        }
+
+        // Parents always have access when the module isn't globally off
+        if ($user->isParent()) {
+            return true;
+        }
+
+        // Role-based access
+        if ($mode === 'roles') {
+            $allowedRoles = $access['roles'] ?? [];
+            return in_array($user->family_role->value, $allowedRoles, true);
+        }
+
+        // Per-user access
+        if ($mode === 'users') {
+            $allowedUsers = $access['users'] ?? [];
+            return in_array($user->id, $allowedUsers, true);
+        }
+
+        return false;
+    }
+
+    /**
+     * Get the full module_access map (all modules), filling in defaults.
+     *
+     * Useful for returning to the frontend so the Settings UI can render the grid.
+     */
+    public function getAllModuleAccess(): array
+    {
+        $result = [];
+        foreach (self::MODULES as $mod) {
+            $result[$mod] = $this->getModuleAccess($mod);
+        }
+        return $result;
     }
 
     /**

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -18,6 +18,7 @@ return Application::configure(basePath: dirname(__DIR__))
 
         $middleware->alias([
             'verified' => \Illuminate\Auth\Middleware\EnsureEmailIsVerified::class,
+            'module' => \App\Http\Middleware\CheckModuleAccess::class,
         ]);
     })
     ->withExceptions(function (Exceptions $exceptions) {

--- a/resources/js/router/index.js
+++ b/resources/js/router/index.js
@@ -196,10 +196,9 @@ router.beforeEach(async (to, from, next) => {
     }
   }
 
-  // Module-gated routes
+  // Module-gated routes — uses granular per-user access
   if (to.meta.module) {
-    const modules = authStore.enabledModules
-    if (modules[to.meta.module] === false) {
+    if (!authStore.userCanAccessModule(to.meta.module)) {
       return next({ name: 'Dashboard' })
     }
   }

--- a/resources/js/stores/auth.js
+++ b/resources/js/stores/auth.js
@@ -14,20 +14,69 @@ export const useAuthStore = defineStore('auth', () => {
   const isParent = computed(() => user.value?.role === 'parent')
   const familyMembers = computed(() => family.value?.members || [])
   const currentUser = computed(() => user.value)
-  const enabledModules = computed(() => {
-    const settings = family.value?.settings || {}
-    const modules = settings.modules || {}
-    return {
-      calendar: modules.calendar !== false,
-      tasks: modules.tasks !== false,
-      vault: modules.vault !== false,
-      chat: modules.chat !== false,
-      points: modules.points !== false,
-      badges: modules.badges !== false,
-    }
+  /**
+   * Granular module access map from the API.
+   * Each key is a module name, value is { mode, roles?, users? }.
+   */
+  const moduleAccess = computed(() => {
+    return family.value?.module_access || {}
   })
+
+  /**
+   * Check whether the current user can access a specific module.
+   *
+   * Parents always have access unless the module is globally 'off'.
+   * Backward-compatible: if no module_access data exists, falls back to
+   * the legacy boolean settings.modules toggle.
+   */
+  const userCanAccessModule = (moduleName) => {
+    const access = moduleAccess.value[moduleName]
+    const currentUserId = user.value?.id
+    const currentRole = user.value?.role || user.value?.family_role
+
+    // If we have no granular access data, fall back to legacy
+    if (!access) {
+      const settings = family.value?.settings || {}
+      const modules = settings.modules || {}
+      return modules[moduleName] !== false
+    }
+
+    const mode = access.mode || 'all'
+
+    if (mode === 'off') return false
+    if (mode === 'all') return true
+
+    // Parents always have access when not 'off'
+    if (currentRole === 'parent') return true
+
+    if (mode === 'roles') {
+      const allowedRoles = access.roles || []
+      return allowedRoles.includes(currentRole)
+    }
+
+    if (mode === 'users') {
+      const allowedUsers = access.users || []
+      return allowedUsers.includes(currentUserId)
+    }
+
+    return false
+  }
+
+  /**
+   * Legacy computed — now backed by the granular system.
+   * Returns a map of { moduleName: boolean } for the current user.
+   */
+  const enabledModules = computed(() => {
+    const modules = ['calendar', 'tasks', 'vault', 'chat', 'points', 'badges']
+    const result = {}
+    for (const mod of modules) {
+      result[mod] = userCanAccessModule(mod)
+    }
+    return result
+  })
+
   const isModuleEnabled = computed(() => (moduleName) => {
-    return enabledModules.value[moduleName] !== false
+    return userCanAccessModule(moduleName)
   })
 
   // Actions
@@ -234,6 +283,8 @@ export const useAuthStore = defineStore('auth', () => {
     currentUser,
     enabledModules,
     isModuleEnabled,
+    moduleAccess,
+    userCanAccessModule,
 
     // Actions
     login,

--- a/resources/js/views/settings/SettingsView.vue
+++ b/resources/js/views/settings/SettingsView.vue
@@ -537,30 +537,114 @@
       </div>
     </div>
 
-    <!-- Module Toggles (parent only) -->
+    <!-- Feature Access Control (parent only) -->
     <div v-if="isParent" class="card-lg mb-6">
-      <h2 class="text-lg font-semibold text-prussian-500 dark:text-lavender-200 mb-4">Feature Toggles</h2>
+      <h2 class="text-lg font-semibold text-prussian-500 dark:text-lavender-200 mb-2">Feature Access Control</h2>
+      <p class="text-sm text-lavender-700 dark:text-lavender-400 mb-4">
+        Control which features each family member can access. Parents always have access unless a feature is turned off entirely.
+      </p>
 
-      <div class="space-y-3">
-        <label
+      <!-- Access control per module -->
+      <div class="space-y-4">
+        <div
           v-for="module in availableModules"
           :key="module.id"
-          class="flex items-center gap-3 p-4 bg-lavender-50 dark:bg-prussian-700 rounded-lg cursor-pointer hover:bg-lavender-100 dark:hover:bg-prussian-600 transition-colors"
+          class="p-4 bg-lavender-50 dark:bg-prussian-700 rounded-lg"
         >
-          <input
-            v-model="moduleToggles[module.id]"
-            type="checkbox"
-            class="rounded"
-          />
-          <div class="flex-1">
-            <p class="font-medium text-prussian-500 dark:text-lavender-200">{{ module.name }}</p>
-            <p class="text-xs text-lavender-700 dark:text-lavender-400">{{ module.description }}</p>
+          <!-- Module header with quick-action buttons -->
+          <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2 mb-3">
+            <div>
+              <p class="font-medium text-prussian-500 dark:text-lavender-200">{{ module.name }}</p>
+              <p class="text-xs text-lavender-700 dark:text-lavender-400">{{ module.description }}</p>
+            </div>
+            <div class="flex gap-1.5 shrink-0">
+              <button
+                @click="setModuleMode(module.id, 'all')"
+                :class="[
+                  'px-2.5 py-1 text-xs font-medium rounded-full transition-colors',
+                  moduleAccessState[module.id]?.mode === 'all'
+                    ? 'bg-wisteria-500 text-white'
+                    : 'bg-lavender-200 dark:bg-prussian-600 text-lavender-700 dark:text-lavender-300 hover:bg-lavender-300 dark:hover:bg-prussian-500',
+                ]"
+              >
+                Everyone
+              </button>
+              <button
+                @click="setModuleMode(module.id, 'roles', ['parent'])"
+                :class="[
+                  'px-2.5 py-1 text-xs font-medium rounded-full transition-colors',
+                  moduleAccessState[module.id]?.mode === 'roles'
+                    ? 'bg-wisteria-500 text-white'
+                    : 'bg-lavender-200 dark:bg-prussian-600 text-lavender-700 dark:text-lavender-300 hover:bg-lavender-300 dark:hover:bg-prussian-500',
+                ]"
+              >
+                Parents Only
+              </button>
+              <button
+                @click="setModuleMode(module.id, 'off')"
+                :class="[
+                  'px-2.5 py-1 text-xs font-medium rounded-full transition-colors',
+                  moduleAccessState[module.id]?.mode === 'off'
+                    ? 'bg-red-500 text-white'
+                    : 'bg-lavender-200 dark:bg-prussian-600 text-lavender-700 dark:text-lavender-300 hover:bg-lavender-300 dark:hover:bg-prussian-500',
+                ]"
+              >
+                Off
+              </button>
+              <button
+                @click="setModuleMode(module.id, 'users', getSelectedUserIds(module.id))"
+                :class="[
+                  'px-2.5 py-1 text-xs font-medium rounded-full transition-colors',
+                  moduleAccessState[module.id]?.mode === 'users'
+                    ? 'bg-wisteria-500 text-white'
+                    : 'bg-lavender-200 dark:bg-prussian-600 text-lavender-700 dark:text-lavender-300 hover:bg-lavender-300 dark:hover:bg-prussian-500',
+                ]"
+              >
+                Custom
+              </button>
+            </div>
           </div>
-        </label>
+
+          <!-- Per-member checkboxes (shown only in 'users' mode) -->
+          <div v-if="moduleAccessState[module.id]?.mode === 'users'" class="mt-3 pt-3 border-t border-lavender-200 dark:border-prussian-600">
+            <p class="text-xs font-medium text-prussian-400 dark:text-lavender-300 mb-2">Select family members:</p>
+            <div class="flex flex-wrap gap-2">
+              <label
+                v-for="member in familyMembers"
+                :key="member.id"
+                class="flex items-center gap-2 px-3 py-2 bg-white dark:bg-prussian-800 rounded-lg cursor-pointer hover:bg-lavender-100 dark:hover:bg-prussian-600 transition-colors"
+              >
+                <input
+                  type="checkbox"
+                  :checked="isMemberSelected(module.id, member.id)"
+                  @change="toggleMemberAccess(module.id, member.id)"
+                  class="rounded"
+                  :disabled="(member.family_role || member.role) === 'parent'"
+                />
+                <UserAvatar :user="member" size="xs" />
+                <span class="text-sm text-prussian-500 dark:text-lavender-200">{{ member.name }}</span>
+                <span
+                  v-if="(member.family_role || member.role) === 'parent'"
+                  class="text-xs text-lavender-500 dark:text-lavender-400 italic"
+                >(always)</span>
+              </label>
+            </div>
+          </div>
+
+          <!-- Mode summary -->
+          <p class="text-xs text-lavender-600 dark:text-lavender-400 mt-2">
+            <template v-if="moduleAccessState[module.id]?.mode === 'all'">All family members can access this feature.</template>
+            <template v-else-if="moduleAccessState[module.id]?.mode === 'off'">This feature is disabled for everyone.</template>
+            <template v-else-if="moduleAccessState[module.id]?.mode === 'roles'">Only parents can access this feature.</template>
+            <template v-else-if="moduleAccessState[module.id]?.mode === 'users'">
+              {{ getSelectedMemberNames(module.id) || 'No members selected (parents always have access).' }}
+            </template>
+          </p>
+        </div>
       </div>
 
       <!-- Leaderboard Period -->
-      <div v-if="moduleToggles.points" class="mt-4 pt-4 border-t border-lavender-200 dark:border-prussian-700">
+      <div v-if="moduleAccessState.points?.mode !== 'off'" class="mt-4 pt-4 border-t border-lavender-200 dark:border-prussian-700">
         <label class="block text-sm font-medium text-prussian-400 dark:text-lavender-300 mb-2">
           Leaderboard Reset Period
         </label>
@@ -845,10 +929,23 @@ const aiConfig = reactive({
   hasSavedKey: false,
 })
 
-// Module toggles
+// Module access (granular)
 const savingModules = ref(false)
-const moduleToggles = reactive({
-  calendar: true, tasks: true, vault: true, chat: true, points: true, badges: true,
+const moduleAccessState = reactive({
+  calendar: { mode: 'all' },
+  tasks: { mode: 'all' },
+  vault: { mode: 'all' },
+  chat: { mode: 'all' },
+  points: { mode: 'all' },
+  badges: { mode: 'all' },
+})
+// Legacy compat: moduleToggles is derived from moduleAccessState
+const moduleToggles = computed(() => {
+  const result = {}
+  for (const mod of Object.keys(moduleAccessState)) {
+    result[mod] = moduleAccessState[mod]?.mode !== 'off'
+  }
+  return result
 })
 const leaderboardPeriod = ref('weekly')
 const kudosCostEnabled = ref(false)
@@ -973,6 +1070,57 @@ const availableModules = [
   { id: 'points', name: 'Points & Rewards', description: 'Earn points, give kudos, purchase rewards' },
   { id: 'badges', name: 'Badges', description: 'Achievement badges and milestones' },
 ]
+
+// ---- Module access helpers ----
+const setModuleMode = (moduleId, mode, extra = []) => {
+  if (mode === 'all' || mode === 'off') {
+    moduleAccessState[moduleId] = { mode }
+  } else if (mode === 'roles') {
+    moduleAccessState[moduleId] = { mode: 'roles', roles: extra.length ? extra : ['parent'] }
+  } else if (mode === 'users') {
+    // When switching to 'users' mode, pre-select all parent IDs + any previously selected
+    const parentIds = (familyMembers.value || [])
+      .filter((m) => (m.family_role || m.role) === 'parent')
+      .map((m) => m.id)
+    const existing = extra.length ? extra : parentIds
+    moduleAccessState[moduleId] = { mode: 'users', users: [...new Set([...parentIds, ...existing])] }
+  }
+}
+
+const getSelectedUserIds = (moduleId) => {
+  const state = moduleAccessState[moduleId]
+  if (state?.mode === 'users') return state.users || []
+  return []
+}
+
+const isMemberSelected = (moduleId, memberId) => {
+  const state = moduleAccessState[moduleId]
+  if (state?.mode !== 'users') return false
+  return (state.users || []).includes(memberId)
+}
+
+const toggleMemberAccess = (moduleId, memberId) => {
+  const state = moduleAccessState[moduleId]
+  if (state?.mode !== 'users') return
+  const users = state.users || []
+  const idx = users.indexOf(memberId)
+  if (idx >= 0) {
+    users.splice(idx, 1)
+  } else {
+    users.push(memberId)
+  }
+  moduleAccessState[moduleId] = { ...state, users: [...users] }
+}
+
+const getSelectedMemberNames = (moduleId) => {
+  const state = moduleAccessState[moduleId]
+  if (state?.mode !== 'users') return ''
+  const userIds = state.users || []
+  const members = (familyMembers.value || []).filter((m) => userIds.includes(m.id))
+  if (members.length === 0) return ''
+  const names = members.map((m) => m.name).join(', ')
+  return `Access: ${names}`
+}
 
 // ---- Family name ----
 const updateFamily = async () => {
@@ -1265,8 +1413,19 @@ const saveAiSettings = async () => {
 const saveModuleSettings = async () => {
   savingModules.value = true
   try {
+    // Build the module_access payload from local state
+    const module_access = {}
+    for (const mod of availableModules) {
+      const state = moduleAccessState[mod.id]
+      if (!state) continue
+      const rule = { mode: state.mode }
+      if (state.mode === 'roles') rule.roles = state.roles || ['parent']
+      if (state.mode === 'users') rule.users = state.users || []
+      module_access[mod.id] = rule
+    }
+
     await api.put('/settings', {
-      modules: { ...moduleToggles },
+      module_access,
       leaderboard_period: leaderboardPeriod.value,
       kudos_cost_enabled: kudosCostEnabled.value,
     })
@@ -1299,15 +1458,20 @@ const saveDefaultPoints = async () => {
 onMounted(async () => {
   familyForm.name = family.value?.name || ''
 
-  // Initialize module toggles
+  // Initialize module access state from the API-provided module_access map
   const settings = family.value?.settings || {}
-  const modules = settings.modules || {}
-  moduleToggles.calendar = modules.calendar !== false
-  moduleToggles.tasks = modules.tasks !== false
-  moduleToggles.vault = modules.vault !== false
-  moduleToggles.chat = modules.chat !== false
-  moduleToggles.points = modules.points !== false
-  moduleToggles.badges = modules.badges !== false
+  const moduleAccessFromApi = family.value?.module_access || {}
+  const legacyModules = settings.modules || {}
+
+  for (const mod of availableModules) {
+    if (moduleAccessFromApi[mod.id]) {
+      // Use granular access data
+      moduleAccessState[mod.id] = { ...moduleAccessFromApi[mod.id] }
+    } else {
+      // Fall back to legacy boolean
+      moduleAccessState[mod.id] = { mode: legacyModules[mod.id] === false ? 'off' : 'all' }
+    }
+  }
   leaderboardPeriod.value = settings.leaderboard_period || 'weekly'
   kudosCostEnabled.value = settings.kudos_cost_enabled ?? false
 

--- a/routes/api.php
+++ b/routes/api.php
@@ -38,8 +38,8 @@ Route::prefix('v1')->group(function () {
             Route::delete('/members/{member}', [FamilyController::class, 'removeMember']);
         });
 
-        // Task Lists
-        Route::prefix('/task-lists')->group(function () {
+        // Task Lists (module: tasks)
+        Route::prefix('/task-lists')->middleware('module:tasks')->group(function () {
             Route::get('/', [TaskListController::class, 'index']);
             Route::post('/', [TaskListController::class, 'store']);
             Route::get('/{taskList}', [TaskListController::class, 'show']);
@@ -53,16 +53,16 @@ Route::prefix('v1')->group(function () {
             });
         });
 
-        // Tags
-        Route::prefix('/tags')->group(function () {
+        // Tags (module: tasks)
+        Route::prefix('/tags')->middleware('module:tasks')->group(function () {
             Route::get('/', [TagController::class, 'index']);
             Route::post('/', [TagController::class, 'store']);
             Route::put('/{tag}', [TagController::class, 'update']);
             Route::delete('/{tag}', [TagController::class, 'destroy']);
         });
 
-        // Tasks
-        Route::prefix('/tasks')->group(function () {
+        // Tasks (module: tasks)
+        Route::prefix('/tasks')->middleware('module:tasks')->group(function () {
             Route::get('/', [TaskController::class, 'index']);
             Route::post('/', [TaskController::class, 'store']);
             Route::get('/{task}', [TaskController::class, 'show']);
@@ -72,8 +72,8 @@ Route::prefix('v1')->group(function () {
             Route::patch('/{task}/uncomplete', [TaskController::class, 'uncomplete']);
         });
 
-        // Vault
-        Route::prefix('/vault')->group(function () {
+        // Vault (module: vault)
+        Route::prefix('/vault')->middleware('module:vault')->group(function () {
             Route::get('/categories', [VaultController::class, 'categories']);
             Route::get('/entries', [VaultController::class, 'index']);
             Route::post('/entries', [VaultController::class, 'store']);
@@ -86,8 +86,8 @@ Route::prefix('v1')->group(function () {
             Route::delete('/documents/{document}', [VaultController::class, 'deleteDocument']);
         });
 
-        // Calendar
-        Route::prefix('/calendar')->group(function () {
+        // Calendar (module: calendar)
+        Route::prefix('/calendar')->middleware('module:calendar')->group(function () {
             Route::get('/events', [CalendarController::class, 'events']);
             Route::get('/connections', [CalendarController::class, 'connections']);
             Route::post('/connect', [CalendarController::class, 'connect']);
@@ -96,14 +96,14 @@ Route::prefix('v1')->group(function () {
             Route::post('/sync', [CalendarController::class, 'sync']);
         });
 
-        // Chat
-        Route::prefix('/chat')->group(function () {
+        // Chat (module: chat)
+        Route::prefix('/chat')->middleware('module:chat')->group(function () {
             Route::post('/', [ChatController::class, 'send']);
             Route::get('/history', [ChatController::class, 'history']);
         });
 
-        // Points
-        Route::prefix('/points')->group(function () {
+        // Points (module: points)
+        Route::prefix('/points')->middleware('module:points')->group(function () {
             Route::get('/bank', [PointsController::class, 'bank']);
             Route::get('/leaderboard', [PointsController::class, 'leaderboard']);
             Route::get('/feed', [PointsController::class, 'feed']);
@@ -111,8 +111,8 @@ Route::prefix('v1')->group(function () {
             Route::post('/deduct', [PointsController::class, 'deduct']);
         });
 
-        // Rewards
-        Route::prefix('/rewards')->group(function () {
+        // Rewards (module: points)
+        Route::prefix('/rewards')->middleware('module:points')->group(function () {
             Route::get('/', [RewardsController::class, 'index']);
             Route::post('/', [RewardsController::class, 'store']);
             Route::put('/{reward}', [RewardsController::class, 'update']);
@@ -121,8 +121,8 @@ Route::prefix('v1')->group(function () {
             Route::get('/purchases', [RewardsController::class, 'purchases']);
         });
 
-        // Badges
-        Route::prefix('/badges')->group(function () {
+        // Badges (module: badges)
+        Route::prefix('/badges')->middleware('module:badges')->group(function () {
             Route::get('/', [BadgesController::class, 'index']);
             Route::post('/', [BadgesController::class, 'store']);
             Route::put('/{badge}', [BadgesController::class, 'update']);


### PR DESCRIPTION
## Summary
Fixes #19

- Replaces simple on/off module toggles with granular per-user/role access control
- Parents can set each module to: Everyone, Parents Only, Off, or Custom (per-member checkboxes)
- API enforces access via new `CheckModuleAccess` middleware on all module routes (returns 403 if denied)
- Frontend router guard checks per-user access, not just family-wide boolean
- Backward compatible — existing families with simple on/off settings still work (`true` → all, `false` → off)
- Parents always have access to everything (unless module is globally off)

### Files changed
- `Family` model: access check methods
- New `CheckModuleAccess` middleware applied to all module route groups
- Settings UI: per-module access cards with quick-action buttons
- Auth store: per-user module access evaluation
- Router guard: granular access check

## Test plan
- [ ] Existing families with simple toggles still work
- [ ] Parent sets Calendar to "Parents Only" — child can't access calendar
- [ ] Parent sets Vault to "Custom" + selects specific kids — only those kids see vault
- [ ] Parent sets module to "Off" — nobody sees it (not even parents)
- [ ] API returns 403 when accessing a restricted module
- [ ] Settings UI shows correct state after save + reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)