### PR TITLE
feat: expand MCP tool field coverage from API parity audit

### DIFF
--- a/app/Mcp/Tools/KinholdAchievements.php
+++ b/app/Mcp/Tools/KinholdAchievements.php
@@ -19,8 +19,8 @@ Manage badges and view earned achievements.
 
 Actions:
   badge_list — List all family badges (children see hidden badges masked unless earned).
-  badge_create (name*, description*, trigger_type*, trigger_threshold?, icon?, color?, is_hidden?) — Parent only.
-  badge_update (badge_id*, [any field]) — Parent only.
+  badge_create (name*, description*, trigger_type*, trigger_threshold?, icon?, color?, is_hidden?, is_active?, sort_order?) — Parent only. is_active defaults to true.
+  badge_update (badge_id*, [any field — including is_active and sort_order]) — Parent only.
   badge_delete (badge_id*) — Parent only.
   badge_award (badge_id*, user_id*) — Manually award. Parent only.
   badge_revoke (badge_id*, user_id*) — Manually revoke. Parent only.
@@ -53,7 +53,8 @@ class KinholdAchievements extends Tool
             ])->description('What triggers this badge (required for create)'),
             'trigger_threshold' => $schema->integer()->description('Threshold value for auto-trigger (null for custom badges)'),
             'is_hidden' => $schema->boolean()->description('Whether badge is hidden until earned'),
-            'is_active' => $schema->boolean()->description('Whether badge is active'),
+            'is_active' => $schema->boolean()->description('Whether badge is active (defaults to true on create)'),
+            'sort_order' => $schema->integer()->description('Sort order within the badge list (badge_list orders by this)'),
         ];
     }
 
@@ -134,6 +135,8 @@ class KinholdAchievements extends Tool
             'trigger_type' => $triggerType,
             'trigger_threshold' => $request->get('trigger_threshold'),
             'is_hidden' => $request->get('is_hidden', false),
+            'is_active' => $request->get('is_active', true),
+            'sort_order' => $request->get('sort_order', 0),
         ]);
 
         return Response::json([
@@ -160,7 +163,7 @@ class KinholdAchievements extends Tool
         // triggered badge or vice versa.
         $updates = $this->mergeUpdates(
             $request,
-            simpleFields: ['name', 'trigger_type', 'is_hidden', 'is_active'],
+            simpleFields: ['name', 'trigger_type', 'is_hidden', 'is_active', 'sort_order'],
             nullableFields: ['description', 'icon', 'color', 'trigger_threshold'],
         );
 

--- a/app/Mcp/Tools/KinholdCalendar.php
+++ b/app/Mcp/Tools/KinholdCalendar.php
@@ -24,7 +24,7 @@ Family calendar: events (manual + external + tasks), connections, and featured/c
 Actions:
   event_list (start?, end?) — Aggregated events from external calendars (Google/ICS), manual family events, and task due dates. Defaults: today → +3mo.
   event_create (title*, start_time*, end_time?, all_day?, description?, location?, color?, recurrence?, visibility?, featured_scope?, icon?, is_countdown?) — Create a manual family event.
-  event_update (event_id*, [any field]) — Creator or parent only.
+  event_update (event_id*, [any field — including is_active to soft-disable]) — Creator or parent only.
   event_delete (event_id*) — Creator or parent only.
   connection_list — List connected external calendars.
   connection_sync — Refresh sync timestamps + Google tokens for the current user's connections.
@@ -67,7 +67,7 @@ class KinholdCalendar extends Tool
             'event_date' => $schema->string()->description('Featured event date YYYY-MM-DD (required for featured_create)'),
             'event_time' => $schema->string()->description('Featured event time HH:MM'),
             'is_countdown' => $schema->boolean()->description('Whether this is THE countdown event on the dashboard (only one allowed per family)'),
-            'is_active' => $schema->boolean()->description('Whether the featured event is active'),
+            'is_active' => $schema->boolean()->description('Whether the event is active (soft-disable). Applies to event_update and featured_update.'),
         ];
     }
 
@@ -145,6 +145,7 @@ class KinholdCalendar extends Tool
                 $allEvents[] = [
                     'id' => $event->id,
                     'title' => $event->title,
+                    'description' => $event->description,
                     'start' => $event->all_day ? $occurrenceDate->toDateString() : $occurrenceDate->copy()->setTimeFrom($event->start_time)->toIso8601String(),
                     'end' => $event->end_time ? $occurrenceDate->copy()->setTimeFrom($event->end_time)->toIso8601String() : null,
                     'all_day' => $event->all_day,
@@ -247,7 +248,7 @@ class KinholdCalendar extends Tool
 
         $updateData = $this->mergeUpdates(
             $request,
-            simpleFields: ['title', 'recurrence', 'visibility', 'all_day'],
+            simpleFields: ['title', 'recurrence', 'visibility', 'all_day', 'is_active'],
             nullableFields: ['description', 'location', 'color', 'featured_scope', 'icon'],
         );
 

--- a/app/Mcp/Tools/KinholdFood.php
+++ b/app/Mcp/Tools/KinholdFood.php
@@ -54,8 +54,8 @@ Shopping lists & items:
   shopping_update_list (list_id*, name?, store_name?).
   shopping_delete_list (list_id*).
   shopping_complete_trip (list_id*) — Mark a shopping trip as completed.
-  shopping_add_item (list_id*, name*, quantity?, category?, notes?, is_recurring?).
-  shopping_update_item (item_id*, [any field]).
+  shopping_add_item (list_id*, name*, quantity?, category?, notes?, is_recurring?, default_quantity?).
+  shopping_update_item (item_id*, [any field — name, quantity, category, notes, is_recurring, sort_order]).
   shopping_remove_item (item_id*).
   shopping_check_item (item_id*) / shopping_uncheck_item (item_id*).
   shopping_mark_on_hand (item_id*) / shopping_clear_on_hand (item_id*).
@@ -174,6 +174,7 @@ class KinholdFood extends Tool
             'quantity' => $schema->string()->description('Item quantity (shopping_add_item)'),
             'category' => $schema->string()->description('Item category'),
             'is_recurring' => $schema->boolean()->description('Mark item as recurring'),
+            'default_quantity' => $schema->string()->description('Default quantity restored when a recurring shopping item resets (shopping_add_item)'),
             'q' => $schema->string()->description('Search query (shopping_search_catalog)'),
             'ingredient_ids' => $schema->array()->items($schema->string())->description('Recipe ingredient UUIDs to add (shopping_add_recipe)'),
 
@@ -187,7 +188,7 @@ class KinholdFood extends Tool
             'selections' => $schema->array()->description('Curated entry selections for meal_plan_add_to_shopping. Array of {entry_id, ingredient_ids?}.'),
             'label' => $schema->string()->description('Meal preset label'),
             'icon' => $schema->string()->description('Icon (presets, restaurants)'),
-            'sort_order' => $schema->integer()->description('Sort order (presets, recipes, meal-plan entries)'),
+            'sort_order' => $schema->integer()->description('Sort order (presets, recipes, meal-plan entries, shopping items)'),
             'assigned_cooks' => $schema->array()->items($schema->string())->description('User UUIDs assigned as cooks for a meal-plan entry'),
 
             // Restaurant
@@ -740,6 +741,7 @@ class KinholdFood extends Tool
             'category' => $request->get('category'),
             'notes' => $request->get('notes'),
             'is_recurring' => $request->get('is_recurring'),
+            'default_quantity' => $request->get('default_quantity'),
         ], fn ($v) => $v !== null);
 
         $item = app(ShoppingListService::class)->addItem($list, $data, $this->user());
@@ -763,7 +765,7 @@ class KinholdFood extends Tool
 
         $updates = $this->mergeUpdates(
             $request,
-            simpleFields: ['name', 'is_recurring'],
+            simpleFields: ['name', 'is_recurring', 'sort_order'],
             nullableFields: ['quantity', 'category', 'notes'],
         );
 

--- a/app/Mcp/Tools/KinholdTasks.php
+++ b/app/Mcp/Tools/KinholdTasks.php
@@ -24,8 +24,8 @@ Tasks, completion (with points + badge side effects), and tags.
 
 Tasks:
   task_list (status?, assigned_to?) — Family tasks ordered by due date.
-  task_create (title*, description?, assigned_to?, due_date?, priority?, is_family_task?, points?, tag_ids?) — Children cannot set custom points.
-  task_update (task_id*, [any field]) — Subject to policy.
+  task_create (title*, description?, assigned_to?, due_date?, priority?, is_family_task?, points?, tag_ids?, recurrence_rule?, recurrence_end?, allow_pileup?) — Children cannot set custom points.
+  task_update (task_id*, [any field — title, description, assigned_to, due_date, priority, is_family_task, points, tag_ids, recurrence_rule, recurrence_end, sort_order]) — Subject to policy.
   task_delete (task_id*) — Subject to policy.
   task_complete (task_id*) — Awards points + checks badges. Children get 0 points for tasks they created themselves. Notifies family.
   task_uncomplete (task_id*) — Reverses points.
@@ -62,6 +62,10 @@ class KinholdTasks extends Tool
             'points' => $schema->integer()->description('Custom points (parent only)'),
             'status' => $schema->string()->enum(['pending', 'completed'])->description('Filter for task_list'),
             'tag_ids' => $schema->array()->items($schema->string())->description('Tag UUIDs to attach'),
+            'recurrence_rule' => $schema->string()->description('Recurrence pattern (e.g. RRULE string). Pass null/"" on update to clear.'),
+            'recurrence_end' => $schema->string()->description('Recurrence end date YYYY-MM-DD. Pass null/"" on update to clear.'),
+            'allow_pileup' => $schema->boolean()->description('Allow recurring task instances to pile up rather than rolling forward (task_create only)'),
+            'sort_order' => $schema->integer()->description('Sort order within the family task list (task_update only)'),
             'name' => $schema->string()->description('Tag name (required for tag_create)'),
             'color' => $schema->string()->description('Hex color for tag (e.g. #FF5733)'),
             'scope' => $schema->string()->enum(['task', 'food'])->description('Tag scope. Default for tag_create: task. Acts as filter on tag_list.'),
@@ -154,6 +158,9 @@ class KinholdTasks extends Tool
             'priority' => $request->get('priority', 'medium'),
             'is_family_task' => $request->get('is_family_task', false),
             'points' => $points,
+            'recurrence_rule' => $request->get('recurrence_rule'),
+            'recurrence_end' => $request->get('recurrence_end'),
+            'allow_pileup' => $request->get('allow_pileup', false),
             'sort_order' => Task::where('family_id', $family->id)->max('sort_order') + 1,
         ]);
 
@@ -197,8 +204,8 @@ class KinholdTasks extends Tool
 
         $updates = $this->mergeUpdates(
             $request,
-            simpleFields: ['title', 'priority', 'is_family_task'],
-            nullableFields: ['description', 'due_date'],
+            simpleFields: ['title', 'priority', 'is_family_task', 'sort_order'],
+            nullableFields: ['description', 'due_date', 'recurrence_rule', 'recurrence_end'],
         );
 
         // assigned_to: empty/null clears, otherwise must be a family member.

--- a/app/Mcp/Tools/KinholdVault.php
+++ b/app/Mcp/Tools/KinholdVault.php
@@ -30,7 +30,7 @@ Entries (encrypted at rest):
   entry_list (category_id?) — Children see only personal-they-own + entries shared with them.
   entry_get (entry_id*) — Returns decrypted data. Subject to permissions.
   entry_create (title*, category_id*, data*, notes?, is_personal?) — data: { body: "markdown", sensitive_fields: { ... } }.
-  entry_update (entry_id*, [title|notes|data|category_id]) — Subject to policy.
+  entry_update (entry_id*, [title|notes|data|category_id|is_personal]) — Subject to policy. Toggling is_personal changes privacy status.
   entry_delete (entry_id*) — Subject to policy.
 
 Per-user access (parent only):
@@ -325,7 +325,7 @@ class KinholdVault extends Tool
         // Title is required; notes is nullable text where "" should clear.
         $updates = $this->mergeUpdates(
             $request,
-            simpleFields: ['title'],
+            simpleFields: ['title', 'is_personal'],
             nullableFields: ['notes'],
         );
 


### PR DESCRIPTION
## Summary

Follow-up to [#198](https://github.com/gregqualls/kinhold/pull/198) (the 20→7 MCP router consolidation). An audit of the new MCP tool schemas against the corresponding API `FormRequest` validation classes turned up several fields the API accepts but MCP doesn't expose. None of these were active bugs — just incomplete parity. This PR closes those gaps.

All update paths use the `MergesUpdates` trait so nullable fields can be cleared via `null`/`""`.

## Fields added by tool

**KinholdTasks** (`app/Mcp/Tools/KinholdTasks.php`)
- `recurrence_rule` (`StoreTaskRequest:35`, `UpdateTaskRequest:36`) — create + update
- `recurrence_end` (`StoreTaskRequest:36`, `UpdateTaskRequest:37`) — create + update
- `allow_pileup` (`StoreTaskRequest:37`) — create only
- `sort_order` (`UpdateTaskRequest:34`) — update only

**KinholdCalendar** (`app/Mcp/Tools/KinholdCalendar.php`)
- `is_active` on `event_update` — already in schema and used on `featured_update`; was unwired on regular `event_update`
- `description` added to `event_list` JSON for manual family events (was being dropped)

**KinholdVault** (`app/Mcp/Tools/KinholdVault.php`)
- `is_personal` on `entry_update` — already accepted on `entry_create`; vault entries can now change privacy status via MCP

**KinholdAchievements** (`app/Mcp/Tools/KinholdAchievements.php`)
- `is_active` defaulting to `true` on `badge_create` (was in schema, silently dropped)
- `sort_order` on `badge_create` + `badge_update` (Badge model has it; `badge_list` already orders by it)

**KinholdFood — Shopping** (`app/Mcp/Tools/KinholdFood.php`)
- `default_quantity` on `shopping_add_item` (`AddShoppingItemRequest:22`)
- `sort_order` on `shopping_update_item` (`UpdateShoppingItemRequest:21`)

Each addition updates: schema entry, action documentation in the `#[Description]` block, and the relevant create/update handler.

## Notes on two borderline items

The audit also flagged `is_active` on regular events and `is_personal` on `entry_update` as MCP gaps. Both columns are in the model `$fillable` and supported on adjacent endpoints (featured events, entry create), but neither is currently in the API request class for the corresponding update endpoint (`CalendarController::updateEvent` inline validation, `UpdateVaultEntryRequest`). I added them to MCP per the audit, since the audit framing was "MCP coverage of model-supported fields." If we want strict API parity instead, follow-up to add them to the request classes.

## Test plan

- [x] `vendor/bin/pint app/Mcp/Tools/` — clean
- [x] `vendor/bin/phpunit --testsuite=Feature` — 125/125 passing
- [x] `vendor/bin/phpstan analyse --memory-limit=512M --no-progress` — no errors
- [ ] Manual MCP smoke test: create a recurring task with `recurrence_rule`, toggle vault entry `is_personal` via update, set badge `sort_order`

🤖 Generated with [Claude Code](https://claude.com/claude-code)