### PR TITLE
Add /demo landing page for marketing deep-linking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,11 @@
 
 > Updated at the end of every working session. Newest entries first.
 
-## 2026-04-27 — Demo landing page at `/demo`
+## 2026-04-27 — Demo landing page at `/demo`, fix dashboard-flash on boot
 
 New `DemoView.vue` at `/demo` — a full-page version of the existing demo modal that the marketing site can deep-link to instead of `/login`. Reuses the same five Johnson-family member picker and `authStore.demoLogin()` action as the modal, wrapped in a Kin design-system layout with intro copy ("Meet the Johnson family"), a "What's inside" highlights row (calendar/tasks, vault/recipes, points/badges), and footer links to sign in or create an account. Route is `requiresGuest`, so authenticated visitors bounce to Dashboard. `'Demo'` added to App.vue's chromeless-page list.
+
+Also fixed a brief authenticated-chrome flash on SPA boot when visiting `/login` or `/demo`. The router's async `beforeEach` awaits `initAuth`, so `route.name` is undefined for the first frame — App.vue's `isAuthPage` previously evaluated to `false` and rendered Sidebar/TopBar/BottomNav before the route resolved. Now `isAuthPage` returns `true` (chromeless) until `authStore.initialAuthChecked` flips, eliminating the flash without changing post-boot behavior.
 
 ## 2026-04-27 — Removed landing page from SPA (#134)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 > Updated at the end of every working session. Newest entries first.
 
+## 2026-04-27 — Demo landing page at `/demo`
+
+New `DemoView.vue` at `/demo` — a full-page version of the existing demo modal that the marketing site can deep-link to instead of `/login`. Reuses the same five Johnson-family member picker and `authStore.demoLogin()` action as the modal, wrapped in a Kin design-system layout with intro copy ("Meet the Johnson family"), a "What's inside" highlights row (calendar/tasks, vault/recipes, points/badges), and footer links to sign in or create an account. Route is `requiresGuest`, so authenticated visitors bounce to Dashboard. `'Demo'` added to App.vue's chromeless-page list.
+
 ## 2026-04-27 — Removed landing page from SPA (#134)
 
 `LandingView.vue` and its five screenshot assets deleted. `/` now redirects to `/login` via a Vue Router redirect; the `meta.isPublic` guard branch (dead code) removed. The existing `requiresGuest` guard on Login already handles authenticated visitors (→ Dashboard) and first-boot (→ Register). Inbound links in PrivacyPolicyView, TermsView, and NotFoundView updated from `to="/"` to `to="/login"`. The server-side email-verification-error redirect in `routes/web.php` updated from `/?verify_error=invalid` to `/login?verify_error=invalid`; minimal `onMounted` handling added to LoginView to surface the error message. README landing-page bullet removed; LAUNCH-PLAN.md marked archival.

--- a/resources/js/App.vue
+++ b/resources/js/App.vue
@@ -126,11 +126,13 @@ provide('easterEggs', easterEggsRef)
 // `isAuthPage` doubles as "chromeless" — no sidebar/topbar/bottomnav wraps these routes.
 // The design system is chromeless by design: it owns its full viewport with its own sidebar.
 //
-// Also chromeless during the initial auth check: until the router's async beforeEach
-// finishes initAuth, `route.name` is undefined and the chrome would briefly render
-// before the real route resolves. Defaulting to chromeless avoids that flash.
+// Also chromeless while the router is still resolving: between SPA boot and the moment
+// the route lands, `route.name` is undefined and `initialAuthChecked` may also be false.
+// If chrome renders during that window it briefly flashes before /login or /demo
+// finishes resolving. Both signals must be ready before the chrome is allowed to render.
 const isAuthPage = computed(() => {
   if (!authStore.initialAuthChecked) return true
+  if (!route.name) return true
   return ['Login', 'Register', 'Demo', 'Privacy', 'Terms', 'Onboarding', 'DesignSystem'].includes(route.name)
 })
 

--- a/resources/js/App.vue
+++ b/resources/js/App.vue
@@ -126,7 +126,7 @@ provide('easterEggs', easterEggsRef)
 // `isAuthPage` doubles as "chromeless" — no sidebar/topbar/bottomnav wraps these routes.
 // The design system is chromeless by design: it owns its full viewport with its own sidebar.
 const isAuthPage = computed(() => {
-  return ['Login', 'Register', 'Privacy', 'Terms', 'Onboarding', 'DesignSystem'].includes(route.name)
+  return ['Login', 'Register', 'Demo', 'Privacy', 'Terms', 'Onboarding', 'DesignSystem'].includes(route.name)
 })
 
 // Email verification banner

--- a/resources/js/App.vue
+++ b/resources/js/App.vue
@@ -125,7 +125,12 @@ provide('easterEggs', easterEggsRef)
 
 // `isAuthPage` doubles as "chromeless" — no sidebar/topbar/bottomnav wraps these routes.
 // The design system is chromeless by design: it owns its full viewport with its own sidebar.
+//
+// Also chromeless during the initial auth check: until the router's async beforeEach
+// finishes initAuth, `route.name` is undefined and the chrome would briefly render
+// before the real route resolves. Defaulting to chromeless avoids that flash.
 const isAuthPage = computed(() => {
+  if (!authStore.initialAuthChecked) return true
   return ['Login', 'Register', 'Demo', 'Privacy', 'Terms', 'Onboarding', 'DesignSystem'].includes(route.name)
 })
 

--- a/resources/js/router/index.js
+++ b/resources/js/router/index.js
@@ -34,6 +34,7 @@ const RecipeDetailView = () => import('@/views/food/RecipeDetailView.vue')
 const ShoppingView = () => import('@/views/food/ShoppingTab.vue')
 
 const NotFoundView = () => import('@/views/NotFoundView.vue')
+const DemoView = () => import('@/views/DemoView.vue')
 
 // Design System — always open, accessible as a community reference for
 // contributors. Lives outside auth so the component library can be linked to
@@ -46,6 +47,7 @@ const routes = [
   { path: '/terms', name: 'Terms', component: TermsView, meta: { isOpen: true } },
   { path: '/login', name: 'Login', component: LoginView, meta: { requiresGuest: true } },
   { path: '/register', name: 'Register', component: RegisterView, meta: { requiresGuest: true } },
+  { path: '/demo', name: 'Demo', component: DemoView, meta: { requiresGuest: true } },
   { path: '/onboarding', name: 'Onboarding', component: OnboardingView, meta: { requiresAuth: true, isOnboarding: true } },
   { path: '/dashboard', name: 'Dashboard', component: DashboardView, meta: { requiresAuth: true } },
   { path: '/calendar', name: 'Calendar', component: CalendarView, meta: { requiresAuth: true, module: 'calendar' } },

--- a/resources/js/views/DemoView.vue
+++ b/resources/js/views/DemoView.vue
@@ -1,0 +1,166 @@
+<template>
+  <div class="kin-page min-h-screen flex items-center justify-center p-4 py-10">
+    <div class="w-full max-w-3xl">
+      <!-- Logo -->
+      <div class="text-center mb-8">
+        <router-link to="/login" class="inline-flex flex-col items-center gap-3">
+          <img src="/images/logo-100.png" alt="Kinhold" class="w-16 h-16 rounded-2xl" />
+          <h1 class="text-4xl font-heading font-bold text-kin-gold">Kinhold</h1>
+        </router-link>
+        <p class="kin-muted mt-2">Try the live demo</p>
+      </div>
+
+      <KinFlatCard padding="lg">
+        <!-- Intro -->
+        <div class="text-center mb-6">
+          <h2 class="text-2xl font-heading font-bold text-ink-primary mb-2">
+            Meet the Johnson family
+          </h2>
+          <p class="kin-muted max-w-xl mx-auto">
+            The demo is a fully working Kinhold instance pre-loaded with a family of five —
+            calendar events, tasks, vault entries, points, badges, recipes, the works.
+            Pick any family member below to log in as them and explore the app from their
+            perspective. Switch between accounts anytime by signing out and coming back here.
+          </p>
+        </div>
+
+        <!-- Member picker -->
+        <div v-if="demoAvailable" class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-3 mb-6">
+          <button
+            v-for="member in members"
+            :key="member.key"
+            :disabled="loadingMember !== null"
+            class="relative flex flex-col items-center gap-2 p-4 rounded-xl border border-border-subtle hover:border-accent-lavender-bold hover:bg-surface-sunken transition-all text-left disabled:opacity-50 disabled:cursor-not-allowed"
+            @click="handleSelect(member.key)"
+          >
+            <!-- Loading overlay -->
+            <div
+              v-if="loadingMember === member.key"
+              class="absolute inset-0 flex items-center justify-center bg-surface-raised/60 rounded-xl"
+            >
+              <LoadingSpinner size="sm" />
+            </div>
+
+            <!-- Avatar circle -->
+            <div
+              class="w-14 h-14 rounded-full flex items-center justify-center text-white font-bold text-xl"
+              :style="{ backgroundColor: member.color }"
+            >
+              {{ member.name[0] }}
+            </div>
+
+            <!-- Name & role -->
+            <div class="text-center">
+              <div class="font-semibold text-sm text-ink-primary">{{ member.name }}</div>
+              <span
+                class="inline-block mt-1 text-xs px-2 py-0.5 rounded-full"
+                :class="
+                  member.role === 'Parent'
+                    ? 'bg-accent-lavender-soft/40 text-accent-lavender-bold'
+                    : 'bg-accent-sun-soft/40 text-accent-sun-bold'
+                "
+              >
+                {{ member.role }}
+              </span>
+              <div class="text-xs kin-muted mt-1">{{ member.description }}</div>
+            </div>
+          </button>
+        </div>
+
+        <!-- Demo unavailable -->
+        <div
+          v-else
+          class="p-4 bg-status-failed/10 border border-status-failed/30 rounded-[10px] text-center"
+        >
+          <p class="text-sm text-status-failed">
+            The demo isn't available on this instance right now. Please try again later.
+          </p>
+        </div>
+
+        <!-- Error -->
+        <p v-if="errorMsg" class="text-sm text-status-failed text-center mb-4">
+          {{ errorMsg }}
+        </p>
+
+        <!-- What you'll see -->
+        <div class="border-t border-border-subtle pt-6 mt-2">
+          <h3 class="text-sm font-semibold text-ink-primary mb-3 text-center">
+            What's inside the demo
+          </h3>
+          <div class="grid grid-cols-1 sm:grid-cols-3 gap-3">
+            <div
+              v-for="item in highlights"
+              :key="item.title"
+              class="p-3 rounded-[10px] bg-surface-sunken"
+            >
+              <div class="text-sm font-semibold text-ink-primary">{{ item.title }}</div>
+              <div class="text-xs kin-muted mt-1">{{ item.description }}</div>
+            </div>
+          </div>
+        </div>
+
+        <!-- Footer links -->
+        <div class="border-t border-border-subtle mt-6 pt-6 text-center">
+          <p class="kin-muted text-sm">
+            Already have an account?
+            <RouterLink to="/login" class="kin-link font-medium">Sign in</RouterLink>
+            &nbsp;·&nbsp;
+            <RouterLink to="/register" class="kin-link font-medium">Create one</RouterLink>
+          </p>
+        </div>
+      </KinFlatCard>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref, computed } from 'vue'
+import { useRouter } from 'vue-router'
+import { useAuthStore } from '@/stores/auth'
+import KinFlatCard from '@/components/design-system/KinFlatCard.vue'
+import LoadingSpinner from '@/components/common/LoadingSpinner.vue'
+
+const router = useRouter()
+const authStore = useAuthStore()
+
+const demoAvailable = computed(() => authStore.appConfig?.demo_available)
+const loadingMember = ref(null)
+const errorMsg = ref('')
+
+const members = [
+  { key: 'mike', name: 'Mike', role: 'Parent', description: 'Dad', color: '#5B8C9C' },
+  { key: 'sarah', name: 'Sarah', role: 'Parent', description: 'Mom', color: '#8B5B9C' },
+  { key: 'emma', name: 'Emma', role: 'Teen', description: 'Age 16', color: '#9C5B7B' },
+  { key: 'jake', name: 'Jake', role: 'Kid', description: 'Age 13', color: '#5B6B9C' },
+  { key: 'lily', name: 'Lily', role: 'Kid', description: 'Age 9', color: '#5B9C7B' },
+]
+
+const highlights = [
+  {
+    title: 'Calendar & tasks',
+    description: 'A populated week, recurring chores, kid-assigned tasks with points.',
+  },
+  {
+    title: 'Vault & recipes',
+    description: 'Encrypted family docs, meal plan, shopping list, and a recipe library.',
+  },
+  {
+    title: 'Points & badges',
+    description: 'Live leaderboard, kudos, the rewards shop, and earned achievements.',
+  },
+]
+
+const handleSelect = async (key) => {
+  loadingMember.value = key
+  errorMsg.value = ''
+
+  const result = await authStore.demoLogin(key)
+
+  if (result.success) {
+    router.push({ name: 'Dashboard' })
+  } else {
+    errorMsg.value = result.error || 'Something went wrong. Please try again.'
+    loadingMember.value = null
+  }
+}
+</script>


### PR DESCRIPTION
## Summary
- New `DemoView.vue` at `/demo` — a full-page version of the existing demo-login modal so the new marketing site can deep-link to `/demo` instead of `/login`.
- Reuses the proven `authStore.demoLogin()` action and the same five Johnson-family members as the modal — no new auth surface area.
- Wrapped in a Kin design-system layout: hero ("Meet the Johnson family"), member picker, "What's inside" highlights row (calendar/tasks, vault/recipes, points/badges), and footer links to sign in or create an account.
- Route is `requiresGuest`, so authenticated visitors bounce to Dashboard. `'Demo'` added to App.vue's chromeless-page list so the auth chrome (no sidebar/topbar) is used.

## Test plan
- [ ] Hit `/demo` while signed out — page renders with all 5 family members, intro copy, highlights, and footer links.
- [ ] Click a family member — logs in as them and lands on `/dashboard` (same flow as the modal).
- [ ] Hit `/demo` while signed in — guard redirects to `/dashboard`.
- [ ] On a fresh self-hosted instance with no demo seed, the picker is replaced by a "demo unavailable" notice (driven by `appConfig.demo_available`).
- [ ] No console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)