### PR TITLE
Quick wins: 7 fixes — chat, calendar, vault, email, recurring tasks

### DIFF
--- a/app/Console/Commands/GenerateRecurringTasks.php
+++ b/app/Console/Commands/GenerateRecurringTasks.php
@@ -27,29 +27,43 @@ class GenerateRecurringTasks extends Command
         $created = 0;
 
         foreach ($templates as $template) {
-            // Skip if there's already an incomplete instance of this template
-            $hasPending = Task::where('parent_task_id', $template->id)
+            $allowPileup = $template->allow_pileup ?? false;
+
+            // Get any incomplete (uncompleted) instances
+            $pendingInstances = Task::where('parent_task_id', $template->id)
                 ->whereNull('completed_at')
-                ->exists();
+                ->get();
 
-            if ($hasPending) {
-                continue;
-            }
+            if (!$allowPileup) {
+                // Default behavior: only ONE active instance at a time.
+                // If there's already an incomplete instance, update its due date
+                // to today (rolling forward) instead of creating a new one.
+                if ($pendingInstances->count() > 0) {
+                    // Keep only the most recent pending instance, update it to today
+                    $keeper = $pendingInstances->sortByDesc('due_date')->first();
+                    if ($keeper->due_date->lt($today)) {
+                        $keeper->update(['due_date' => $today]);
+                    }
 
-            $dates = $this->getOccurrenceDates($template->recurrence_rule, $today, $endDate);
+                    // Clean up any extra stale instances (shouldn't happen, but defensive)
+                    $staleIds = $pendingInstances->where('id', '!=', $keeper->id)->pluck('id');
+                    if ($staleIds->isNotEmpty()) {
+                        Task::whereIn('id', $staleIds)->delete();
+                        $this->info("Cleaned up {$staleIds->count()} stale instance(s) of '{$template->title}'.");
+                    }
 
-            foreach ($dates as $date) {
-                // Check if an instance already exists for this date
-                $exists = Task::where('parent_task_id', $template->id)
-                    ->whereDate('due_date', $date)
-                    ->exists();
-
-                if ($exists) {
                     continue;
                 }
 
-                // Check recurrence end
-                if ($template->recurrence_end && $date->gt($template->recurrence_end)) {
+                // No pending instance — create one for the next occurrence
+                $dates = $this->getOccurrenceDates($template->recurrence_rule, $today, $endDate);
+                $nextDate = $dates[0] ?? null;
+
+                if (!$nextDate) {
+                    continue;
+                }
+
+                if ($template->recurrence_end && $nextDate->gt($template->recurrence_end)) {
                     continue;
                 }
 
@@ -59,7 +73,7 @@ class GenerateRecurringTasks extends Command
                     'assigned_to' => $template->assigned_to,
                     'title' => $template->title,
                     'description' => $template->description,
-                    'due_date' => $date,
+                    'due_date' => $nextDate,
                     'priority' => $template->priority,
                     'is_family_task' => $template->is_family_task,
                     'points' => $template->points,
@@ -67,6 +81,43 @@ class GenerateRecurringTasks extends Command
                 ]);
 
                 $created++;
+            } else {
+                // Pileup mode: generate all instances in the window (original behavior).
+                // Useful for tasks like "take medication" where each missed dose matters.
+                if ($pendingInstances->isNotEmpty()) {
+                    continue;
+                }
+
+                $dates = $this->getOccurrenceDates($template->recurrence_rule, $today, $endDate);
+
+                foreach ($dates as $date) {
+                    $exists = Task::where('parent_task_id', $template->id)
+                        ->whereDate('due_date', $date)
+                        ->exists();
+
+                    if ($exists) {
+                        continue;
+                    }
+
+                    if ($template->recurrence_end && $date->gt($template->recurrence_end)) {
+                        continue;
+                    }
+
+                    Task::create([
+                        'family_id' => $template->family_id,
+                        'created_by' => $template->created_by,
+                        'assigned_to' => $template->assigned_to,
+                        'title' => $template->title,
+                        'description' => $template->description,
+                        'due_date' => $date,
+                        'priority' => $template->priority,
+                        'is_family_task' => $template->is_family_task,
+                        'points' => $template->points,
+                        'parent_task_id' => $template->id,
+                    ]);
+
+                    $created++;
+                }
             }
         }
 

--- a/app/Http/Controllers/Api/V1/CalendarController.php
+++ b/app/Http/Controllers/Api/V1/CalendarController.php
@@ -6,6 +6,7 @@ use App\Http\Controllers\Controller;
 use App\Http\Resources\CalendarEventResource;
 use App\Models\CalendarConnection;
 use App\Models\FamilyEvent;
+use App\Models\Task;
 use App\Services\GoogleCalendarService;
 use App\Services\IcsCalendarService;
 use Carbon\Carbon;
@@ -99,6 +100,31 @@ class CalendarController extends Controller
                     'color' => $event->color ?? '#6366f1',
                 ],
                 'source' => 'manual',
+            ];
+        }
+
+        // ── Tasks with due dates ──
+        $tasks = Task::where('family_id', $familyId)
+            ->whereNotNull('due_date')
+            ->whereBetween('due_date', [$start, $end])
+            ->with('assignee:id,name')
+            ->get();
+
+        foreach ($tasks as $task) {
+            $allEvents[] = [
+                'id' => 'task-' . $task->id,
+                'title' => ($task->completed_at ? "\u{2705} " : '') . $task->title,
+                'description' => $task->description,
+                'start' => $task->due_date->toDateString(),
+                'end' => $task->due_date->toDateString(),
+                'all_day' => true,
+                'location' => null,
+                'calendar_id' => null,
+                'user' => [
+                    'name' => $task->assignee?->name ?? 'Unassigned',
+                    'color' => $task->completed_at ? '#9A9892' : '#B38A50',
+                ],
+                'source' => 'task',
             ];
         }
 

--- a/app/Http/Controllers/Api/V1/VaultController.php
+++ b/app/Http/Controllers/Api/V1/VaultController.php
@@ -295,6 +295,29 @@ class VaultController extends Controller
      * @param Document $document
      * @return JsonResponse
      */
+    /**
+     * Download a vault document.
+     */
+    public function downloadDocument(Request $request, Document $document)
+    {
+        // Ensure the document belongs to a vault entry in the user's family
+        $entry = $document->documentable;
+
+        if (!$entry || !($entry instanceof VaultEntry)) {
+            return response()->json(['message' => 'Document not found.'], 404);
+        }
+
+        $this->authorize('view', $entry);
+
+        $disk = \Storage::disk($document->disk ?? 'private');
+
+        if (!$disk->exists($document->path)) {
+            return response()->json(['message' => 'File not found.'], 404);
+        }
+
+        return $disk->download($document->path, $document->original_filename);
+    }
+
     public function deleteDocument(Request $request, Document $document): JsonResponse
     {
         $this->authorize('view', $document->vaultEntry);

--- a/app/Http/Requests/Task/StoreTaskRequest.php
+++ b/app/Http/Requests/Task/StoreTaskRequest.php
@@ -35,6 +35,7 @@ class StoreTaskRequest extends FormRequest
             'points' => 'nullable|integer|min:0',
             'recurrence_rule' => 'nullable|string|max:255',
             'recurrence_end' => 'nullable|date',
+            'allow_pileup' => 'nullable|boolean',
         ];
     }
 }

--- a/app/Http/Resources/DocumentResource.php
+++ b/app/Http/Resources/DocumentResource.php
@@ -19,7 +19,7 @@ class DocumentResource extends JsonResource
             'original_filename' => $this->original_filename,
             'mime_type' => $this->mime_type,
             'size' => $this->size,
-            'download_url' => route('documents.download', $this->id),
+            'download_url' => url("/api/v1/vault/documents/{$this->id}/download"),
             'created_at' => $this->created_at,
         ];
     }

--- a/app/Models/Task.php
+++ b/app/Models/Task.php
@@ -43,6 +43,7 @@ class Task extends Model
         'points',
         'recurrence_rule',
         'recurrence_end',
+        'allow_pileup',
         'parent_task_id',
     ];
 
@@ -60,6 +61,7 @@ class Task extends Model
             'is_family_task' => 'boolean',
             'points' => 'integer',
             'recurrence_end' => 'date',
+            'allow_pileup' => 'boolean',
         ];
     }
 

--- a/app/Services/AiProviders/AiProviderInterface.php
+++ b/app/Services/AiProviders/AiProviderInterface.php
@@ -9,10 +9,11 @@ interface AiProviderInterface
      *
      * @param string $systemPrompt The system prompt with context
      * @param string $userMessage The user's message with family context appended
+     * @param array $conversationHistory Previous messages as [{role: 'user'|'assistant', content: string}, ...]
      * @return string The AI's response text
      * @throws \RuntimeException If the API call fails
      */
-    public function ask(string $systemPrompt, string $userMessage): string;
+    public function ask(string $systemPrompt, string $userMessage, array $conversationHistory = []): string;
 
     /**
      * Get the provider's display name.

--- a/app/Services/AiProviders/AnthropicProvider.php
+++ b/app/Services/AiProviders/AnthropicProvider.php
@@ -14,8 +14,24 @@ class AnthropicProvider implements AiProviderInterface
         $this->model = $model ?: self::defaultModel();
     }
 
-    public function ask(string $systemPrompt, string $userMessage): string
+    public function ask(string $systemPrompt, string $userMessage, array $conversationHistory = []): string
     {
+        $messages = [];
+
+        // Add conversation history (last N turns)
+        foreach ($conversationHistory as $msg) {
+            $messages[] = [
+                'role' => $msg['role'],
+                'content' => $msg['content'],
+            ];
+        }
+
+        // Add current user message
+        $messages[] = [
+            'role' => 'user',
+            'content' => $userMessage,
+        ];
+
         $response = Http::withHeaders([
             'x-api-key' => $this->apiKey,
             'anthropic-version' => '2023-06-01',
@@ -24,12 +40,7 @@ class AnthropicProvider implements AiProviderInterface
             'model' => $this->model,
             'max_tokens' => 1024,
             'system' => $systemPrompt,
-            'messages' => [
-                [
-                    'role' => 'user',
-                    'content' => $userMessage,
-                ],
-            ],
+            'messages' => $messages,
         ]);
 
         if ($response->failed()) {

--- a/app/Services/AiProviders/GoogleGeminiProvider.php
+++ b/app/Services/AiProviders/GoogleGeminiProvider.php
@@ -14,9 +14,29 @@ class GoogleGeminiProvider implements AiProviderInterface
         $this->model = $model ?: self::defaultModel();
     }
 
-    public function ask(string $systemPrompt, string $userMessage): string
+    public function ask(string $systemPrompt, string $userMessage, array $conversationHistory = []): string
     {
         $url = "https://generativelanguage.googleapis.com/v1beta/models/{$this->model}:generateContent?key={$this->apiKey}";
+
+        $contents = [];
+
+        // Add conversation history (Gemini uses 'user' and 'model' roles)
+        foreach ($conversationHistory as $msg) {
+            $contents[] = [
+                'role' => $msg['role'] === 'assistant' ? 'model' : 'user',
+                'parts' => [
+                    ['text' => $msg['content']],
+                ],
+            ];
+        }
+
+        // Add current user message
+        $contents[] = [
+            'role' => 'user',
+            'parts' => [
+                ['text' => $userMessage],
+            ],
+        ];
 
         $response = Http::withHeaders([
             'Content-Type' => 'application/json',
@@ -26,14 +46,7 @@ class GoogleGeminiProvider implements AiProviderInterface
                     ['text' => $systemPrompt],
                 ],
             ],
-            'contents' => [
-                [
-                    'role' => 'user',
-                    'parts' => [
-                        ['text' => $userMessage],
-                    ],
-                ],
-            ],
+            'contents' => $contents,
             'generationConfig' => [
                 'maxOutputTokens' => 1024,
             ],

--- a/app/Services/AiProviders/OpenAiProvider.php
+++ b/app/Services/AiProviders/OpenAiProvider.php
@@ -14,24 +14,36 @@ class OpenAiProvider implements AiProviderInterface
         $this->model = $model ?: self::defaultModel();
     }
 
-    public function ask(string $systemPrompt, string $userMessage): string
+    public function ask(string $systemPrompt, string $userMessage, array $conversationHistory = []): string
     {
+        $messages = [
+            [
+                'role' => 'system',
+                'content' => $systemPrompt,
+            ],
+        ];
+
+        // Add conversation history
+        foreach ($conversationHistory as $msg) {
+            $messages[] = [
+                'role' => $msg['role'],
+                'content' => $msg['content'],
+            ];
+        }
+
+        // Add current user message
+        $messages[] = [
+            'role' => 'user',
+            'content' => $userMessage,
+        ];
+
         $response = Http::withHeaders([
             'Authorization' => 'Bearer ' . $this->apiKey,
             'Content-Type' => 'application/json',
         ])->timeout(60)->post('https://api.openai.com/v1/chat/completions', [
             'model' => $this->model,
             'max_tokens' => 1024,
-            'messages' => [
-                [
-                    'role' => 'system',
-                    'content' => $systemPrompt,
-                ],
-                [
-                    'role' => 'user',
-                    'content' => $userMessage,
-                ],
-            ],
+            'messages' => $messages,
         ]);
 
         if ($response->failed()) {

--- a/app/Services/ChatbotService.php
+++ b/app/Services/ChatbotService.php
@@ -3,6 +3,8 @@
 namespace App\Services;
 
 use App\Models\User;
+use App\Models\Badge;
+use App\Models\ChatMessage;
 use App\Models\Family;
 use App\Models\Task;
 use App\Models\VaultEntry;
@@ -39,8 +41,11 @@ class ChatbotService
         $systemPrompt = $this->buildSystemPrompt($user, $family);
         $userMessage = "{$message}\n\nFamily Context:\n{$context}";
 
+        // Fetch recent conversation history (last 10 messages = 5 turns)
+        $history = $this->getConversationHistory($user, 10);
+
         try {
-            return $provider->ask($systemPrompt, $userMessage);
+            return $provider->ask($systemPrompt, $userMessage, $history);
         } catch (\Exception $e) {
             Log::error('Chatbot error: ' . $e->getMessage());
             throw $e;
@@ -144,10 +149,33 @@ Guidelines:
 - Provide practical advice for family management
 - Respect privacy - only share information the user has access to
 - For children, avoid sharing detailed security/vault information they don't have access to
+- NEVER reveal details about hidden badges (name, description, criteria, or how to earn them). If asked, say "There are some surprise badges to discover!" but don't give specifics
 - Help with task planning, scheduling, and reminders
 - Be concise but helpful
 - Ask clarifying questions when needed
 PROMPT;
+    }
+
+    /**
+     * Get recent conversation history for multi-turn context.
+     */
+    private function getConversationHistory(User $user, int $limit = 10): array
+    {
+        try {
+            return ChatMessage::where('user_id', $user->id)
+                ->orderBy('created_at', 'desc')
+                ->limit($limit)
+                ->get()
+                ->reverse()
+                ->map(fn ($msg) => [
+                    'role' => $msg->role,
+                    'content' => $msg->message,
+                ])
+                ->values()
+                ->toArray();
+        } catch (\Exception $e) {
+            return [];
+        }
     }
 
     /**
@@ -171,6 +199,12 @@ PROMPT;
         $vaultSummary = $this->getAccessibleVaultSummary($user, $family);
         if (!empty($vaultSummary)) {
             $context[] = "Vault info: " . implode(', ', $vaultSummary);
+        }
+
+        // Badges (exclude hidden unearned badges)
+        $badgeSummary = $this->getBadgeSummary($user, $family);
+        if (!empty($badgeSummary)) {
+            $context[] = "Badges:\n" . implode("\n", $badgeSummary);
         }
 
         return implode("\n\n", $context);
@@ -216,6 +250,45 @@ PROMPT;
             })->count();
 
             return ["You have access to {$count} vault entries"];
+        } catch (\Exception $e) {
+            return [];
+        }
+    }
+
+    /**
+     * Get badge summary, excluding hidden badges the user hasn't earned.
+     */
+    private function getBadgeSummary(User $user, Family $family): array
+    {
+        try {
+            $earnedBadgeIds = $user->badges()->pluck('badges.id')->toArray();
+
+            $badges = Badge::where('family_id', $family->id)
+                ->where('is_active', true)
+                ->get();
+
+            $lines = [];
+            foreach ($badges as $badge) {
+                $earned = in_array($badge->id, $earnedBadgeIds);
+
+                // Never reveal hidden badge details unless earned
+                if ($badge->is_hidden && !$earned) {
+                    continue;
+                }
+
+                $status = $earned ? 'EARNED' : 'not yet earned';
+                $lines[] = "- {$badge->name}: {$badge->description} [{$status}]";
+            }
+
+            $hiddenCount = $badges->where('is_hidden', true)
+                ->whereNotIn('id', $earnedBadgeIds)
+                ->count();
+
+            if ($hiddenCount > 0) {
+                $lines[] = "- Plus {$hiddenCount} hidden surprise badge(s) to discover!";
+            }
+
+            return $lines;
         } catch (\Exception $e) {
             return [];
         }

--- a/config/mail.php
+++ b/config/mail.php
@@ -1,0 +1,93 @@
+<?php
+
+return [
+    /*
+    |--------------------------------------------------------------------------
+    | Default Mailer
+    |--------------------------------------------------------------------------
+    */
+    'default' => env('MAIL_MAILER', 'log'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Mailer Configurations
+    |--------------------------------------------------------------------------
+    */
+    'mailers' => [
+        'smtp' => [
+            'transport' => 'smtp',
+            'url' => env('MAIL_URL'),
+            'host' => env('MAIL_HOST', '127.0.0.1'),
+            'port' => env('MAIL_PORT', 2525),
+            'encryption' => env('MAIL_ENCRYPTION', 'tls'),
+            'username' => env('MAIL_USERNAME'),
+            'password' => env('MAIL_PASSWORD'),
+            'timeout' => null,
+            'local_domain' => env('MAIL_EHLO_DOMAIN', parse_url(env('APP_URL', 'http://localhost'), PHP_URL_HOST)),
+        ],
+
+        'ses' => [
+            'transport' => 'ses',
+        ],
+
+        'postmark' => [
+            'transport' => 'postmark',
+        ],
+
+        'resend' => [
+            'transport' => 'resend',
+        ],
+
+        'sendmail' => [
+            'transport' => 'sendmail',
+            'path' => env('MAIL_SENDMAIL_PATH', '/usr/sbin/sendmail -bs -i'),
+        ],
+
+        'log' => [
+            'transport' => 'log',
+            'channel' => env('MAIL_LOG_CHANNEL'),
+        ],
+
+        'array' => [
+            'transport' => 'array',
+        ],
+
+        'failover' => [
+            'transport' => 'failover',
+            'mailers' => [
+                'smtp',
+                'log',
+            ],
+        ],
+
+        'roundrobin' => [
+            'transport' => 'roundrobin',
+            'mailers' => [
+                'ses',
+                'postmark',
+            ],
+        ],
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Global "From" Address
+    |--------------------------------------------------------------------------
+    */
+    'from' => [
+        'address' => env('MAIL_FROM_ADDRESS', 'hello@kinhold.app'),
+        'name' => env('MAIL_FROM_NAME', 'Kinhold'),
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Markdown Mail Settings
+    |--------------------------------------------------------------------------
+    */
+    'markdown' => [
+        'theme' => 'kinhold',
+        'paths' => [
+            resource_path('views/vendor/mail'),
+        ],
+    ],
+];

--- a/config/sanctum.php
+++ b/config/sanctum.php
@@ -39,7 +39,7 @@ return [
     | not expire. This won't tweak the lifetime of first-party sessions.
     |
     */
-    'expiration' => null,
+    'expiration' => 60 * 24 * 30, // 30 days in minutes
 
     /*
     |--------------------------------------------------------------------------

--- a/database/migrations/2026_03_29_180000_add_allow_pileup_to_tasks_table.php
+++ b/database/migrations/2026_03_29_180000_add_allow_pileup_to_tasks_table.php
@@ -1,0 +1,44 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('tasks', function (Blueprint $table) {
+            $table->boolean('allow_pileup')->default(false)->after('recurrence_end');
+        });
+
+        // Clean up stale recurring task pileups: for each parent template,
+        // keep only the most recent incomplete instance, delete the rest.
+        $templates = DB::table('tasks')
+            ->whereNotNull('recurrence_rule')
+            ->whereNull('parent_task_id')
+            ->pluck('id');
+
+        foreach ($templates as $templateId) {
+            $pendingInstances = DB::table('tasks')
+                ->where('parent_task_id', $templateId)
+                ->whereNull('completed_at')
+                ->orderByDesc('due_date')
+                ->pluck('id');
+
+            if ($pendingInstances->count() > 1) {
+                // Keep the first (most recent), delete the rest
+                $toDelete = $pendingInstances->slice(1);
+                DB::table('tasks')->whereIn('id', $toDelete)->delete();
+            }
+        }
+    }
+
+    public function down(): void
+    {
+        Schema::table('tasks', function (Blueprint $table) {
+            $table->dropColumn('allow_pileup');
+        });
+    }
+};

--- a/resources/views/vendor/mail/html/themes/kinhold.css
+++ b/resources/views/vendor/mail/html/themes/kinhold.css
@@ -1,0 +1,76 @@
+/* Kinhold Email Theme */
+/* Brand colors: Gold accent #B38A50, Dark #373430, Surface #F5F2EE */
+
+/* Header */
+.header a {
+    color: #B38A50 !important;
+    font-size: 19px;
+    font-weight: bold;
+    text-decoration: none;
+}
+
+/* Body */
+body {
+    background-color: #F5F2EE;
+    color: #373430;
+}
+
+.body {
+    background-color: #F5F2EE;
+}
+
+.inner-body {
+    background-color: #ffffff;
+    border-color: #E4DED6;
+    border-width: 1px;
+}
+
+/* Headings */
+h1 {
+    color: #373430;
+    font-size: 18px;
+}
+
+/* Buttons */
+.button-primary {
+    background-color: #B38A50;
+    border-bottom: 8px solid #B38A50;
+    border-left: 18px solid #B38A50;
+    border-right: 18px solid #B38A50;
+    border-top: 8px solid #B38A50;
+}
+
+/* Links */
+a {
+    color: #B38A50;
+}
+
+/* Footer */
+.footer p {
+    color: #9A9892;
+    font-size: 12px;
+}
+
+/* Table */
+.table th {
+    border-bottom: 1px solid #E4DED6;
+}
+
+.table td {
+    color: #373430;
+}
+
+/* Panel (info/subcopy boxes) */
+.panel {
+    background-color: #FAF8F5;
+    border-left: 4px solid #B38A50;
+}
+
+.panel-item p {
+    color: #6B6966;
+}
+
+/* Subcopy */
+.subcopy p {
+    color: #9A9892;
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -89,6 +89,7 @@ Route::prefix('v1')->group(function () {
             Route::post('/entries/{entry}/permissions', [VaultController::class, 'grantPermission']);
             Route::delete('/entries/{entry}/permissions/{user}', [VaultController::class, 'revokePermission']);
             Route::post('/entries/{entry}/documents', [VaultController::class, 'uploadDocument']);
+            Route::get('/documents/{document}/download', [VaultController::class, 'downloadDocument']);
             Route::delete('/documents/{document}', [VaultController::class, 'deleteDocument']);
         });
 


### PR DESCRIPTION
## Summary

- **#108 — Hidden badges in chat**: System prompt now explicitly forbids revealing hidden badge details. Badge context added to chatbot with proper filtering (hidden unearned badges excluded).
- **#109 — Multi-turn chat**: All 3 AI providers (Anthropic, OpenAI, Gemini) now receive the last 10 messages as conversation history for multi-turn context.
- **#93 — Tasks on calendar**: Tasks with due dates appear as all-day events on the calendar view. Completed tasks show a checkmark, open tasks use gold accent color.
- **#104 — Brand colors in email**: Created `kinhold.css` mail theme (gold accent, dark text, cream surface). Published `config/mail.php` with `theme => 'kinhold'`.
- **DocumentResource download route**: Fixed `route('documents.download')` error. Added `GET /api/v1/vault/documents/{id}/download` endpoint with proper authorization.
- **Sanctum token expiry**: Changed from `null` (never) to 30 days.
- **Recurring task pileup fix**: Only one active instance per recurring task by default. Missed tasks roll forward to today instead of stacking up. New `allow_pileup` boolean (default false) for tasks where accumulation is desired (e.g., medication). Migration cleans up existing stale pileups.

## Test plan

- [ ] Run `php artisan migrate` — verify `allow_pileup` column added and stale recurring instances cleaned up
- [ ] Check Tasks view — should show only one "Clean kitchen" instance (today's)
- [ ] Check Calendar view — tasks with due dates should appear as all-day events
- [ ] Send a chat message, then a follow-up — AI should remember the previous message
- [ ] Ask chat about hidden badges — should say "surprise badges to discover" without details
- [ ] Upload a document to vault — download URL should work (no route error)
- [ ] Trigger a notification email (register new user) — should use Kinhold gold/cream branding

🤖 Generated with [Claude Code](https://claude.com/claude-code)