### PR TITLE
fix: v1.9.0 batch-1 quick wins (#248, #251, #253, #255, #256, #257)

### DIFF
--- a/app/Http/Controllers/Api/V1/AuthController.php
+++ b/app/Http/Controllers/Api/V1/AuthController.php
@@ -14,6 +14,7 @@ use App\Services\BadgeService;
 use App\Services\BillingService;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
@@ -27,35 +28,47 @@ class AuthController extends Controller
     {
         $family = null;
         $role = 'child';
-
-        if ($request->filled('invite_code')) {
-            $family = Family::where('invite_code', $request->validated('invite_code'))->firstOrFail();
-            // SECURITY: Always assign 'child' role when joining via invite code.
-            // Parents can promote members after they join.
-            $role = 'child';
-        } else {
-            $family = Family::create([
-                'name' => $request->validated('family_name'),
-                'slug' => Str::slug($request->validated('family_name')),
-                'invite_code' => Str::random(16),
-            ]);
-            $role = 'parent';
-        }
-
         $isNewFamily = ! $request->filled('invite_code');
 
-        $user = User::create([
-            'name' => $request->validated('name'),
-            'email' => $request->validated('email'),
-            'password' => Hash::make($request->validated('password')),
-            'family_id' => $family->id,
-            'family_role' => $role,
-        ]);
+        [$family, $user] = DB::transaction(function () use ($request, &$role, $isNewFamily) {
+            if (! $isNewFamily) {
+                $family = Family::where('invite_code', $request->validated('invite_code'))->firstOrFail();
+                // SECURITY: Always assign 'child' role when joining via invite code.
+                // Parents can promote members after they join.
+                $role = 'child';
+            } else {
+                $base = Str::slug($request->validated('family_name')) ?: 'family';
+                $slug = $base;
+                $n = 2;
+                while (Family::where('slug', $slug)->exists() && $n <= 20) {
+                    $slug = $base.'-'.$n++;
+                }
 
-        // Seed default badges for newly created families
-        if ($isNewFamily) {
-            BadgeService::createDefaultBadges($family->id, $user->id);
-        }
+                $family = Family::create([
+                    'name' => $request->validated('family_name'),
+                    'slug' => $slug,
+                    'invite_code' => Str::random(16),
+                ]);
+                $role = 'parent';
+            }
+
+            $user = User::create([
+                'name' => $request->validated('name'),
+                'email' => $request->validated('email'),
+                'password' => Hash::make($request->validated('password')),
+                'family_id' => $family->id,
+                'family_role' => $role,
+            ]);
+
+            if ($isNewFamily) {
+                $family->billing_owner_id = $user->id;
+                $family->save();
+
+                BadgeService::createDefaultBadges($family->id, $user->id);
+            }
+
+            return [$family, $user];
+        });
 
         // Send welcome email
         $user->notify(new WelcomeNotification($family, $isNewFamily));

--- a/app/Http/Controllers/Api/V1/AuthController.php
+++ b/app/Http/Controllers/Api/V1/AuthController.php
@@ -61,7 +61,7 @@ class AuthController extends Controller
             ]);
 
             if ($isNewFamily) {
-                $family->billing_owner_id = $user->id;
+                $family->billing_owner_id = (string) $user->id;
                 $family->save();
 
                 BadgeService::createDefaultBadges($family->id, $user->id);

--- a/app/Services/BillingService.php
+++ b/app/Services/BillingService.php
@@ -304,6 +304,11 @@ class BillingService
         }
 
         if ($trialDays > 0 && ! $family->hasStripeId()) {
+            // Stripe counts whole days remaining from checkout creation to trial_end.
+            // If the session is created just before midnight UTC, the preview may
+            // display (trialDays - 1). If this consistently shows 13 for a 14-day
+            // trial, set BILLING_TRIAL_DAYS=15 in the env — Stripe will display
+            // "14 days free" while granting a 15-day trial (~24h buffer).
             $builder->trialDays($trialDays);
         }
 

--- a/docs/V190-STAGING-PLAN.md
+++ b/docs/V190-STAGING-PLAN.md
@@ -1,0 +1,153 @@
+# v1.9.0 Staging & Cutover Plan
+
+> Reference doc for the v1.9.0 `BILLING_ENABLED=true` flip. Staging-first approach so we shake out billing in a real Upsun environment with sandbox Stripe before touching production.
+
+**Date created:** 2026-05-04
+**Owner:** Greg
+**Related:** [#70](https://github.com/gregqualls/kinhold/issues/70) (closed), [#240](https://github.com/gregqualls/kinhold/issues/240) (promo codes follow-up)
+
+---
+
+## Why staging first
+
+The local dev box has never run with `BILLING_ENABLED=true` against a real public URL Stripe can webhook into. Webhook signatures, OAuth redirect URLs, the Stripe Customer Portal return flow, and the paywall splash all interact with the deployed environment in ways `php artisan serve` can't simulate. A throwaway staging env on Upsun lets us prove the whole loop on sandbox Stripe before flipping production to live keys.
+
+Production stays on `BILLING_ENABLED=false` throughout staging work. Zero risk to real users.
+
+## Step 1 — Create staging environment on Upsun
+
+```bash
+# Branch staging from main (creates a new active environment)
+upsun environment:branch staging main --project=2rozcvqjtjdta
+
+# If the new env doesn't activate automatically:
+upsun environment:activate staging --project=2rozcvqjtjdta
+
+# Get the staging URL (will be something like staging-<hash>.<region>.upsunapp.com)
+upsun environment:url --environment=staging --project=2rozcvqjtjdta
+```
+
+**Note the staging URL.** You'll need it for Stripe webhook config and the auth redirect allow-list.
+
+## Step 2 — Set staging environment variables (Upsun Console, not CLI)
+
+For secrets, prefer the Upsun web console (Project → staging environment → Variables) so they're never on disk locally. Set these as **environment-level variables, sensitive=true** so they don't inherit to feature branch envs:
+
+| Variable | Value | Notes |
+|---|---|---|
+| `BILLING_ENABLED` | `true` | The flip. Staging only, not main. |
+| `STRIPE_KEY` | `pk_test_...` | Sandbox publishable key |
+| `STRIPE_SECRET` | `sk_test_...` | Sandbox secret key |
+| `STRIPE_WEBHOOK_SECRET` | `whsec_...` | NEW webhook endpoint (created in step 3) |
+| `STRIPE_PRICE_BASE_PLAN` | `price_test_...` | Sandbox base subscription price |
+| `STRIPE_PRICE_AI_LITE` | `price_test_...` | Sandbox AI Lite tier |
+| `STRIPE_PRICE_AI_STANDARD` | `price_test_...` | Sandbox AI Standard tier |
+| `STRIPE_PRICE_AI_PRO` | `price_test_...` | Sandbox AI Pro tier |
+| `APP_URL` | staging URL from step 1 | Critical for webhook + redirect URLs |
+
+Production main keeps its existing values (no changes).
+
+## Step 3 — Configure Stripe webhook for staging URL
+
+Stripe Dashboard (still in test mode):
+
+1. Developers → Webhooks → "Add endpoint"
+2. Endpoint URL: `<staging-url>/stripe/webhook`
+3. Events to send (the ones our `StripeWebhookController` handles):
+   - `checkout.session.completed`
+   - `customer.subscription.created`
+   - `customer.subscription.updated`
+   - `customer.subscription.deleted`
+   - `invoice.payment_succeeded`
+   - `invoice.payment_failed`
+   - `customer.subscription.trial_will_end`
+   - `customer.updated`
+   - `payment_method.attached`
+   - `payment_method.detached`
+4. Copy the signing secret (`whsec_...`) into the staging `STRIPE_WEBHOOK_SECRET` env var
+
+Test mode and live mode have separate webhook endpoint lists in Stripe — staging uses test, production will eventually use live.
+
+## Step 4 — Update Google OAuth allowed redirect URIs (if testing OAuth)
+
+If you want to test the Google Calendar / Login flows on staging:
+
+- Google Cloud Console → APIs & Services → Credentials → OAuth 2.0 Client
+- Add the staging URL to "Authorized redirect URIs"
+- Don't remove the production URL
+
+## Step 5 — Seed the staging database
+
+After Upsun finishes the first deploy, the staging DB will be empty:
+
+```bash
+upsun ssh --environment=staging --project=2rozcvqjtjdta
+php artisan migrate --force
+php artisan app:refresh-demo
+```
+
+Now you have the demo family on staging.
+
+## Step 6 — Smoke test (the actual point)
+
+Sign up a fresh test family on staging (NOT the demo family — demo billing is now blocked by [#239](https://github.com/gregqualls/kinhold/pull/239)):
+
+1. **Onboarding plan picker** (70-G): pick a plan, get pushed to Stripe Checkout, complete with `4242 4242 4242 4242`, return to app, confirm subscription is `active` (or `trialing` if trial config is on)
+2. **BillingPanel in Settings**: card on file shows correctly, lifecycle dates render
+3. **Customer Portal**: click "Manage payment", land on Stripe-hosted portal, change card, return cleanly
+4. **AI tier picker**: switch from Lite → Standard mid-trial, verify the trial-end logic in #230 fires (Stripe-side proration kicks in)
+5. **Cancel → resume**: cancel from portal, see the cancelled state in our DB, resume before `ends_at`, watch it flip back to active
+6. **Past-due simulation**: in Stripe Dashboard → Subscriptions, manually set the test subscription's status to `past_due`, reload the SPA, confirm the paywall splash from #237 renders with "Update payment method" CTA
+7. **Trial expired simulation**: in Stripe, end the trial without a payment method, watch the paywall flip to "Welcome back" with "Reactivate" CTA
+8. **Demo family billing lockdown** (#239): log in as `parent@demo.local` on staging, confirm Settings has no Billing section, confirm `POST /api/v1/billing/checkout-session` returns 403
+9. **Webhook reliability**: in Stripe → Webhooks, watch the events page for staging — confirm 200 responses on every event we care about
+
+If any step fails, fix in code, push to `main` (which also redeploys staging since it tracks main + the staging env override), repeat.
+
+## Step 7 — Production cutover (next session, after staging passes)
+
+When staging is solid:
+
+1. **Flip Stripe to live mode** in the Stripe Dashboard
+2. **Recreate Products + Prices in live mode** (sandbox IDs do NOT carry over to live)
+3. **Create live webhook endpoint** pointing at `https://kinhold.app/stripe/webhook`, capture the live `whsec_...`
+4. **Update production env vars** in Upsun Console (main environment):
+   - `STRIPE_KEY` → `pk_live_...`
+   - `STRIPE_SECRET` → `sk_live_...`
+   - `STRIPE_WEBHOOK_SECRET` → live webhook secret from step 3
+   - `STRIPE_PRICE_*` → live price IDs from step 2
+   - `BILLING_ENABLED=true` (the actual flip)
+5. **Smoke production with a real card** (your own, refund yourself after)
+6. **Tag `v1.9.0` GitHub Release** with full changelog (already in `CHANGELOG.md`)
+7. **Tear down staging** to stop the meter:
+   ```bash
+   upsun environment:delete staging --project=2rozcvqjtjdta
+   ```
+
+## Step 8 — Watch the first 24 hours
+
+- Stripe Dashboard → first real customers should appear
+- Upsun logs → no 500s on `/stripe/webhook`
+- Sentry / error tracking → any auth or paywall regressions
+- If something breaks, you can flip `BILLING_ENABLED=false` instantly without a deploy (it's an env var, takes ~30s to propagate)
+
+## Rollback plan
+
+If production cutover goes sideways:
+
+1. Set `BILLING_ENABLED=false` in Upsun (instant)
+2. SPA falls back to free-for-everyone behavior, paywall never mounts, BillingPanel hides
+3. Existing Stripe subscriptions keep ticking on Stripe's side but our app ignores them
+4. Triage in staging, reflip when ready
+
+The only irreversible part is real customer charges. Refund through Stripe Dashboard if anyone got billed during a problem window.
+
+---
+
+## Quick reference
+
+- **Project ID:** `2rozcvqjtjdta`
+- **Production URL:** https://kinhold.app
+- **Staging URL:** TBD after step 1
+- **Stripe Dashboard:** dashboard.stripe.com (test mode toggle in upper-right)
+- **Upsun CLI auth:** `upsun auth:browser-login` if commands fail

--- a/resources/js/views/onboarding/steps/BillingStep.vue
+++ b/resources/js/views/onboarding/steps/BillingStep.vue
@@ -76,12 +76,15 @@
           <p class="text-sm font-medium text-ink-secondary">Monthly total</p>
           <p class="text-base font-semibold text-ink-primary">{{ totalLabel }}</p>
         </div>
-        <p
+        <div
           v-if="billing.summary.trial_eligible && billing.summary.trial_days"
-          class="text-xs text-accent-lavender-bold"
+          class="flex items-center gap-2 px-3 py-2 rounded-md bg-accent-lavender-soft/40 border border-accent-lavender-bold/30"
         >
-          {{ billing.summary.trial_days }}-day free trial — no card charged until the trial ends.
-        </p>
+          <span class="text-sm font-semibold text-accent-lavender-bold">
+            {{ billing.summary.trial_days }}-day free trial
+          </span>
+          <span class="text-sm text-ink-secondary">— no card charged until the trial ends.</span>
+        </div>
         <p v-if="billing.lastError" class="text-xs text-rose-700 dark:text-rose-300">
           {{ billing.lastError }}
         </p>

--- a/resources/js/views/onboarding/steps/FeaturesStep.vue
+++ b/resources/js/views/onboarding/steps/FeaturesStep.vue
@@ -90,6 +90,7 @@ import {
   StarIcon,
   ChatBubbleLeftRightIcon,
   LockClosedIcon,
+  ShoppingCartIcon,
 } from '@heroicons/vue/24/outline'
 import KinFlatCard from '@/components/design-system/KinFlatCard.vue'
 import KinCheckbox from '@/components/design-system/KinCheckbox.vue'
@@ -137,6 +138,12 @@ const features = [
     description: 'Encrypted storage for sensitive info — SSNs, insurance, medical records. Parents see everything; children only see what\'s shared with them.',
     icon: LockClosedIcon,
   },
+  {
+    key: 'food',
+    name: 'Food & Shopping',
+    description: 'Meal planning, recipes, and shared shopping lists for the whole family.',
+    icon: ShoppingCartIcon,
+  },
 ]
 
 const accessOptions = [
@@ -153,6 +160,7 @@ const moduleState = reactive({
   badges: { mode: 'all' },
   chat: { mode: 'all' },
   vault: { mode: 'all' },
+  food: { mode: 'all' },
 })
 
 function isActiveMode(key, mode) {


### PR DESCRIPTION
## Summary

- **#248** — Collision-safe family slug on register: appends `-2`, `-3`, etc. instead of hitting the DB unique constraint with a 500. Whole register flow now wrapped in a `DB::transaction`.
- **#253** — `billing_owner_id` set on the new family immediately after the registering user is created, so the onboarding BillingStep is shown for new signups.
- **#251** — Food & Shopping module toggle added to onboarding FeaturesStep (was in `Family::MODULES` but missing from the UI).
- **#255** — Trial-days notice in BillingStep promoted from `text-xs` fine print to a styled banner with background, directly above the CTA.
- **#256** — `STRIPE_PRICE_BASE` → `STRIPE_PRICE_BASE_PLAN` in `docs/V190-STAGING-PLAN.md`; webhook events list updated to include `customer.updated`, `payment_method.attached`, `payment_method.detached`.
- **#257** — Code comment documenting the Stripe trial-period display quirk in `createBaseCheckout`. If staging shows 13 days, set `BILLING_TRIAL_DAYS=15` in the Upsun env.

> **Note:** #253 (`billing_owner_id`) is included here because it's in the same registration method as #248 and doesn't activate any paywall logic on its own. The paywall hardening that depends on it (PR 2) ships separately.

## Test plan

- [ ] Register two families with the same name — second registration succeeds with slug `-2` suffix, no 500
- [ ] Register a fresh account — onboarding wizard shows BillingStep (requires `BILLING_ENABLED=true` on staging)
- [ ] Onboarding FeaturesStep — Food & Shopping toggle visible with Everyone/Parents Only/Custom/Off options
- [ ] BillingStep — trial notice is a prominent banner, not fine print (requires `BILLING_ENABLED=true` on staging)
- [ ] `docs/V190-STAGING-PLAN.md` — env var table shows `STRIPE_PRICE_BASE_PLAN`, webhook list has 9 events

🤖 Generated with [Claude Code](https://claude.com/claude-code)