### PR TITLE
chore: add .gitattributes to normalize line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,29 @@
+# Normalize all text files to LF in the repo. Working tree can be whatever
+# the OS prefers — Git converts on checkout/commit so Windows contributors
+# don't end up shipping CRLF to a Linux server.
+* text=auto eol=lf
+
+# Explicit overrides for files where line endings matter.
+*.bat       text eol=crlf
+*.cmd       text eol=crlf
+*.ps1       text eol=crlf
+*.sh        text eol=lf
+
+# Binary — never touch.
+*.png       binary
+*.jpg       binary
+*.jpeg      binary
+*.gif       binary
+*.ico       binary
+*.webp      binary
+*.pdf       binary
+*.zip       binary
+*.gz        binary
+*.tar       binary
+*.woff      binary
+*.woff2     binary
+*.ttf       binary
+*.eot       binary
+*.mp4       binary
+*.mp3       binary
+*.wav       binary


### PR DESCRIPTION
## Summary
- Adds `.gitattributes` enforcing LF line endings for all text files in the repo
- Prevents phantom CRLF/LF "modifications" from showing up in `git status` on Windows
- Pairs with the existing `.editorconfig` (`end_of_line = lf`)

## Why
Working on Windows with `core.autocrlf=true` (the Windows default) produces CRLF in the working tree. Without `.gitattributes`, files modified by some tools end up perpetually flagged as "modified" because Git sees the line-ending difference. This has been showing up as ~9 phantom-modified files since 70-A.

`git add --renormalize .` after committing `.gitattributes` produced zero changes, confirming main's index was already clean — this is purely preventative.

## Test Plan
- [ ] On Windows: `git status` is clean after a fresh checkout (no phantom CRLF entries)
- [ ] On Linux/CI: builds and tests pass unchanged

## Checklist
- [x] No credentials committed
- [x] Pure config change — no code touched