### PR TITLE
feat: one-click "Try the Demo" with family member picker

### DIFF
--- a/.claude/handoff.md
+++ b/.claude/handoff.md
@@ -1,36 +1,35 @@
 # Session Handoff
 
 **Date:** 2026-04-02
-**Branch:** feature/calendar-unified-events (PR #127)
-**Last commit:** 0be3209 fix: countdown banner dismiss persistence — handle async prop arrival
+**Branch:** chore/fresh-demo-and-lint-cleanup (PR #128, pending merge)
+**Last commit:** 6e7aec4 chore: fresh demo family + eliminate all ESLint warnings
 
 ## What Was Done This Session
-- **Unified event model** — Merged `FeaturedEvent` and `FamilyEvent` into single `family_events` table. Any calendar event can be "featured" on the dashboard with personal or family scope. Migration copies existing data.
-- **Manual calendar events** — Full CRUD from calendar UI with recurrence, visibility (visible/busy/private), and featured-on-dashboard toggle. Click-a-day to create, click-to-edit.
-- **Countdown banner fixes** — Dismiss persists in localStorage (fixed async prop race condition), auto-hides past events, parent management actions from banner. Also fixed countdown toggle race condition in `setCountdown`.
-- **MCP parity** — ViewCalendar: fixed empty listing when no Google connections, added create/update/delete. ManageFeaturedEvents repointed to unified model.
-- **Security hardening** — Policy-based auth on CRUD, parent-only guards on featured fields, ownership checks on MCP update/delete.
+- Demo users now skip onboarding and don't see the email verification banner (`email_verified_at` + `onboarding_completed_at` set on all 5 seeded users)
+- New `app:refresh-demo` artisan command re-seeds demo family daily at 03:05 via Laravel scheduler
+- Eliminated all 43 ESLint warnings across 23 files (unused imports, console.error calls, dead code, unused variables)
+- CHANGELOG updated for Session 21
 
 ## Quality State
 - Tests: 60 tests, 118 assertions (pass, 2 deprecations)
 - Pint: pass
-- Larastan: pass (0 new errors, 218 baselined)
-- ESLint: pass (0 errors, 43 warnings — all pre-existing)
-- Build: pass (3175 modules, 2.42s)
-- CI: all 3 checks green on PR #127
+- Larastan: pass (0 errors)
+- ESLint: pass (0 errors, 0 warnings)
+- Build: pass (3175 modules)
+- CI: all checks green on PR #128
+- Upsun preview: deployed and active
 
 ## What's Next
-1. **Merge PR #127** — QA passed locally. Upsun preview has auth config issues (see Blockers). Greg should test on preview or merge and test on production.
-2. **Drop `featured_events` table** — Data migrated to `family_events`. Follow-up migration to drop old table after verifying production.
-3. **Fix Upsun preview auth** — Add preview domain pattern to SANCTUM_STATEFUL_DOMAINS. Blocks QA on previews for all future PRs.
-4. **Continue from ROADMAP** — #65 Shopping lists (Phase A) or #117 Versioning/releases.
+1. **Merge PR #128** — CI green, preview deployed, ready for `/merge`
+2. **Audit all controllers for family_id scoping** — Critical before Corey's family signs up
+3. **Shopping & grocery lists (issue #65)** — Phase A priority, the #1 daily-driver feature
+4. **PWA support (issue #68)** — Get the app installable on phones
 
 ## Blockers or Gotchas
-- **Upsun preview auth broken** — Preview domains aren't in `SANCTUM_STATEFUL_DOMAINS`, so API calls return 401. Google OAuth auto-redirects fail too (preview domain not in Google Cloud Console). Pre-existing but became visible during QA.
-- **`FeaturedEvent` model still exists** — Kept for rollback safety. Don't use in new code. Remove after verifying production migration.
-- **lodash-es npm audit high** — Transitive dep from Milkdown, no newer version available. Browser-bundled, not a real risk.
-- Pint formats differently on PHP 8.4 (CI) vs PHP 8.5 (local) — watch for `array_indentation` issues.
+- NPM audit shows 1 high severity vuln in `lodash-es` (pre-existing, `npm audit fix` available)
+- PHPStan 2.x is available — consider upgrading for 50-70% less memory usage
+- Composer on this machine is at `/usr/local/bin/composer` (not in default PATH), PHP is at `/opt/homebrew/bin/php`
+- **Upsun preview auth still broken** (from last session) — Preview domains not in `SANCTUM_STATEFUL_DOMAINS`. Pre-existing, blocks QA on previews.
 
 ## Open Questions
-- How to handle Upsun preview auth — env var wildcard for SANCTUM_STATEFUL_DOMAINS, or Laravel config change?
-- When to drop the `featured_events` table — next session after verifying production, or wait longer?
+- None from this session

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,18 +2,28 @@
 
 > Updated at the end of every working session. Newest entries first.
 
-## 2026-04-02 — Session 21: Fresh Demo Family
+## 2026-04-02 — Session 21: Fresh Demo Family + Try the Demo
 
 ### What Was Done
 - **Demo UX fixes** — Demo users now skip onboarding and don't see the email verification banner. Added `email_verified_at` and `onboarding_completed_at` to all 5 seeded demo users.
 - **Daily demo refresh** — New `app:refresh-demo` artisan command re-seeds the demo family so data always feels fresh. Scheduled daily at 03:05 via Laravel scheduler (Upsun's `schedule:work` worker picks it up automatically).
+- **Hardened demo passwords** — Demo users now get `Str::random(32)` passwords per seed run instead of `bcrypt('password')`. Passwords are never stored or displayed, change daily with re-seed.
+- **"Try the Demo" feature** — One-click demo access from landing page and login page. Interactive modal lets visitors choose a family member (Mike, Sarah, Emma, Jake, Lily) to log in as. Dedicated `POST /api/v1/demo-login` endpoint creates Sanctum tokens directly — no password needed. Works for managed accounts (Jake, Lily) too.
+- **Conditional visibility** — Demo buttons only appear when the demo family exists (`demo_available` flag in `/api/v1/config`). Self-hosted instances without demo data won't show them.
+- **ESLint cleanup** — Eliminated all 43 pre-existing warnings across 23 files (unused imports, dead code, console.error statements).
 
 ### Files Created
 - `app/Console/Commands/RefreshDemo.php`
+- `resources/js/components/common/DemoModal.vue`
 
 ### Files Modified
-- `database/seeders/DatabaseSeeder.php` (added verification + onboarding fields to demo users)
-- `routes/console.php` (added daily refresh schedule)
+- `database/seeders/DatabaseSeeder.php` (random passwords, verification + onboarding fields)
+- `routes/console.php` (daily refresh schedule)
+- `app/Http/Controllers/Api/V1/AuthController.php` (added `demoLogin()`)
+- `routes/api.php` (demo-login route, `demo_available` config flag)
+- `resources/js/stores/auth.js` (added `demoLogin()` action)
+- `resources/js/views/LandingView.vue` (demo button + modal)
+- `resources/js/views/auth/LoginView.vue` (demo link + modal)
 
 ---
 

--- a/app/Http/Controllers/Api/V1/AuthController.php
+++ b/app/Http/Controllers/Api/V1/AuthController.php
@@ -99,6 +99,42 @@ class AuthController extends Controller
     }
 
     /**
+     * Log in as a demo family member (no password required).
+     * Only works for the reserved demo family (slug: q32-demo-family).
+     */
+    public function demoLogin(Request $request): JsonResponse
+    {
+        $request->validate([
+            'member' => 'required|string|in:mike,sarah,emma,jake,lily',
+        ]);
+
+        $family = Family::where('slug', 'q32-demo-family')->first();
+
+        if (! $family) {
+            return response()->json([
+                'message' => 'Demo family not available.',
+            ], 404);
+        }
+
+        $user = User::where('family_id', $family->id)
+            ->where('name', ucfirst($request->member))
+            ->first();
+
+        if (! $user) {
+            return response()->json([
+                'message' => 'Demo member not found.',
+            ], 404);
+        }
+
+        $token = $user->createToken('demo_token')->plainTextToken;
+
+        return response()->json([
+            'token' => $token,
+            'user' => UserResource::make($user->load('family')),
+        ]);
+    }
+
+    /**
      * Resend email verification notification.
      */
     public function resendVerification(Request $request): JsonResponse

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -64,6 +64,7 @@ class DatabaseSeeder extends Seeder
 
         $now = Carbon::now();
         $vault = new VaultEncryptionService;
+        $demoPassword = bcrypt(Str::random(32));
 
         // ─────────────────────────────────────────────
         //  FAMILY
@@ -100,7 +101,7 @@ class DatabaseSeeder extends Seeder
         $mike = User::create([
             'name' => 'Mike',
             'email' => 'parent@demo.local',
-            'password' => bcrypt('password'),
+            'password' => $demoPassword,
             'family_id' => $family->id,
             'family_role' => FamilyRole::Parent,
             'date_of_birth' => '1984-06-15',
@@ -113,7 +114,7 @@ class DatabaseSeeder extends Seeder
         $sarah = User::create([
             'name' => 'Sarah',
             'email' => 'sarah@demo.local',
-            'password' => bcrypt('password'),
+            'password' => $demoPassword,
             'family_id' => $family->id,
             'family_role' => FamilyRole::Parent,
             'date_of_birth' => '1986-03-22',
@@ -126,7 +127,7 @@ class DatabaseSeeder extends Seeder
         $emma = User::create([
             'name' => 'Emma',
             'email' => 'emma@demo.local',
-            'password' => bcrypt('password'),
+            'password' => $demoPassword,
             'family_id' => $family->id,
             'family_role' => FamilyRole::Child,
             'date_of_birth' => $now->copy()->subYears(16)->subMonths(3)->toDateString(),

--- a/resources/js/components/common/DemoModal.vue
+++ b/resources/js/components/common/DemoModal.vue
@@ -1,0 +1,88 @@
+<template>
+  <BaseModal :show="show" title="Try the Demo" size="lg" @close="$emit('close')">
+    <p class="text-sm kin-muted mb-5">
+      Meet the Johnsons! Pick a family member to explore Kinhold from their perspective.
+    </p>
+
+    <div class="grid grid-cols-2 sm:grid-cols-3 gap-3">
+      <button
+        v-for="member in members"
+        :key="member.key"
+        :disabled="loadingMember !== null"
+        class="relative flex flex-col items-center gap-2 p-4 rounded-xl border border-lavender-200 dark:border-prussian-700 hover:border-wisteria-400 dark:hover:border-wisteria-500 hover:bg-lavender-50 dark:hover:bg-prussian-750 transition-all text-left disabled:opacity-50 disabled:cursor-not-allowed"
+        @click="handleSelect(member.key)"
+      >
+        <!-- Loading overlay -->
+        <div v-if="loadingMember === member.key" class="absolute inset-0 flex items-center justify-center bg-white/60 dark:bg-prussian-800/60 rounded-xl">
+          <LoadingSpinner size="sm" />
+        </div>
+
+        <!-- Avatar circle -->
+        <div
+          class="w-12 h-12 rounded-full flex items-center justify-center text-white font-bold text-lg"
+          :style="{ backgroundColor: member.color }"
+        >
+          {{ member.name[0] }}
+        </div>
+
+        <!-- Name & role -->
+        <div class="text-center">
+          <div class="font-semibold text-sm text-prussian-500 dark:text-lavender-200">{{ member.name }}</div>
+          <span
+            class="inline-block mt-1 text-xs px-2 py-0.5 rounded-full"
+            :class="member.role === 'Parent' ? 'bg-wisteria-100 text-wisteria-700 dark:bg-wisteria-900/30 dark:text-wisteria-300' : 'bg-sand-100 text-sand-700 dark:bg-sand-900/30 dark:text-sand-300'"
+          >
+            {{ member.role }}
+          </span>
+          <div class="text-xs kin-muted mt-1">{{ member.description }}</div>
+        </div>
+      </button>
+    </div>
+
+    <p v-if="errorMsg" class="mt-4 text-sm text-red-600 dark:text-red-400 text-center">{{ errorMsg }}</p>
+  </BaseModal>
+</template>
+
+<script setup>
+import { ref } from 'vue'
+import { useRouter } from 'vue-router'
+import { useAuthStore } from '@/stores/auth'
+import BaseModal from '@/components/common/BaseModal.vue'
+import LoadingSpinner from '@/components/common/LoadingSpinner.vue'
+
+defineProps({
+  show: Boolean,
+})
+
+const emit = defineEmits(['close'])
+
+const router = useRouter()
+const authStore = useAuthStore()
+
+const loadingMember = ref(null)
+const errorMsg = ref('')
+
+const members = [
+  { key: 'mike', name: 'Mike', role: 'Parent', description: 'Dad', color: '#5B8C9C' },
+  { key: 'sarah', name: 'Sarah', role: 'Parent', description: 'Mom', color: '#8B5B9C' },
+  { key: 'emma', name: 'Emma', role: 'Teen', description: 'Age 16', color: '#9C5B7B' },
+  { key: 'jake', name: 'Jake', role: 'Kid', description: 'Age 13', color: '#5B6B9C' },
+  { key: 'lily', name: 'Lily', role: 'Kid', description: 'Age 9', color: '#5B9C7B' },
+]
+
+const handleSelect = async (key) => {
+  loadingMember.value = key
+  errorMsg.value = ''
+
+  const result = await authStore.demoLogin(key)
+
+  if (result.success) {
+    emit('close')
+    router.push({ name: 'Dashboard' })
+  } else {
+    errorMsg.value = result.error || 'Something went wrong. Please try again.'
+  }
+
+  loadingMember.value = null
+}
+</script>

--- a/resources/js/stores/auth.js
+++ b/resources/js/stores/auth.js
@@ -130,6 +130,32 @@ export const useAuthStore = defineStore('auth', () => {
     }
   }
 
+  const demoLogin = async (member) => {
+    isLoading.value = true
+    error.value = null
+
+    try {
+      await axios.get('/sanctum/csrf-cookie')
+      const response = await api.post('/demo-login', { member })
+
+      if (response.data.token) {
+        localStorage.setItem('auth_token', response.data.token)
+        api.defaults.headers.common['Authorization'] = `Bearer ${response.data.token}`
+      }
+
+      user.value = response.data.user
+      isAuthenticated.value = true
+      await fetchUser()
+
+      return { success: true }
+    } catch (err) {
+      error.value = err.response?.data?.message || 'Demo login failed'
+      return { success: false, error: error.value }
+    } finally {
+      isLoading.value = false
+    }
+  }
+
   const register = async (data) => {
     isLoading.value = true
     error.value = null
@@ -397,6 +423,7 @@ export const useAuthStore = defineStore('auth', () => {
 
     // Actions
     login,
+    demoLogin,
     register,
     logout,
     fetchUser,

--- a/resources/js/views/LandingView.vue
+++ b/resources/js/views/LandingView.vue
@@ -36,6 +36,9 @@
           <router-link to="/register" class="kin-btn-primary text-base px-8 py-3.5">
             Create Your Family Hub
           </router-link>
+          <button v-if="demoAvailable" class="kin-btn-secondary text-base px-8 py-3.5" @click="showDemoModal = true">
+            Try the Demo
+          </button>
           <a href="#features" class="kin-btn-secondary text-base px-8 py-3.5">
             See Features
           </a>
@@ -322,11 +325,15 @@
         </nav>
       </div>
     </footer>
+
+    <DemoModal :show="showDemoModal" @close="showDemoModal = false" />
   </div>
 </template>
 
 <script setup>
-import { ref } from 'vue'
+import { ref, computed } from 'vue'
+import { useAuthStore } from '@/stores/auth'
+import DemoModal from '@/components/common/DemoModal.vue'
 import {
   CalendarDaysIcon,
   ClipboardDocumentCheckIcon,
@@ -342,6 +349,10 @@ import {
   RocketLaunchIcon,
   WrenchScrewdriverIcon,
 } from '@heroicons/vue/24/outline'
+
+const authStore = useAuthStore()
+const demoAvailable = computed(() => authStore.appConfig?.demo_available)
+const showDemoModal = ref(false)
 
 const activeShowcaseTab = ref('tasks')
 

--- a/resources/js/views/auth/LoginView.vue
+++ b/resources/js/views/auth/LoginView.vue
@@ -121,6 +121,13 @@
         <!-- Divider -->
         <div class="border-t border-kin-border dark:border-kin-border-dark my-6"></div>
 
+        <!-- Demo link -->
+        <p v-if="demoAvailable" class="text-center mb-4">
+          <button class="kin-link font-medium text-sm" @click="showDemoModal = true">
+            Or try the demo instead
+          </button>
+        </p>
+
         <!-- Register link -->
         <p class="text-center kin-muted">
           Don't have an account?
@@ -131,21 +138,27 @@
       </div>
     </div>
   </div>
+
+  <DemoModal :show="showDemoModal" @close="showDemoModal = false" />
 </template>
 
 <script setup>
-import { reactive, ref } from 'vue'
+import { reactive, ref, computed } from 'vue'
 import { useRouter } from 'vue-router'
 import { storeToRefs } from 'pinia'
 import { useAuthStore } from '@/stores/auth'
 import { useNotification } from '@/composables/useNotification'
 import BaseInput from '@/components/common/BaseInput.vue'
 import BaseButton from '@/components/common/BaseButton.vue'
+import DemoModal from '@/components/common/DemoModal.vue'
 
 const router = useRouter()
 const authStore = useAuthStore()
 const { isLoading } = storeToRefs(authStore)
 const { error: notificationError } = useNotification()
+
+const demoAvailable = computed(() => authStore.appConfig?.demo_available)
+const showDemoModal = ref(false)
 
 const form = reactive({
   email: '',

--- a/routes/api.php
+++ b/routes/api.php
@@ -16,6 +16,7 @@ use App\Http\Controllers\Api\V1\SettingsController;
 use App\Http\Controllers\Api\V1\TagController;
 use App\Http\Controllers\Api\V1\TaskController;
 use App\Http\Controllers\Api\V1\VaultController;
+use App\Models\Family;
 use App\Models\User;
 use Illuminate\Support\Facades\Route;
 
@@ -23,6 +24,7 @@ Route::prefix('v1')->group(function () {
     // Auth routes (no authentication required)
     Route::post('/register', [AuthController::class, 'register'])->middleware('throttle:5,1');
     Route::post('/login', [AuthController::class, 'login'])->middleware('throttle:5,1');
+    Route::post('/demo-login', [AuthController::class, 'demoLogin'])->middleware('throttle:10,1');
     Route::post('/auth/exchange', [GoogleAuthController::class, 'exchange'])->middleware('throttle:10,1');
     Route::post('/auth/google/confirm-link', [GoogleAuthController::class, 'confirmLink'])->middleware('throttle:5,1');
 
@@ -39,6 +41,7 @@ Route::prefix('v1')->group(function () {
             ],
             'registration' => true,
             'first_boot' => User::count() === 0,
+            'demo_available' => Family::where('slug', 'q32-demo-family')->exists(),
         ]);
     });
 


### PR DESCRIPTION
## Summary
- **One-click demo access** — "Try the Demo" button on landing page and login page opens an interactive modal where visitors pick a family member to log in as
- **Dedicated endpoint** — `POST /api/v1/demo-login` creates Sanctum tokens directly, no password needed. Works for managed accounts (Jake, Lily) too
- **Hardened demo passwords** — Demo users now get `Str::random(32)` passwords per seed run instead of `bcrypt('password')`
- **Self-hosted compatible** — Demo buttons only appear when the demo family exists (`demo_available` flag in `/api/v1/config`)

## Test Plan
- [ ] Visit landing page — "Try the Demo" button visible, opens modal
- [ ] Click a family member (e.g., Mike) → logged in, redirected to dashboard
- [ ] Visit login page — "Or try the demo instead" link visible, opens modal
- [ ] Click a managed account (Jake/Lily) → logged in successfully
- [ ] Try invalid member via API → returns 422
- [ ] Verify demo buttons hidden when demo family doesn't exist
- [ ] Test on mobile (375px)
- [ ] Check dark mode

## Checklist
- [x] Tested locally
- [x] Mobile-first (375px)
- [x] Dark mode support
- [x] No credentials committed
- [ ] API changes documented

🤖 Generated with [Claude Code](https://claude.com/claude-code)