### PR TITLE
fix: disable Upsun SMTP injection to allow Resend mail driver

### DIFF
--- a/.upsun/config.yaml
+++ b/.upsun/config.yaml
@@ -35,6 +35,9 @@ applications:
     variables:
       env:
         N_PREFIX: "/app/.global"
+    # Disable Upsun's built-in SMTP injection — we use Resend instead
+    # Without this, Upsun overrides MAIL_MAILER=smtp at the platform level
+    enable_smtp: false
     dependencies:
       nodejs:
         n: "*"


### PR DESCRIPTION
Upsun's `enable_smtp: true` was injecting `MAIL_MAILER=smtp` at the platform level, overriding our `MAIL_MAILER=resend` app variable. Setting `enable_smtp: false` stops the injection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)