### PR TITLE
Chat setup prompt + feature ship checklist (#64, #77)

### DIFF
--- a/.claude/commands/ship.md
+++ b/.claude/commands/ship.md
@@ -1,0 +1,18 @@
+---
+description: Pre-merge audit — checks if a feature is ready to ship
+---
+
+Run the Kinhold ship checklist against the current branch. Compare what changed in this branch vs `main` and audit each item:
+
+1. **API endpoints** — Check if new routes were added in `routes/api.php`. If yes, confirm controllers exist and work.
+2. **Vue frontend** — Check if new Vue components/views were added. If yes, confirm they render (build must pass).
+3. **MCP server tools** — Check if new API routes exist that don't have matching MCP tools in `mcp-server/src/tools/`. Flag any gaps.
+4. **Pinia stores** — Check if new frontend features have corresponding stores.
+5. **Database seeder** — Check if new models/tables were added. If yes, verify `database/seeders/` covers them with demo data.
+6. **Landing page** — Remind that any new user-facing feature needs a landing page update.
+7. **README** — Check if the README feature list mentions the new feature.
+8. **ROADMAP.md** — Check if the feature is tracked in the roadmap.
+9. **CHANGELOG.md** — Check if this work is logged in the changelog.
+10. **Tests** — Check if new test files were added for the new code.
+
+Output a checklist with pass/fail/warning for each item. Be specific about what's missing.

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,47 @@
+name: Bug Report
+description: Report something that isn't working correctly
+title: "Bug: "
+labels: ["bug"]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: What happened?
+      description: A clear description of the bug.
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What should have happened instead?
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: How can we trigger this bug?
+      placeholder: |
+        1. Go to ...
+        2. Click on ...
+        3. See error ...
+
+  - type: dropdown
+    id: environment
+    attributes:
+      label: Environment
+      options:
+        - Production (kinhold.app)
+        - Local development
+        - Docker
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Screenshots, error logs, browser info, etc.

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,0 +1,52 @@
+name: Feature Request
+description: Propose a new feature for Kinhold
+title: "Feature: "
+labels: ["feature"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for suggesting a feature! Please fill out the sections below.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What problem does this feature solve?
+      placeholder: "When I try to ..., I can't ..."
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed Solution
+      description: How should this work? Include UI, API, and data model ideas.
+      placeholder: "Add a new endpoint that ..."
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives Considered
+      description: Any other approaches you thought about?
+
+  - type: checkboxes
+    id: ship-checklist
+    attributes:
+      label: Ship Checklist
+      description: |
+        A feature is NOT done until all of these are complete.
+        Check them off as you go during implementation.
+      options:
+        - label: "API endpoints implemented"
+        - label: "Vue frontend components built"
+        - label: "MCP server tools added (MCP is a primary interface — not optional)"
+        - label: "Pinia store created/updated"
+        - label: "Database seeder updated (demo data for self-hosters)"
+        - label: "Landing page updated (if it's not on the landing page, it doesn't exist)"
+        - label: "README updated (feature list, screenshots)"
+        - label: "ROADMAP.md updated"
+        - label: "CHANGELOG.md updated"
+        - label: "Tests written"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,7 +62,23 @@ chmod +x setup.sh && ./setup.sh
 1. Fork the repo and create a branch from `main`.
 2. Make your changes. Keep commits focused.
 3. Ensure the frontend builds cleanly: `npx vite build`
-4. Open a pull request against `main` with a clear description of what and why.
+4. Run the **ship checklist** below before opening your PR.
+5. Open a pull request against `main` with a clear description of what and why.
+
+## Ship checklist
+
+A feature is **not done** until all applicable items are complete. This is enforced in our [feature issue template](.github/ISSUE_TEMPLATE/feature.yml).
+
+- [ ] API endpoints implemented
+- [ ] Vue frontend components built
+- [ ] **MCP server tools added** — MCP is a primary interface, not an afterthought
+- [ ] Pinia store created/updated
+- [ ] **Database seeder updated** — self-hosters must see the feature with demo data on first run
+- [ ] **Landing page updated** — if it's not on the landing page, it doesn't exist to new users
+- [ ] README updated (feature list, screenshots)
+- [ ] ROADMAP.md updated
+- [ ] CHANGELOG.md updated
+- [ ] Tests written
 
 ## Principles check
 

--- a/resources/js/views/chat/ChatView.vue
+++ b/resources/js/views/chat/ChatView.vue
@@ -1,7 +1,36 @@
 <template>
   <div class="h-full flex flex-col">
+    <!-- Setup Prompt: No API Key -->
+    <div v-if="!checkingKey && !hasApiKey" class="flex-1 flex items-center justify-center px-4 md:px-6 py-4">
+      <div class="text-center max-w-sm">
+        <div class="w-16 h-16 rounded-2xl bg-golden-50 dark:bg-golden-900/20 flex items-center justify-center mx-auto mb-4">
+          <Cog6ToothIcon class="w-8 h-8 text-golden-500" />
+        </div>
+        <h2 class="text-xl font-bold font-heading text-prussian-500 dark:text-lavender-200 mb-2">
+          {{ isParent ? 'Set Up AI Chat' : 'Chat Not Available' }}
+        </h2>
+        <p class="text-sm text-lavender-500 dark:text-lavender-400 mb-6">
+          <template v-if="isParent">
+            The AI assistant needs an API key to work. Add your Anthropic API key in
+            <strong>Settings &gt; API Configuration</strong> to activate this feature.
+          </template>
+          <template v-else>
+            This feature hasn't been set up yet. Ask a parent to configure it in Settings.
+          </template>
+        </p>
+        <router-link
+          v-if="isParent"
+          to="/settings"
+          class="inline-flex items-center gap-2 px-5 py-2.5 bg-wisteria-600 text-white rounded-xl hover:bg-wisteria-500 transition-colors text-sm font-medium"
+        >
+          Go to Settings
+          <ArrowRightIcon class="w-4 h-4" />
+        </router-link>
+      </div>
+    </div>
+
     <!-- Messages Container -->
-    <div ref="messagesContainer" class="flex-1 overflow-y-auto px-4 md:px-6 py-4">
+    <div v-else-if="!checkingKey" ref="messagesContainer" class="flex-1 overflow-y-auto px-4 md:px-6 py-4">
       <!-- Welcome / Empty State -->
       <div v-if="messages.length === 0 && !loading" class="flex items-center justify-center h-full">
         <div class="text-center max-w-sm">
@@ -87,7 +116,7 @@
     </div>
 
     <!-- Input Area -->
-    <div class="border-t border-lavender-200 dark:border-prussian-700 bg-white dark:bg-prussian-800 px-4 md:px-6 py-3 pb-safe-bottom">
+    <div v-if="!checkingKey && hasApiKey" class="border-t border-lavender-200 dark:border-prussian-700 bg-white dark:bg-prussian-800 px-4 md:px-6 py-3 pb-safe-bottom">
       <form @submit.prevent="handleSend" class="max-w-2xl mx-auto flex gap-2">
         <input
           v-model="messageInput"
@@ -109,13 +138,16 @@
 </template>
 
 <script setup>
-import { ref, onMounted, nextTick, watch } from 'vue'
+import { ref, computed, onMounted, nextTick, watch } from 'vue'
 import { storeToRefs } from 'pinia'
 import { useChatStore } from '@/stores/chat'
 import { useAuthStore } from '@/stores/auth'
+import api from '@/services/api'
 import {
   SparklesIcon,
   PaperAirplaneIcon,
+  Cog6ToothIcon,
+  ArrowRightIcon,
 } from '@heroicons/vue/24/outline'
 
 const chatStore = useChatStore()
@@ -123,9 +155,12 @@ const authStore = useAuthStore()
 
 const { messages, loading } = storeToRefs(chatStore)
 const { currentUser } = storeToRefs(authStore)
+const isParent = computed(() => authStore.isParent)
 
 const messageInput = ref('')
 const messagesContainer = ref(null)
+const hasApiKey = ref(true) // assume true until checked to avoid flash
+const checkingKey = ref(true)
 
 const suggestedQuestions = [
   "What's on my calendar today?",
@@ -165,7 +200,16 @@ const quickSend = async (text) => {
 
 watch(messages, scrollToBottom, { deep: true })
 
-onMounted(() => {
+onMounted(async () => {
+  try {
+    const { data } = await api.get('/settings')
+    hasApiKey.value = data.settings?.ai_has_key || false
+  } catch {
+    // If settings fetch fails, let them try chatting (backend will error gracefully)
+    hasApiKey.value = true
+  } finally {
+    checkingKey.value = false
+  }
   scrollToBottom()
 })
 </script>


### PR DESCRIPTION
## Summary
- **#64**: Chat view now checks for `ai_has_key` on mount. If no API key is configured, parents see a "Set Up AI Chat" prompt with a link to Settings; children see "Chat Not Available". Prevents the broken UX of sending messages that silently fail.
- **#77**: Added GitHub issue templates (`feature.yml` with mandatory ship checklist, `bug.yml`), a `/ship` Claude Code command for pre-merge audits, and updated `CONTRIBUTING.md` with the full ship checklist.

## Test plan
- [ ] Open Chat view with no `ai_api_key` in family settings — verify setup prompt appears
- [ ] As a child user, verify "Chat Not Available" message (no settings link)
- [ ] As a parent, click "Go to Settings" link — verify it navigates correctly
- [ ] Add an API key in settings, return to chat — verify normal chat interface appears
- [ ] Create a new issue on GitHub — verify feature and bug templates appear
- [ ] Run `/ship` in Claude Code — verify it audits the current branch

Closes #64, closes #77

🤖 Generated with [Claude Code](https://claude.com/claude-code)