### PR TITLE
chore: raise phpstan memory limit to 512M via bootstrap

### DIFF
--- a/phpstan-bootstrap.php
+++ b/phpstan-bootstrap.php
@@ -1,0 +1,3 @@
+<?php
+
+ini_set('memory_limit', '512M');

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -3,6 +3,8 @@ includes:
     - phpstan-baseline.neon
 
 parameters:
+    bootstrapFiles:
+        - phpstan-bootstrap.php
     paths:
         - app
     level: 5


### PR DESCRIPTION
## Summary
- PHPStan was crashing at PHP's default 128M memory limit, requiring everyone to remember `--memory-limit=512M` on the CLI.
- Adds `phpstan-bootstrap.php` that calls `ini_set('memory_limit', '512M')` and wires it via `parameters.bootstrapFiles` in `phpstan.neon`.
- Tooling/config only, no application code touched.

## Test Plan
- [x] `./vendor/bin/phpstan analyse --no-progress` runs clean (0 errors) without the flag.
- [x] Existing `--memory-limit=512M` invocations in `scripts/check.sh`, CI workflow, and `/handoff` still work (flag is now redundant but harmless).

## Notes
- Pre-existing PHPUnit failures on `main` (15 errors, 1 failure) are unrelated to this change and reproduce on a clean checkout.

## Checklist
- [x] No credentials committed
- [x] Tooling-only change

🤖 Generated with [Claude Code](https://claude.com/claude-code)