### PR TITLE
revert: remove invalid enable_smtp from config.yaml

### DIFF
--- a/.upsun/config.yaml
+++ b/.upsun/config.yaml
@@ -32,9 +32,6 @@ applications:
       scheduler:
         commands:
           start: php artisan schedule:work
-    # Disable Upsun's built-in SMTP injection — we use Resend instead
-    # Without this, Upsun overrides MAIL_MAILER=smtp at the platform level
-    enable_smtp: false
     variables:
       env:
         N_PREFIX: "/app/.global"


### PR DESCRIPTION
Removes the invalid `enable_smtp` key from config.yaml. Per Upsun docs, this is a per-environment CLI setting (`upsun environment:info enable_smtp false`), not a config.yaml property.