### PR TITLE
feat: Food Step 2 — Recipe Import Service (URL + Photo)

### DIFF
--- a/app/Http/Controllers/Api/V1/RecipeController.php
+++ b/app/Http/Controllers/Api/V1/RecipeController.php
@@ -3,12 +3,15 @@
 namespace App\Http\Controllers\Api\V1;
 
 use App\Http\Controllers\Controller;
+use App\Http\Requests\Recipe\ImportPhotoRequest;
+use App\Http\Requests\Recipe\ImportUrlRequest;
 use App\Http\Requests\Recipe\StoreRecipeRequest;
 use App\Http\Requests\Recipe\UpdateRecipeRequest;
 use App\Http\Resources\RatingResource;
 use App\Http\Resources\RecipeCookLogResource;
 use App\Http\Resources\RecipeResource;
 use App\Models\Recipe;
+use App\Services\RecipeImportService;
 use App\Services\RecipeService;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
@@ -16,7 +19,10 @@ use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
 
 class RecipeController extends Controller
 {
-    public function __construct(private RecipeService $recipeService) {}
+    public function __construct(
+        private RecipeService $recipeService,
+        private RecipeImportService $recipeImportService,
+    ) {}
 
     public function index(Request $request): AnonymousResourceCollection
     {
@@ -139,5 +145,54 @@ class RecipeController extends Controller
         $ratings = $recipe->ratings()->with('user')->get();
 
         return RatingResource::collection($ratings);
+    }
+
+    public function importFromUrl(ImportUrlRequest $request): JsonResponse
+    {
+        $preview = $request->boolean('preview');
+        $family = $request->user()->family;
+        $user = $request->user();
+
+        $result = $this->recipeImportService->importFromUrl(
+            $request->validated('url'),
+            $family,
+            $user,
+            $preview,
+        );
+
+        if ($preview) {
+            return response()->json($result);
+        }
+
+        return response()->json(['recipe' => new RecipeResource($result['recipe'])], 201);
+    }
+
+    public function importFromPhoto(ImportPhotoRequest $request): JsonResponse
+    {
+        $preview = $request->boolean('preview');
+        $family = $request->user()->family;
+        $user = $request->user();
+
+        $result = $this->recipeImportService->importFromPhoto(
+            $request->file('photo'),
+            $family,
+            $user,
+            $preview,
+        );
+
+        if ($preview) {
+            return response()->json($result);
+        }
+
+        return response()->json(['recipe' => new RecipeResource($result['recipe'])], 201);
+    }
+
+    public function importFromSocialMedia(Request $request): JsonResponse
+    {
+        $this->authorize('create', Recipe::class);
+
+        return response()->json([
+            'message' => 'Social media import coming soon',
+        ], 501);
     }
 }

--- a/app/Http/Requests/Recipe/ImportPhotoRequest.php
+++ b/app/Http/Requests/Recipe/ImportPhotoRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Http\Requests\Recipe;
+
+use App\Models\Recipe;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Support\Facades\Gate;
+
+class ImportPhotoRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return Gate::allows('create', Recipe::class);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'photo' => ['required', 'image', 'max:10240', 'mimes:jpeg,png,heic,heif'],
+        ];
+    }
+}

--- a/app/Http/Requests/Recipe/ImportUrlRequest.php
+++ b/app/Http/Requests/Recipe/ImportUrlRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Http\Requests\Recipe;
+
+use App\Models\Recipe;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Support\Facades\Gate;
+
+class ImportUrlRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return Gate::allows('create', Recipe::class);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'url' => ['required', 'url', 'max:2048'],
+        ];
+    }
+}

--- a/app/Http/Requests/Recipe/StoreRecipeRequest.php
+++ b/app/Http/Requests/Recipe/StoreRecipeRequest.php
@@ -2,13 +2,15 @@
 
 namespace App\Http\Requests\Recipe;
 
+use App\Models\Recipe;
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Support\Facades\Gate;
 
 class StoreRecipeRequest extends FormRequest
 {
     public function authorize(): bool
     {
-        return $this->user()->isParent();
+        return Gate::allows('create', Recipe::class);
     }
 
     public function rules(): array

--- a/app/Models/Family.php
+++ b/app/Models/Family.php
@@ -146,6 +146,41 @@ class Family extends Model
     }
 
     /**
+     * Get the recipe creation permission setting.
+     *
+     * Returns ['mode' => 'all'|'parents_only'|'users', 'users' => [...]]
+     */
+    public function getRecipeCreation(): array
+    {
+        return $this->settings['recipe_creation'] ?? [
+            'mode' => 'all',
+            'users' => [],
+        ];
+    }
+
+    /**
+     * Determine if a user is allowed to create/import recipes.
+     *
+     * Parents always return true. Children depend on the recipe_creation setting.
+     */
+    public function userCanCreateRecipes(User $user): bool
+    {
+        if ($user->isParent()) {
+            return true;
+        }
+
+        $setting = $this->getRecipeCreation();
+        $mode = $setting['mode'] ?? 'all';
+
+        return match ($mode) {
+            'all' => true,
+            'parents_only' => false,
+            'users' => in_array($user->id, $setting['users'] ?? []),
+            default => true,
+        };
+    }
+
+    /**
      * All module names the system supports.
      */
     public const MODULES = ['calendar', 'tasks', 'vault', 'chat', 'points', 'badges', 'food'];

--- a/app/Policies/RecipePolicy.php
+++ b/app/Policies/RecipePolicy.php
@@ -19,7 +19,7 @@ class RecipePolicy
 
     public function create(User $user): bool
     {
-        return $user->isParent();
+        return $user->family->userCanCreateRecipes($user);
     }
 
     public function update(User $user, Recipe $recipe): bool

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -2,6 +2,8 @@
 
 namespace App\Providers;
 
+use Illuminate\Cache\RateLimiting\Limit;
+use Illuminate\Support\Facades\RateLimiter;
 use Illuminate\Support\Facades\URL;
 use Illuminate\Support\ServiceProvider;
 use Laravel\Passport\Passport;
@@ -29,5 +31,10 @@ class AppServiceProvider extends ServiceProvider
         Passport::tokensExpireIn(now()->addDays(15));
         Passport::refreshTokensExpireIn(now()->addDays(30));
         Passport::authorizationView('mcp.authorize');
+
+        // Recipe import: 20 requests per hour per family
+        RateLimiter::for('recipe-import', function ($request) {
+            return Limit::perHour(20)->by($request->user()?->family_id ?? $request->ip());
+        });
     }
 }

--- a/app/Services/RecipeImportService.php
+++ b/app/Services/RecipeImportService.php
@@ -1,0 +1,561 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\Family;
+use App\Models\Recipe;
+use App\Models\User;
+use Illuminate\Http\Client\ConnectionException;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+
+class RecipeImportService
+{
+    private const ANTHROPIC_API_URL = 'https://api.anthropic.com/v1/messages';
+
+    private const ANTHROPIC_VERSION = '2023-06-01';
+
+    private const MAX_TOKENS = 2048;
+
+    private const URL_SYSTEM_PROMPT = <<<'PROMPT'
+You are a recipe extraction assistant. Extract a structured recipe from the following web page content.
+
+Return a JSON object with EXACTLY these fields:
+{
+  "title": "Recipe title (string, required)",
+  "description": "Short description (string, optional)",
+  "servings": "Number of servings (integer, optional)",
+  "prep_time": "Prep time in minutes (integer, optional)",
+  "cook_time": "Cook time in minutes (integer, optional)",
+  "ingredients": [
+    {
+      "name": "Ingredient name (string, required)",
+      "quantity": "Numeric amount as string (string, optional)",
+      "unit": "Unit of measure (string, optional)",
+      "preparation": "Prep instructions like 'diced' or 'minced' (string, optional)"
+    }
+  ],
+  "instructions": ["Step 1 text", "Step 2 text", "..."]
+}
+
+Rules:
+- Extract ONLY recipe information. Ignore ads, navigation, comments.
+- If a field is not found, set it to null (except title and instructions which are required).
+- Separate ingredient preparation from the ingredient name (e.g., "2 cups diced onion" → name: "onion", quantity: "2", unit: "cups", preparation: "diced").
+- Instructions should be clean step strings without numbering prefixes.
+- Return valid JSON only. No markdown, no explanation.
+PROMPT;
+
+    private const PHOTO_PROMPT = <<<'PROMPT'
+Extract a structured recipe from this image. Return JSON with:
+{
+  "title": "Recipe title",
+  "description": "Short description",
+  "servings": 4,
+  "prep_time": 15,
+  "cook_time": 30,
+  "ingredients": [
+    {"name": "ingredient", "quantity": "2", "unit": "cups", "preparation": "diced"}
+  ],
+  "instructions": ["Step 1", "Step 2"]
+}
+
+If any field cannot be determined from the image, set it to null.
+Return valid JSON only.
+PROMPT;
+
+    public function __construct(private RecipeService $recipeService) {}
+
+    /**
+     * Import a recipe from a URL.
+     *
+     * @return array<string, mixed>
+     */
+    public function importFromUrl(string $url, Family $family, User $user, bool $preview = false): array
+    {
+        $html = $this->fetchUrl($url);
+
+        $data = $this->parseJsonLd($html);
+
+        if ($data === null) {
+            $data = $this->extractViaLlm($html, $family);
+        }
+
+        $this->validateExtracted($data);
+
+        $data['source_url'] = $url;
+        $data['source_type'] = 'url';
+
+        // Check for duplicate source_url within this family
+        $existing = Recipe::where('family_id', $family->id)
+            ->where('source_url', $url)
+            ->first();
+
+        if ($existing) {
+            $data['duplicate_of'] = $existing->id;
+            $data['duplicate_title'] = $existing->title;
+        }
+
+        if ($preview) {
+            return $data;
+        }
+
+        return $this->persistImport($data, $family, $user);
+    }
+
+    /**
+     * Import a recipe from a photo.
+     *
+     * @return array<string, mixed>
+     */
+    public function importFromPhoto(UploadedFile $photo, Family $family, User $user, bool $preview = false): array
+    {
+        $data = $this->extractFromPhoto($photo, $family);
+
+        $this->validateExtracted($data);
+
+        $data['source_type'] = 'photo';
+
+        if ($preview) {
+            return $data;
+        }
+
+        // Store the image before persisting
+        $imagePath = $this->storeRecipeImage($photo);
+        $data['image_path'] = $imagePath;
+
+        return $this->persistImport($data, $family, $user);
+    }
+
+    /**
+     * Fetch raw HTML from a URL with SSRF protection.
+     *
+     * Resolves DNS once and validates the IP before making the request.
+     * The request is then pinned to the validated IP via cURL's RESOLVE option
+     * to prevent DNS rebinding (TOCTOU) attacks.
+     */
+    private function fetchUrl(string $url): string
+    {
+        $parsed = parse_url($url);
+        $host = $parsed['host'] ?? '';
+        $port = $parsed['port'] ?? ($parsed['scheme'] === 'http' ? 80 : 443);
+
+        // Resolve DNS once and validate the IP
+        $ip = gethostbyname($host);
+        if ($ip === $host) {
+            // gethostbyname returns the input if resolution fails
+            throw new HttpException(422, "Couldn't fetch that URL. Check the link and try again.");
+        }
+
+        if (! $this->isPublicIp($ip)) {
+            throw new HttpException(422, "Couldn't fetch that URL. Check the link and try again.");
+        }
+
+        try {
+            // Pin DNS resolution to the validated IP to prevent rebinding
+            $response = Http::withHeaders([
+                'User-Agent' => 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36',
+                'Accept' => 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
+            ])->withOptions([
+                'resolve' => ["{$host}:{$port}:{$ip}"],
+            ])->timeout(15)->get($url);
+        } catch (ConnectionException $e) {
+            throw new HttpException(422, "Couldn't fetch that URL. Check the link and try again.");
+        }
+
+        if ($response->failed()) {
+            throw new HttpException(422, "Couldn't fetch that URL. Check the link and try again.");
+        }
+
+        return $response->body();
+    }
+
+    /**
+     * Attempt to parse schema.org/Recipe JSON-LD from HTML.
+     *
+     * @return array<string, mixed>|null
+     */
+    private function parseJsonLd(string $html): ?array
+    {
+        preg_match_all('/<script[^>]+type=["\']application\/ld\+json["\'][^>]*>(.*?)<\/script>/si', $html, $matches);
+
+        foreach ($matches[1] as $raw) {
+            $decoded = json_decode(trim($raw), true);
+
+            if (! is_array($decoded)) {
+                continue;
+            }
+
+            // Handle @graph wrapper
+            $candidates = isset($decoded['@graph']) ? $decoded['@graph'] : [$decoded];
+
+            foreach ($candidates as $item) {
+                $type = $item['@type'] ?? '';
+                if (is_array($type)) {
+                    $type = implode(',', $type);
+                }
+
+                if (stripos($type, 'Recipe') !== false) {
+                    return $this->mapJsonLdToInternal($item);
+                }
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Map schema.org Recipe fields to our internal format.
+     *
+     * @param  array<string, mixed>  $item
+     * @return array<string, mixed>
+     */
+    private function mapJsonLdToInternal(array $item): array
+    {
+        $ingredients = [];
+        foreach ($item['recipeIngredient'] ?? [] as $line) {
+            $ingredients[] = $this->parseIngredientString((string) $line);
+        }
+
+        $instructions = [];
+        $rawInstructions = $item['recipeInstructions'] ?? [];
+
+        if (is_string($rawInstructions)) {
+            $instructions = array_values(array_filter(array_map('trim', explode("\n", $rawInstructions))));
+        } elseif (is_array($rawInstructions)) {
+            foreach ($rawInstructions as $step) {
+                if (is_string($step)) {
+                    $instructions[] = trim($step);
+                } elseif (is_array($step)) {
+                    // HowToStep or HowToSection
+                    if (isset($step['itemListElement'])) {
+                        foreach ($step['itemListElement'] as $subStep) {
+                            $text = $subStep['text'] ?? $subStep['name'] ?? '';
+                            if ($text !== '') {
+                                $instructions[] = trim((string) $text);
+                            }
+                        }
+                    } else {
+                        $text = $step['text'] ?? $step['name'] ?? '';
+                        if ($text !== '') {
+                            $instructions[] = trim((string) $text);
+                        }
+                    }
+                }
+            }
+        }
+
+        return [
+            'title' => $item['name'] ?? null,
+            'description' => isset($item['description']) ? strip_tags((string) $item['description']) : null,
+            'servings' => $this->parseServings($item['recipeYield'] ?? null),
+            'prep_time' => $this->parseIsoDuration($item['prepTime'] ?? null),
+            'cook_time' => $this->parseIsoDuration($item['cookTime'] ?? null),
+            'ingredients' => $ingredients,
+            'instructions' => array_values(array_filter($instructions)),
+        ];
+    }
+
+    /**
+     * Parse a plain ingredient string into structured fields.
+     *
+     * @return array<string, string|null>
+     */
+    private function parseIngredientString(string $line): array
+    {
+        return [
+            'name' => $line,
+            'quantity' => null,
+            'unit' => null,
+            'preparation' => null,
+        ];
+    }
+
+    /**
+     * Parse ISO 8601 duration (e.g. PT30M, PT1H30M) to integer minutes.
+     */
+    private function parseIsoDuration(mixed $value): ?int
+    {
+        if (empty($value)) {
+            return null;
+        }
+
+        $str = (string) $value;
+
+        if (preg_match('/PT(?:(\d+)H)?(?:(\d+)M)?/', $str, $m)) {
+            $hours = (int) ($m[1] ?? 0);
+            $minutes = (int) ($m[2] ?? 0);
+            $total = ($hours * 60) + $minutes;
+
+            return $total > 0 ? $total : null;
+        }
+
+        return null;
+    }
+
+    /**
+     * Parse recipeYield to an integer servings count.
+     */
+    private function parseServings(mixed $value): ?int
+    {
+        if (empty($value)) {
+            return null;
+        }
+
+        if (is_array($value)) {
+            $value = $value[0] ?? '';
+        }
+
+        preg_match('/\d+/', (string) $value, $m);
+
+        return isset($m[0]) ? (int) $m[0] : null;
+    }
+
+    /**
+     * Strip non-recipe HTML and call Claude to extract structured data.
+     *
+     * @return array<string, mixed>
+     */
+    private function extractViaLlm(string $html, Family $family): array
+    {
+        $cleaned = $this->stripNonContentHtml($html);
+        // Truncate to ~10k chars to avoid huge token counts
+        $cleaned = mb_substr($cleaned, 0, 10000);
+
+        $apiKey = $this->resolveApiKey($family);
+        $model = $this->resolveModel($family);
+
+        $response = Http::withHeaders([
+            'x-api-key' => $apiKey,
+            'anthropic-version' => self::ANTHROPIC_VERSION,
+            'Content-Type' => 'application/json',
+        ])->timeout(60)->post(self::ANTHROPIC_API_URL, [
+            'model' => $model,
+            'max_tokens' => self::MAX_TOKENS,
+            'system' => self::URL_SYSTEM_PROMPT,
+            'messages' => [
+                ['role' => 'user', 'content' => $cleaned],
+            ],
+        ]);
+
+        if ($response->failed()) {
+            Log::error('RecipeImportService: Anthropic API error (URL import)', [
+                'status' => $response->status(),
+            ]);
+            throw new HttpException(500, 'Something went wrong with recipe extraction. Please try again.');
+        }
+
+        return $this->parseLlmResponse($response->json());
+    }
+
+    /**
+     * Send photo to Claude Vision and extract recipe data.
+     *
+     * @return array<string, mixed>
+     */
+    private function extractFromPhoto(UploadedFile $photo, Family $family): array
+    {
+        $apiKey = $this->resolveApiKey($family);
+        $model = $this->resolveModel($family);
+
+        $base64 = base64_encode(file_get_contents($photo->getRealPath()));
+        $mediaType = $photo->getMimeType() ?? 'image/jpeg';
+
+        // HEIC isn't directly supported by Claude Vision — treat as jpeg
+        if (in_array($mediaType, ['image/heic', 'image/heif'])) {
+            $mediaType = 'image/jpeg';
+        }
+
+        $response = Http::withHeaders([
+            'x-api-key' => $apiKey,
+            'anthropic-version' => self::ANTHROPIC_VERSION,
+            'Content-Type' => 'application/json',
+        ])->timeout(60)->post(self::ANTHROPIC_API_URL, [
+            'model' => $model,
+            'max_tokens' => self::MAX_TOKENS,
+            'messages' => [
+                [
+                    'role' => 'user',
+                    'content' => [
+                        [
+                            'type' => 'image',
+                            'source' => [
+                                'type' => 'base64',
+                                'media_type' => $mediaType,
+                                'data' => $base64,
+                            ],
+                        ],
+                        [
+                            'type' => 'text',
+                            'text' => self::PHOTO_PROMPT,
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+
+        if ($response->failed()) {
+            Log::error('RecipeImportService: Anthropic API error (photo import)', [
+                'status' => $response->status(),
+            ]);
+            throw new HttpException(500, 'Something went wrong with recipe extraction. Please try again.');
+        }
+
+        return $this->parseLlmResponse($response->json());
+    }
+
+    /**
+     * Parse the Anthropic API response and decode the JSON recipe.
+     *
+     * @param  array<string, mixed>  $responseData
+     * @return array<string, mixed>
+     */
+    private function parseLlmResponse(array $responseData): array
+    {
+        $text = $responseData['content'][0]['text'] ?? '';
+
+        // Strip markdown code fences if present
+        $text = preg_replace('/^```(?:json)?\s*/m', '', $text);
+        $text = preg_replace('/\s*```$/m', '', $text);
+
+        $parsed = json_decode(trim($text), true);
+
+        if (! is_array($parsed)) {
+            throw new HttpException(422, "Couldn't extract a recipe — try manual entry?");
+        }
+
+        return $parsed;
+    }
+
+    /**
+     * Validate that minimum required fields are present.
+     *
+     * @param  array<string, mixed>  $data
+     */
+    private function validateExtracted(array $data): void
+    {
+        if (empty($data['title'])) {
+            throw new HttpException(422, "Couldn't extract a recipe — try manual entry?");
+        }
+
+        $instructions = $data['instructions'] ?? [];
+        if (empty($instructions) || ! is_array($instructions)) {
+            throw new HttpException(422, "Couldn't extract a recipe — try manual entry?");
+        }
+    }
+
+    /**
+     * Persist the imported recipe via RecipeService.
+     *
+     * @param  array<string, mixed>  $data
+     * @return array<string, mixed>
+     */
+    private function persistImport(array $data, Family $family, User $user): array
+    {
+        $recipeData = [
+            'title' => $data['title'],
+            'description' => $data['description'] ?? null,
+            'servings' => isset($data['servings']) ? (int) $data['servings'] : null,
+            'prep_time_minutes' => isset($data['prep_time']) ? (int) $data['prep_time'] : null,
+            'cook_time_minutes' => isset($data['cook_time']) ? (int) $data['cook_time'] : null,
+            'source_url' => $data['source_url'] ?? null,
+            'source_type' => $data['source_type'] ?? 'url',
+            'image_path' => $data['image_path'] ?? null,
+            'instructions' => $data['instructions'] ?? [],
+            'ingredients' => $data['ingredients'] ?? [],
+        ];
+
+        $recipe = $this->recipeService->createRecipe($family, $user, $recipeData);
+
+        return ['recipe' => $recipe];
+    }
+
+    /**
+     * Store uploaded recipe photo to the recipes disk.
+     */
+    private function storeRecipeImage(UploadedFile $photo): string
+    {
+        $filename = Str::uuid()->toString().'.'.$photo->guessExtension();
+
+        return Storage::disk('public')->putFileAs('recipes', $photo, $filename);
+    }
+
+    /**
+     * Strip navigation, footer, header, aside, and ad-related elements from HTML.
+     */
+    private function stripNonContentHtml(string $html): string
+    {
+        // Remove script and style blocks
+        $html = preg_replace('/<script\b[^>]*>.*?<\/script>/si', '', $html) ?? $html;
+        $html = preg_replace('/<style\b[^>]*>.*?<\/style>/si', '', $html) ?? $html;
+
+        // Remove structural noise elements
+        foreach (['nav', 'footer', 'aside', 'header'] as $tag) {
+            $html = preg_replace("/<{$tag}\b[^>]*>.*?<\/{$tag}>/si", '', $html) ?? $html;
+        }
+
+        // Strip remaining tags and decode entities
+        $text = strip_tags($html);
+        $text = html_entity_decode($text, ENT_QUOTES | ENT_HTML5, 'UTF-8');
+
+        // Collapse whitespace
+        $text = preg_replace('/\s{3,}/', "\n\n", $text) ?? $text;
+
+        return trim($text);
+    }
+
+    /**
+     * Resolve the Anthropic API key (platform key → family BYOK).
+     */
+    private function resolveApiKey(Family $family): string
+    {
+        // Platform key first
+        $platformKey = config('kinhold.chatbot.api_key');
+        if (! empty($platformKey)) {
+            return $platformKey;
+        }
+
+        // BYOK fallback
+        $settings = $family->settings ?? [];
+        $aiMode = $settings['ai_mode'] ?? 'kinhold';
+
+        if ($aiMode === 'byok' && ! empty($settings['ai_api_key'])) {
+            $providerSlug = $settings['ai_provider'] ?? 'anthropic';
+
+            if ($providerSlug === 'anthropic') {
+                try {
+                    return decrypt($settings['ai_api_key']);
+                } catch (\Throwable $e) {
+                    Log::warning('RecipeImportService: Failed to decrypt family AI API key');
+                }
+            }
+        }
+
+        throw new HttpException(
+            500,
+            'No AI API key configured. Ask a parent to add one in Settings > API Configuration.'
+        );
+    }
+
+    /**
+     * Resolve the model to use for extraction.
+     */
+    private function resolveModel(Family $family): string
+    {
+        $settings = $family->settings ?? [];
+
+        return $settings['ai_model'] ?? config('kinhold.chatbot.model', 'claude-sonnet-4-5-20250929');
+    }
+
+    /**
+     * Check if an IP address is public (not private, not reserved, not loopback).
+     */
+    private function isPublicIp(string $ip): bool
+    {
+        return filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE) !== false;
+    }
+}

--- a/app/Services/RecipeService.php
+++ b/app/Services/RecipeService.php
@@ -150,21 +150,39 @@ class RecipeService
     private function insertIngredients(Recipe $recipe, array $ingredients): void
     {
         $rows = [];
-        foreach ($ingredients as $index => $ingredient) {
+        $seen = [];
+        $sortOrder = 0;
+
+        foreach ($ingredients as $ingredient) {
+            $name = trim($ingredient['name'] ?? '');
+            if ($name === '') {
+                continue;
+            }
+
+            // Deduplicate by lowercase name + quantity + unit
+            $dedupeKey = mb_strtolower($name).'|'.($ingredient['quantity'] ?? '').'|'.($ingredient['unit'] ?? '');
+            if (isset($seen[$dedupeKey])) {
+                continue;
+            }
+            $seen[$dedupeKey] = true;
+
             $rows[] = [
                 'id' => Str::uuid()->toString(),
                 'recipe_id' => $recipe->id,
-                'name' => $ingredient['name'],
+                'name' => $name,
                 'quantity' => $ingredient['quantity'] ?? null,
                 'unit' => $ingredient['unit'] ?? null,
                 'preparation' => $ingredient['preparation'] ?? null,
                 'group_name' => $ingredient['group_name'] ?? null,
                 'is_optional' => $ingredient['is_optional'] ?? false,
-                'sort_order' => $ingredient['sort_order'] ?? $index,
+                'sort_order' => $ingredient['sort_order'] ?? $sortOrder++,
                 'created_at' => now(),
                 'updated_at' => now(),
             ];
         }
-        $recipe->ingredients()->insert($rows);
+
+        if (! empty($rows)) {
+            $recipe->ingredients()->insert($rows);
+        }
     }
 }

--- a/docs/FOOD-IMPLEMENTATION-PLAN.md
+++ b/docs/FOOD-IMPLEMENTATION-PLAN.md
@@ -22,6 +22,8 @@ Errands List (standalone, always available)
 
 The central insight: the shopping list is a **live derivative** of the meal plan — not a one-time export. When a meal plan changes, only recipe-derived items update. Manual and staple items are untouched.
 
+**Design note (from Step 2 review):** `recipe_ingredients` is per-recipe and stays that way. Shopping lists must support manual items (e.g., "bread, peanut butter, jelly" — no recipe needed) alongside recipe-derived items. Cross-recipe ingredient aggregation ("flour" in 3 recipes → "6 cups flour" on the list) happens at shopping list generation time, not in the ingredient table. The `shopping_items.source` enum (manual/recipe/staple) covers this.
+
 ---
 
 ## Step 1: Recipe Backend + Module Gating

--- a/routes/api.php
+++ b/routes/api.php
@@ -188,6 +188,14 @@ Route::prefix('v1')->group(function () {
         Route::prefix('/recipes')->middleware('module:food')->group(function () {
             Route::get('/', [RecipeController::class, 'index']);
             Route::post('/', [RecipeController::class, 'store']);
+
+            // Import routes (rate-limited, parent-only via form request)
+            Route::middleware(['throttle:recipe-import'])->group(function () {
+                Route::post('/import/url', [RecipeController::class, 'importFromUrl']);
+                Route::post('/import/photo', [RecipeController::class, 'importFromPhoto']);
+                Route::post('/import/social', [RecipeController::class, 'importFromSocialMedia']);
+            });
+
             Route::get('/{recipe}', [RecipeController::class, 'show']);
             Route::put('/{recipe}', [RecipeController::class, 'update']);
             Route::delete('/{recipe}', [RecipeController::class, 'destroy']);

--- a/tests/Feature/RecipeImportTest.php
+++ b/tests/Feature/RecipeImportTest.php
@@ -1,0 +1,429 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Enums\FamilyRole;
+use App\Models\Family;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Storage;
+use Laravel\Sanctum\Sanctum;
+use Tests\TestCase;
+
+class RecipeImportTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private Family $family;
+
+    private User $parent;
+
+    private User $child;
+
+    /** HTML page with a valid schema.org/Recipe JSON-LD block */
+    private string $jsonLdHtml;
+
+    /** HTML page with no JSON-LD (forces LLM fallback) */
+    private string $plainHtml;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Provide a fake API key so resolveApiKey() doesn't throw in tests
+        config(['kinhold.chatbot.api_key' => 'test-api-key']);
+
+        $this->family = Family::create([
+            'name' => 'Test Family',
+            'slug' => 'test-family',
+            'invite_code' => 'TEST01',
+        ]);
+
+        $this->parent = User::create([
+            'name' => 'Parent',
+            'email' => 'parent@test.com',
+            'password' => bcrypt('password'),
+            'family_id' => $this->family->id,
+            'family_role' => FamilyRole::Parent,
+        ]);
+
+        $this->child = User::create([
+            'name' => 'Child',
+            'email' => 'child@test.com',
+            'password' => bcrypt('password'),
+            'family_id' => $this->family->id,
+            'family_role' => FamilyRole::Child,
+        ]);
+
+        $this->jsonLdHtml = <<<'HTML'
+<!DOCTYPE html>
+<html>
+<head>
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Recipe",
+  "name": "Chicken Parmesan",
+  "description": "Classic Italian comfort food.",
+  "recipeYield": "4 servings",
+  "prepTime": "PT20M",
+  "cookTime": "PT30M",
+  "recipeIngredient": ["2 lbs chicken breast", "1 cup breadcrumbs"],
+  "recipeInstructions": [
+    {"@type": "HowToStep", "text": "Preheat oven to 400F."},
+    {"@type": "HowToStep", "text": "Season chicken."}
+  ]
+}
+</script>
+</head>
+<body><h1>Chicken Parmesan</h1></body>
+</html>
+HTML;
+
+        $this->plainHtml = <<<'HTML'
+<!DOCTYPE html>
+<html>
+<head><title>Simple Recipe Page</title></head>
+<body>
+<h1>Banana Bread</h1>
+<p>A delicious quick bread.</p>
+<ul>
+  <li>3 bananas</li>
+  <li>2 cups flour</li>
+</ul>
+<ol>
+  <li>Mash bananas.</li>
+  <li>Mix in flour.</li>
+  <li>Bake at 350F for 60 minutes.</li>
+</ol>
+</body>
+</html>
+HTML;
+    }
+
+    // ── URL Import — JSON-LD path ──
+
+    public function test_url_import_with_json_ld_extracts_recipe_without_calling_llm(): void
+    {
+        Sanctum::actingAs($this->parent);
+
+        Http::fake([
+            'example.com/*' => Http::response($this->jsonLdHtml, 200),
+        ]);
+
+        $response = $this->postJson('/api/v1/recipes/import/url?preview=1', [
+            'url' => 'https://example.com/recipe/chicken-parmesan',
+        ]);
+
+        $response->assertStatus(200);
+        $response->assertJsonPath('title', 'Chicken Parmesan');
+        $response->assertJsonPath('servings', 4);
+        $response->assertJsonPath('prep_time', 20);
+        $response->assertJsonPath('cook_time', 30);
+        $response->assertJsonStructure(['ingredients', 'instructions']);
+
+        // Anthropic API should NOT have been called
+        Http::assertNotSent(fn ($r) => str_contains($r->url(), 'api.anthropic.com'));
+    }
+
+    // ── URL Import — LLM fallback path ──
+
+    public function test_url_import_falls_back_to_llm_when_no_json_ld(): void
+    {
+        Sanctum::actingAs($this->parent);
+
+        $llmResponseBody = json_encode([
+            'content' => [[
+                'type' => 'text',
+                'text' => json_encode([
+                    'title' => 'Banana Bread',
+                    'description' => 'A delicious quick bread.',
+                    'servings' => 8,
+                    'prep_time' => 10,
+                    'cook_time' => 60,
+                    'ingredients' => [
+                        ['name' => 'bananas', 'quantity' => '3', 'unit' => null, 'preparation' => 'mashed'],
+                        ['name' => 'flour', 'quantity' => '2', 'unit' => 'cups', 'preparation' => null],
+                    ],
+                    'instructions' => ['Mash bananas.', 'Mix in flour.', 'Bake at 350F for 60 minutes.'],
+                ]),
+            ]],
+            'stop_reason' => 'end_turn',
+        ]);
+
+        Http::fake([
+            'example.com/*' => Http::response($this->plainHtml, 200),
+            'api.anthropic.com/*' => Http::response($llmResponseBody, 200),
+        ]);
+
+        $response = $this->postJson('/api/v1/recipes/import/url?preview=1', [
+            'url' => 'https://example.com/banana-bread',
+        ]);
+
+        $response->assertStatus(200);
+        $response->assertJsonPath('title', 'Banana Bread');
+        $response->assertJsonPath('servings', 8);
+
+        Http::assertSent(fn ($r) => str_contains($r->url(), 'api.anthropic.com'));
+    }
+
+    // ── Photo Import ──
+
+    public function test_photo_import_extracts_recipe_via_claude_vision(): void
+    {
+        Sanctum::actingAs($this->parent);
+        Storage::fake('public');
+
+        $llmResponseBody = json_encode([
+            'content' => [[
+                'type' => 'text',
+                'text' => json_encode([
+                    'title' => 'Handwritten Pancakes',
+                    'description' => null,
+                    'servings' => 2,
+                    'prep_time' => 5,
+                    'cook_time' => 10,
+                    'ingredients' => [
+                        ['name' => 'flour', 'quantity' => '1', 'unit' => 'cup', 'preparation' => null],
+                        ['name' => 'egg', 'quantity' => '1', 'unit' => null, 'preparation' => null],
+                    ],
+                    'instructions' => ['Mix ingredients.', 'Cook on griddle.'],
+                ]),
+            ]],
+            'stop_reason' => 'end_turn',
+        ]);
+
+        Http::fake([
+            'api.anthropic.com/*' => Http::response($llmResponseBody, 200),
+        ]);
+
+        $photo = UploadedFile::fake()->image('recipe.jpg', 400, 300);
+
+        $response = $this->postJson('/api/v1/recipes/import/photo?preview=1', [
+            'photo' => $photo,
+        ]);
+
+        $response->assertStatus(200);
+        $response->assertJsonPath('title', 'Handwritten Pancakes');
+
+        Http::assertSent(function ($request) {
+            if (! str_contains($request->url(), 'api.anthropic.com')) {
+                return false;
+            }
+            $data = json_decode($request->body(), true);
+            $content = $data['messages'][0]['content'] ?? [];
+
+            return collect($content)->contains(fn ($c) => ($c['type'] ?? '') === 'image');
+        });
+    }
+
+    // ── Preview mode — no DB persistence ──
+
+    public function test_preview_mode_returns_data_without_persisting(): void
+    {
+        Sanctum::actingAs($this->parent);
+
+        Http::fake([
+            'example.com/*' => Http::response($this->jsonLdHtml, 200),
+        ]);
+
+        $response = $this->postJson('/api/v1/recipes/import/url?preview=1', [
+            'url' => 'https://example.com/recipe/chicken-parmesan',
+        ]);
+
+        $response->assertStatus(200);
+        $response->assertJsonPath('title', 'Chicken Parmesan');
+        $this->assertDatabaseCount('recipes', 0);
+    }
+
+    // ── Save mode — creates DB record ──
+
+    public function test_save_mode_creates_recipe_and_ingredients(): void
+    {
+        Sanctum::actingAs($this->parent);
+
+        Http::fake([
+            'example.com/*' => Http::response($this->jsonLdHtml, 200),
+        ]);
+
+        $response = $this->postJson('/api/v1/recipes/import/url', [
+            'url' => 'https://example.com/recipe/chicken-parmesan',
+        ]);
+
+        $response->assertStatus(201);
+        $response->assertJsonPath('recipe.title', 'Chicken Parmesan');
+        $this->assertDatabaseHas('recipes', ['title' => 'Chicken Parmesan']);
+        $this->assertDatabaseCount('recipe_ingredients', 2);
+    }
+
+    // ── Rate limiting ──
+
+    public function test_rate_limiting_blocks_after_20_requests(): void
+    {
+        Sanctum::actingAs($this->parent);
+
+        Http::fake([
+            'example.com/*' => Http::response($this->jsonLdHtml, 200),
+        ]);
+
+        // Make 20 successful requests
+        for ($i = 0; $i < 20; $i++) {
+            $this->postJson('/api/v1/recipes/import/url?preview=1', [
+                'url' => 'https://example.com/recipe/chicken-parmesan',
+            ])->assertStatus(200);
+        }
+
+        // 21st should be rate-limited
+        $response = $this->postJson('/api/v1/recipes/import/url?preview=1', [
+            'url' => 'https://example.com/recipe/chicken-parmesan',
+        ]);
+
+        $response->assertStatus(429);
+    }
+
+    // ── Child access — configurable via family settings ──
+
+    public function test_child_can_import_when_recipe_creation_allows_all(): void
+    {
+        Sanctum::actingAs($this->child);
+
+        Http::fake([
+            'example.com/*' => Http::response($this->jsonLdHtml, 200),
+        ]);
+
+        // Default is 'all' — children can create
+        $response = $this->postJson('/api/v1/recipes/import/url?preview=1', [
+            'url' => 'https://example.com/recipe/chicken-parmesan',
+        ]);
+
+        $response->assertStatus(200);
+    }
+
+    public function test_child_cannot_import_when_recipe_creation_is_parents_only(): void
+    {
+        Sanctum::actingAs($this->child);
+
+        $settings = $this->family->settings ?? [];
+        $settings['recipe_creation'] = ['mode' => 'parents_only'];
+        $this->family->settings = $settings;
+        $this->family->save();
+
+        $response = $this->postJson('/api/v1/recipes/import/url', [
+            'url' => 'https://example.com/recipe/chicken-parmesan',
+        ]);
+
+        $response->assertStatus(403);
+    }
+
+    // ── Validation ──
+
+    public function test_malformed_url_returns_422(): void
+    {
+        Sanctum::actingAs($this->parent);
+
+        $response = $this->postJson('/api/v1/recipes/import/url', [
+            'url' => 'not-a-url',
+        ]);
+
+        $response->assertStatus(422);
+        $response->assertJsonValidationErrors(['url']);
+    }
+
+    // ── Claude API failure — graceful error ──
+
+    public function test_claude_api_failure_returns_graceful_error(): void
+    {
+        Sanctum::actingAs($this->parent);
+
+        Http::fake([
+            'example.com/*' => Http::response($this->plainHtml, 200),
+            'api.anthropic.com/*' => Http::response(['error' => 'overloaded'], 529),
+        ]);
+
+        $response = $this->postJson('/api/v1/recipes/import/url', [
+            'url' => 'https://example.com/banana-bread',
+        ]);
+
+        $response->assertStatus(500);
+
+        // Must NOT leak raw API error details
+        $responseBody = $response->getContent();
+        $this->assertStringNotContainsString('overloaded', $responseBody);
+        $this->assertStringNotContainsString('anthropic.com', $responseBody);
+    }
+
+    // ── Duplicate URL detection ──
+
+    public function test_duplicate_url_import_returns_duplicate_warning(): void
+    {
+        Sanctum::actingAs($this->parent);
+
+        Http::fake([
+            'example.com/*' => Http::response($this->jsonLdHtml, 200),
+        ]);
+
+        // First import — save it
+        $this->postJson('/api/v1/recipes/import/url', [
+            'url' => 'https://example.com/recipe/chicken-parmesan',
+        ])->assertStatus(201);
+
+        // Second import of same URL — preview should flag duplicate
+        $response = $this->postJson('/api/v1/recipes/import/url?preview=1', [
+            'url' => 'https://example.com/recipe/chicken-parmesan',
+        ]);
+
+        $response->assertStatus(200);
+        $response->assertJsonStructure(['duplicate_of', 'duplicate_title']);
+        $response->assertJsonPath('duplicate_title', 'Chicken Parmesan');
+    }
+
+    // ── Ingredient deduplication ──
+
+    public function test_duplicate_ingredients_are_deduplicated_on_save(): void
+    {
+        Sanctum::actingAs($this->parent);
+
+        // JSON-LD with duplicate ingredients (same name+quantity+unit)
+        $htmlWithDupes = <<<'HTML'
+<!DOCTYPE html>
+<html><head>
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Recipe",
+  "name": "Duplicate Ingredient Test",
+  "recipeIngredient": ["2 cups flour", "1 egg", "2 cups flour", "1 cup sugar", "1 egg"],
+  "recipeInstructions": [{"@type": "HowToStep", "text": "Mix everything."}]
+}
+</script>
+</head><body></body></html>
+HTML;
+
+        Http::fake([
+            'example.com/*' => Http::response($htmlWithDupes, 200),
+        ]);
+
+        $response = $this->postJson('/api/v1/recipes/import/url', [
+            'url' => 'https://example.com/recipe/dupes',
+        ]);
+
+        $response->assertStatus(201);
+
+        // Should only have 3 unique ingredients, not 5
+        $this->assertDatabaseCount('recipe_ingredients', 3);
+    }
+
+    // ── Social media stub ──
+
+    public function test_social_media_import_returns_501(): void
+    {
+        Sanctum::actingAs($this->parent);
+
+        $response = $this->postJson('/api/v1/recipes/import/social', []);
+
+        $response->assertStatus(501);
+        $response->assertJsonPath('message', 'Social media import coming soon');
+    }
+}

--- a/tests/Feature/RecipeTest.php
+++ b/tests/Feature/RecipeTest.php
@@ -206,9 +206,14 @@ class RecipeTest extends TestCase
 
     // ── Permission Tests ──
 
-    public function test_child_cannot_create_recipe(): void
+    public function test_child_cannot_create_recipe_when_parents_only(): void
     {
         Sanctum::actingAs($this->child);
+
+        $settings = $this->family->settings ?? [];
+        $settings['recipe_creation'] = ['mode' => 'parents_only'];
+        $this->family->settings = $settings;
+        $this->family->save();
 
         $response = $this->postJson('/api/v1/recipes', [
             'title' => 'Child Recipe',


### PR DESCRIPTION
## Summary
- **RecipeImportService**: Three-path import strategy — schema.org JSON-LD parsing (no LLM cost), Claude text extraction fallback, and Claude Vision API for photo imports
- **Configurable recipe creation access**: Parents can now set `recipe_creation` mode in family settings (`all` / `parents_only` / `users`) — no longer hardcoded to parents-only, since some kids enjoy finding recipes
- **SSRF protection**: DNS resolved once, validated as public IP, then pinned via cURL RESOLVE option to prevent DNS rebinding race conditions
- **Duplicate detection**: Preview mode returns `duplicate_of` + `duplicate_title` when a URL has already been imported by the family
- **Ingredient deduplication**: `RecipeService::insertIngredients()` deduplicates by `name|quantity|unit` key before DB insert — prevents duplicate rows from messy recipe sites

## Linked Issues
Closes #149

## Test Plan
- [x] 13 tests in `RecipeImportTest` covering all paths: JSON-LD, LLM fallback, Vision, preview/save modes, rate limiting, child access (allowed + blocked), URL validation, Claude API failure (no leaked details), duplicate URL, ingredient dedup, social stub
- [x] Tested locally against 4 real recipe URLs (allrecipes.com, foodnetwork.com, seriouseats.com, food52.com) — all 4 had JSON-LD, no LLM calls made
- [x] Tested photo import with physical recipe card (IMG_5358.jpeg) — correctly extracted "White Chicken Enchiladas"
- [x] 95/95 tests passing, Pint clean, Larastan 0 errors

## Checklist
- [x] Tested locally
- [x] Mobile-first (375px) — import is backend-only, UI in Step 3
- [x] No credentials committed
- [ ] API changes documented — MCP tools in Step 6