### PR TITLE
fix: v1.9.0 paywall hardening (#245, #262, #264, #265)

### DIFF
--- a/app/Http/Controllers/Webhooks/StripeWebhookController.php
+++ b/app/Http/Controllers/Webhooks/StripeWebhookController.php
@@ -18,6 +18,9 @@ use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 use Laravel\Cashier\Cashier;
 use Laravel\Cashier\Http\Controllers\WebhookController as CashierWebhookController;
+use Stripe\Customer;
+use Stripe\Exception\ApiErrorException;
+use Stripe\Subscription;
 use Symfony\Component\HttpFoundation\Response;
 
 /**
@@ -86,21 +89,54 @@ class StripeWebhookController extends CashierWebhookController
 
     /**
      * `checkout.session.completed` fires when the customer finishes Checkout.
-     * Cashier doesn't ship a default handler — we use it to persist any
-     * onboarding metadata the SPA passed through (the AI tier choice was
-     * already written before the redirect, so this is mostly a nudge to make
-     * sure the family.stripe_id is set, which Cashier handles via subscription
-     * events anyway). Returning success keeps Stripe happy.
+     * Cashier doesn't ship a default handler — we use it to:
+     *   1. Promote the just-attached payment method to the customer's default
+     *      so future invoices have a PM to charge (#262). Stripe Checkout
+     *      attaches the PM but does NOT set `invoice_settings.default_payment_method`
+     *      automatically for subscription-mode sessions; without this, the
+     *      first invoice after the trial fails with "no payment method".
+     *   2. Log unknown customers (data integrity sanity check).
      */
     protected function handleCheckoutSessionCompleted(array $payload): Response
     {
         $session = $payload['data']['object'] ?? [];
         $customerId = $session['customer'] ?? null;
 
-        if ($customerId && ! Cashier::findBillable($customerId)) {
+        if (! $customerId) {
+            return $this->successMethod();
+        }
+
+        if (! Cashier::findBillable($customerId)) {
             Log::warning('Stripe checkout.session.completed for unknown customer', [
                 'customer' => $customerId,
                 'session' => $session['id'] ?? null,
+            ]);
+
+            return $this->successMethod();
+        }
+
+        // Resolve the payment method — present on the session for some flows,
+        // otherwise read it off the new subscription. Wrap the Stripe call so
+        // an API blip doesn't 500 the webhook (which would trigger Stripe
+        // retries and could double-fire other handlers).
+        try {
+            $paymentMethodId = $session['payment_method'] ?? null;
+
+            if (! $paymentMethodId && ! empty($session['subscription'])) {
+                $sub = Subscription::retrieve((string) $session['subscription']);
+                $paymentMethodId = $sub->default_payment_method ?? null;
+            }
+
+            if ($paymentMethodId) {
+                Customer::update($customerId, [
+                    'invoice_settings' => ['default_payment_method' => $paymentMethodId],
+                ]);
+            }
+        } catch (ApiErrorException $e) {
+            Log::warning('Stripe checkout.session.completed: failed to promote PM to default', [
+                'customer' => $customerId,
+                'session' => $session['id'] ?? null,
+                'error' => $e->getMessage(),
             ]);
         }
 

--- a/app/Http/Middleware/BillingRequired.php
+++ b/app/Http/Middleware/BillingRequired.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use App\Services\BillingService;
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Server-side paywall gate (#264). Mirrors the SPA's `useBillingGate` check on
+ * the API surface so removing the client-side overlay (DevTools) doesn't grant
+ * access to feature endpoints.
+ *
+ * Returns 402 Payment Required when the family's subscription has lapsed; the
+ * SPA's Axios interceptor catches this and re-mounts the SubscriptionPaywall.
+ *
+ * `needs_onboarding` is intentionally allowed through — that state is handled
+ * by the SPA redirecting the billing owner to /onboarding. Blocking it at the
+ * API would 402 the wizard's own data fetches.
+ *
+ * Apply via the `billing.required` alias to feature route groups (tasks, vault,
+ * calendar, chat, points, rewards, badges, food, etc.). Do NOT apply to auth,
+ * billing management, settings (incl. GDPR data export + account deletion),
+ * onboarding, or family invite routes.
+ */
+class BillingRequired
+{
+    public function __construct(private readonly BillingService $billing) {}
+
+    public function handle(Request $request, Closure $next): Response
+    {
+        if (! $this->billing->isEnabled()) {
+            return $next($request);
+        }
+
+        $user = $request->user();
+        $family = $user?->family;
+
+        if (! $family) {
+            return $next($request);
+        }
+
+        $reason = $this->billing->paywallReason($family);
+
+        if ($reason === null || $reason === 'needs_onboarding') {
+            return $next($request);
+        }
+
+        return response()->json([
+            'message' => 'Subscription required.',
+            'paywall_reason' => $reason,
+        ], 402);
+    }
+}

--- a/app/Services/BillingService.php
+++ b/app/Services/BillingService.php
@@ -62,15 +62,18 @@ class BillingService
 
     /**
      * Why the SPA should hard-gate this family behind the paywall splash, or
-     * null if it shouldn't. Drives 70-I (#223). Three reasons surface:
+     * null if it shouldn't. Drives 70-I (#223). Four reasons surface:
+     *   - 'needs_onboarding'   — existing family with no Stripe customer; SPA
+     *                            redirects the billing owner to /onboarding
+     *                            instead of showing the paywall overlay (#245)
      *   - 'trial_expired'      — trial ended without ever activating a paid sub
      *   - 'past_due'           — Stripe says past_due / unpaid / incomplete_expired
      *   - 'cancelled_expired'  — was cancelled and ends_at has now passed
      *
-     * Returns null when self-hosted, billing-disabled, pre-checkout (no Stripe
-     * customer yet — onboarding handles them), inside the 7-day dunning grace
-     * window, or holding a currently-valid subscription (active, trialing, or
-     * cancelled-but-still-in-period).
+     * Returns null when self-hosted, billing-disabled, mid-registration (no
+     * billing_owner_id set yet), inside the 7-day dunning grace window, or
+     * holding a currently-valid subscription (active, trialing, or cancelled-
+     * but-still-in-period).
      */
     public function paywallReason(Family $family): ?string
     {
@@ -95,10 +98,23 @@ class BillingService
             return ['reason' => null, 'subscription' => null];
         }
 
-        // Brand-new families that never went through checkout fall through to
-        // the onboarding plan picker (70-G), not the paywall splash.
-        if (! $family->hasStripeId()) {
+        // Demo family always bypasses billing — see isDemoFamily() docs.
+        if ($this->isDemoFamily($family)) {
             return ['reason' => null, 'subscription' => null];
+        }
+
+        // No Stripe customer yet — three sub-cases:
+        //   1. Mid-registration: billing_owner_id not set yet. Let them through
+        //      so the rest of the registration request can complete.
+        //   2. Existing family / completed registration without subscription:
+        //      block with 'needs_onboarding' so the SPA pushes the billing
+        //      owner into the wizard at BillingStep (#245).
+        if (! $family->hasStripeId()) {
+            if (! $family->billing_owner_id) {
+                return ['reason' => null, 'subscription' => null];
+            }
+
+            return ['reason' => 'needs_onboarding', 'subscription' => null];
         }
 
         // 7-day dunning window — the grace-period scheduler is still cycling

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Http\Middleware\BillingRequired;
 use App\Http\Middleware\CheckModuleAccess;
 use Illuminate\Auth\Middleware\EnsureEmailIsVerified;
 use Illuminate\Foundation\Application;
@@ -22,6 +23,7 @@ return Application::configure(basePath: dirname(__DIR__))
         $middleware->alias([
             'verified' => EnsureEmailIsVerified::class,
             'module' => CheckModuleAccess::class,
+            'billing.required' => BillingRequired::class,
         ]);
     })
     ->withExceptions(function (Exceptions $exceptions) {

--- a/resources/js/App.vue
+++ b/resources/js/App.vue
@@ -111,12 +111,29 @@
          of <main> so the underlying route stays in the tree (avoids unmount
          thrash on resolve) but is unreachable behind the overlay. -->
     <SubscriptionPaywall v-if="showPaywall" />
+
+    <!-- Awaiting-owner overlay (#245): family hasn't subscribed yet and the
+         viewer isn't the billing owner. Billing owner is redirected to the
+         wizard; everyone else sees this. -->
+    <div
+      v-if="showAwaitingOwner"
+      class="fixed inset-0 z-[80] flex items-center justify-center p-6 bg-surface-base/95 dark:bg-prussian-900/95"
+      data-testid="awaiting-owner-overlay"
+    >
+      <div class="max-w-sm text-center space-y-3">
+        <h2 class="text-xl font-heading font-bold text-ink-primary">Subscription pending</h2>
+        <p class="text-base text-ink-secondary">
+          {{ billingGate.billingOwnerName.value || 'The billing owner' }} needs to finish setting up your family's subscription before you can use Kinhold.
+        </p>
+        <p class="text-sm text-ink-tertiary">Check back once they've completed signup.</p>
+      </div>
+    </div>
   </div>
 </template>
 
 <script setup>
-import { computed, ref, provide } from 'vue'
-import { useRoute } from 'vue-router'
+import { computed, ref, provide, watch } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
 import { storeToRefs } from 'pinia'
 import { useAuthStore } from '@/stores/auth'
 import Sidebar from '@/components/layout/Sidebar.vue'
@@ -136,6 +153,7 @@ import { useDarkMode } from '@/composables/useDarkMode'
 import { useTheme } from '@/composables/useTheme'
 
 const route = useRoute()
+const router = useRouter()
 const authStore = useAuthStore()
 const { notifications } = useNotification()
 const { isLoading, currentUser, family } = storeToRefs(authStore)
@@ -162,7 +180,39 @@ const isAuthPage = computed(() => {
   return ['Login', 'Register', 'Demo', 'Privacy', 'Terms', 'Onboarding', 'DesignSystem'].includes(route.name)
 })
 
-const showPaywall = computed(() => !isAuthPage.value && billingGate.requiresPayment.value)
+// `needs_onboarding` is handled by redirect (for the billing owner) or a
+// dedicated overlay (for other family members) — not the lapsed-subscription
+// paywall splash. See useBillingGate + watch below.
+const showPaywall = computed(() => {
+  if (isAuthPage.value) return false
+  if (!billingGate.requiresPayment.value) return false
+  return !billingGate.needsOnboarding.value
+})
+
+const showAwaitingOwner = computed(() => {
+  if (isAuthPage.value) return false
+  return billingGate.needsOnboarding.value && !billingGate.isBillingOwner.value
+})
+
+// Push the billing owner into the onboarding wizard whenever the backend says
+// the family hasn't subscribed yet. The wizard's BillingStep takes over from
+// there. Skip when already on /onboarding (avoids redirect loop) and when the
+// route hasn't resolved yet.
+watch(
+  [
+    () => billingGate.needsOnboarding.value,
+    () => billingGate.isBillingOwner.value,
+    () => route.name,
+  ],
+  ([needs, isOwner, routeName]) => {
+    if (!needs || !isOwner) return
+    if (!routeName) return
+    if (routeName === 'Onboarding') return
+    if (isAuthPage.value) return
+    router.push({ name: 'Onboarding' })
+  },
+  { immediate: true },
+)
 
 // Email verification banner
 const verificationDismissed = ref(false)

--- a/resources/js/composables/useBillingGate.js
+++ b/resources/js/composables/useBillingGate.js
@@ -4,12 +4,17 @@ import { useAuthStore } from '@/stores/auth'
 
 /**
  * SPA-side paywall gate for 70-I (#223). Reads the lightweight `family.billing`
- * block injected by AuthController::user() and exposes the four signals the
- * App.vue shell + SubscriptionPaywall.vue need.
+ * block injected by AuthController::user() and exposes the signals the App.vue
+ * shell + SubscriptionPaywall.vue need.
  *
  * Self-host and BILLING_ENABLED=false return the `family.billing === null`
  * shape from the server, so `requiresPayment` resolves false everywhere off
  * the hosted product.
+ *
+ * `needsOnboarding` is a special case (#245): the family exists and has a
+ * billing owner, but no Stripe customer. The SPA should redirect the owner to
+ * /onboarding (where BillingStep takes over) instead of showing the lapsed-
+ * subscription paywall overlay.
  */
 export function useBillingGate() {
   const auth = useAuthStore()
@@ -18,6 +23,7 @@ export function useBillingGate() {
   const billing = computed(() => family.value?.billing || null)
   const requiresPayment = computed(() => !!billing.value?.requires_payment)
   const paywallReason = computed(() => billing.value?.paywall_reason || null)
+  const needsOnboarding = computed(() => paywallReason.value === 'needs_onboarding')
   const isBillingOwner = computed(() => !!billing.value?.is_billing_owner)
   const billingOwnerName = computed(() => billing.value?.billing_owner_name || null)
   const cancelledEndsAt = computed(() => billing.value?.cancelled_ends_at || null)
@@ -25,6 +31,7 @@ export function useBillingGate() {
   return {
     requiresPayment,
     paywallReason,
+    needsOnboarding,
     isBillingOwner,
     billingOwnerName,
     cancelledEndsAt,

--- a/resources/js/services/api.js
+++ b/resources/js/services/api.js
@@ -45,6 +45,18 @@ api.interceptors.response.use(
       }
     }
 
+    // 402 = paywalled. Server-side gate (#264). Re-fetch the user payload so
+    // the SPA's billing state matches what the server believes; useBillingGate
+    // then mounts SubscriptionPaywall on the next tick.
+    if (error.response?.status === 402) {
+      const skip = error.config?.url?.includes('/user') || error.config?.url?.includes('/billing')
+      if (!skip) {
+        import('@/stores/auth')
+          .then(({ useAuthStore }) => useAuthStore().fetchUser())
+          .catch(() => {})
+      }
+    }
+
     // Return the error so it can be handled in the store/component
     return Promise.reject(error)
   }

--- a/routes/api.php
+++ b/routes/api.php
@@ -105,205 +105,213 @@ Route::prefix('v1')->group(function () {
             Route::delete('/', [FamilyController::class, 'deleteFamily'])->middleware('throttle:5,1');
         });
 
-        // Tags (module: tasks)
-        Route::prefix('/tags')->middleware('module:tasks')->group(function () {
-            Route::get('/', [TagController::class, 'index']);
-            Route::post('/', [TagController::class, 'store']);
-            Route::put('/{tag}', [TagController::class, 'update']);
-            Route::delete('/{tag}', [TagController::class, 'destroy']);
-        });
+        // Feature endpoints — gated server-side by the billing paywall (#264)
+        // in addition to per-module access checks. Keeps DevTools-bypassed
+        // paywall users from hitting the API directly.
+        Route::middleware('billing.required')->group(function () {
 
-        // Tasks (module: tasks)
-        Route::prefix('/tasks')->middleware('module:tasks')->group(function () {
-            Route::get('/', [TaskController::class, 'index']);
-            Route::post('/', [TaskController::class, 'store']);
-            Route::get('/{task}', [TaskController::class, 'show']);
-            Route::put('/{task}', [TaskController::class, 'update']);
-            Route::delete('/{task}', [TaskController::class, 'destroy']);
-            Route::patch('/{task}/complete', [TaskController::class, 'complete']);
-            Route::patch('/{task}/uncomplete', [TaskController::class, 'uncomplete']);
-        });
-
-        // Vault (module: vault)
-        Route::prefix('/vault')->middleware('module:vault')->group(function () {
-            Route::get('/categories', [VaultController::class, 'categories']);
-            Route::post('/categories', [VaultController::class, 'storeCategory']);
-            Route::put('/categories/{category}', [VaultController::class, 'updateCategory']);
-            Route::delete('/categories/{category}', [VaultController::class, 'destroyCategory']);
-            Route::get('/entries', [VaultController::class, 'index']);
-            Route::post('/entries', [VaultController::class, 'store']);
-            Route::get('/entries/{entry}', [VaultController::class, 'show']);
-            Route::put('/entries/{entry}', [VaultController::class, 'update']);
-            Route::delete('/entries/{entry}', [VaultController::class, 'destroy']);
-            Route::post('/entries/{entry}/permissions', [VaultController::class, 'grantPermission']);
-            Route::delete('/entries/{entry}/permissions/{user}', [VaultController::class, 'revokePermission']);
-            Route::post('/entries/{entry}/documents', [VaultController::class, 'uploadDocument']);
-            Route::get('/documents/{document}/download', [VaultController::class, 'downloadDocument']);
-            Route::delete('/documents/{document}', [VaultController::class, 'deleteDocument']);
-        });
-
-        // Calendar (module: calendar)
-        Route::prefix('/calendar')->middleware('module:calendar')->group(function () {
-            Route::get('/events', [CalendarController::class, 'events']);
-            Route::post('/events', [CalendarController::class, 'storeEvent']);
-            Route::put('/events/{familyEvent}', [CalendarController::class, 'updateEvent']);
-            Route::delete('/events/{familyEvent}', [CalendarController::class, 'destroyEvent']);
-            Route::get('/connections', [CalendarController::class, 'connections']);
-            Route::post('/connect', [CalendarController::class, 'connect']);
-            Route::delete('/connections/{connection}', [CalendarController::class, 'disconnect']);
-            Route::post('/subscribe', [CalendarController::class, 'subscribe']);
-            Route::post('/sync', [CalendarController::class, 'sync']);
-        });
-
-        // Chat (module: chat)
-        Route::prefix('/chat')->middleware('module:chat')->group(function () {
-            Route::post('/', [ChatController::class, 'send']);
-            Route::get('/history', [ChatController::class, 'history']);
-        });
-
-        // Points (module: points)
-        Route::prefix('/points')->middleware('module:points')->group(function () {
-            Route::get('/bank', [PointsController::class, 'bank']);
-            Route::get('/leaderboard', [PointsController::class, 'leaderboard']);
-            Route::get('/feed', [PointsController::class, 'feed']);
-            Route::post('/kudos', [PointsController::class, 'kudos']);
-            Route::post('/deduct', [PointsController::class, 'deduct']);
-            Route::get('/requests', [PointRequestController::class, 'index']);
-            Route::post('/request', [PointRequestController::class, 'store']);
-            Route::post('/requests/{pointRequest}/approve', [PointRequestController::class, 'approve']);
-            Route::post('/requests/{pointRequest}/deny', [PointRequestController::class, 'deny']);
-        });
-
-        // Rewards (module: points)
-        Route::prefix('/rewards')->middleware('module:points')->group(function () {
-            Route::get('/', [RewardsController::class, 'index']);
-            Route::post('/', [RewardsController::class, 'store']);
-            Route::put('/{reward}', [RewardsController::class, 'update']);
-            Route::delete('/{reward}', [RewardsController::class, 'destroy']);
-            Route::post('/{reward}/purchase', [RewardsController::class, 'purchase']);
-            Route::post('/{reward}/bid', [RewardsController::class, 'bid']);
-            Route::get('/{reward}/bids', [RewardsController::class, 'bids']);
-            Route::post('/{reward}/close-auction', [RewardsController::class, 'closeAuction']);
-            Route::post('/{reward}/cancel-auction', [RewardsController::class, 'cancelAuction']);
-            Route::get('/purchases', [RewardsController::class, 'purchases']);
-        });
-
-        // Badges (module: badges)
-        Route::prefix('/badges')->middleware('module:badges')->group(function () {
-            Route::get('/', [BadgesController::class, 'index']);
-            Route::post('/', [BadgesController::class, 'store']);
-            Route::put('/{badge}', [BadgesController::class, 'update']);
-            Route::delete('/{badge}', [BadgesController::class, 'destroy']);
-            Route::post('/{badge}/award', [BadgesController::class, 'award']);
-            Route::delete('/{badge}/revoke/{user}', [BadgesController::class, 'revoke']);
-            Route::get('/earned', [BadgesController::class, 'earned']);
-            Route::post('/easter-egg', [BadgesController::class, 'easterEgg']);
-        });
-
-        // Recipes (module: food)
-        Route::prefix('/recipes')->middleware('module:food')->group(function () {
-            Route::get('/', [RecipeController::class, 'index']);
-            Route::post('/', [RecipeController::class, 'store']);
-
-            // Import routes (rate-limited, parent-only via form request)
-            Route::middleware(['throttle:recipe-import'])->group(function () {
-                Route::post('/import/url', [RecipeController::class, 'importFromUrl']);
-                Route::post('/import/photo', [RecipeController::class, 'importFromPhoto']);
-                Route::post('/import/social', [RecipeController::class, 'importFromSocialMedia']);
+            // Tags (module: tasks)
+            Route::prefix('/tags')->middleware('module:tasks')->group(function () {
+                Route::get('/', [TagController::class, 'index']);
+                Route::post('/', [TagController::class, 'store']);
+                Route::put('/{tag}', [TagController::class, 'update']);
+                Route::delete('/{tag}', [TagController::class, 'destroy']);
             });
 
-            Route::post('/upload-image', [RecipeController::class, 'uploadImage']);
+            // Tasks (module: tasks)
+            Route::prefix('/tasks')->middleware('module:tasks')->group(function () {
+                Route::get('/', [TaskController::class, 'index']);
+                Route::post('/', [TaskController::class, 'store']);
+                Route::get('/{task}', [TaskController::class, 'show']);
+                Route::put('/{task}', [TaskController::class, 'update']);
+                Route::delete('/{task}', [TaskController::class, 'destroy']);
+                Route::patch('/{task}/complete', [TaskController::class, 'complete']);
+                Route::patch('/{task}/uncomplete', [TaskController::class, 'uncomplete']);
+            });
 
-            Route::get('/{recipe}', [RecipeController::class, 'show']);
-            Route::put('/{recipe}', [RecipeController::class, 'update']);
-            Route::delete('/{recipe}', [RecipeController::class, 'destroy']);
-            Route::post('/{recipe}/restore', [RecipeController::class, 'restore']);
-            Route::post('/{recipe}/favorite', [RecipeController::class, 'toggleFavorite']);
-            Route::get('/{recipe}/cook-logs', [RecipeController::class, 'cookLogs']);
-            Route::post('/{recipe}/cook-logs', [RecipeController::class, 'addCookLog']);
-            Route::post('/{recipe}/rate', [RecipeController::class, 'rate']);
-            Route::get('/{recipe}/ratings', [RecipeController::class, 'ratings']);
-        });
+            // Vault (module: vault)
+            Route::prefix('/vault')->middleware('module:vault')->group(function () {
+                Route::get('/categories', [VaultController::class, 'categories']);
+                Route::post('/categories', [VaultController::class, 'storeCategory']);
+                Route::put('/categories/{category}', [VaultController::class, 'updateCategory']);
+                Route::delete('/categories/{category}', [VaultController::class, 'destroyCategory']);
+                Route::get('/entries', [VaultController::class, 'index']);
+                Route::post('/entries', [VaultController::class, 'store']);
+                Route::get('/entries/{entry}', [VaultController::class, 'show']);
+                Route::put('/entries/{entry}', [VaultController::class, 'update']);
+                Route::delete('/entries/{entry}', [VaultController::class, 'destroy']);
+                Route::post('/entries/{entry}/permissions', [VaultController::class, 'grantPermission']);
+                Route::delete('/entries/{entry}/permissions/{user}', [VaultController::class, 'revokePermission']);
+                Route::post('/entries/{entry}/documents', [VaultController::class, 'uploadDocument']);
+                Route::get('/documents/{document}/download', [VaultController::class, 'downloadDocument']);
+                Route::delete('/documents/{document}', [VaultController::class, 'deleteDocument']);
+            });
 
-        // Shopping (module: food)
-        Route::prefix('/shopping')->middleware('module:food')->group(function () {
-            // Product catalog autocomplete (read-only global data)
-            Route::get('/catalog/search', [ShoppingListController::class, 'searchCatalog']);
+            // Calendar (module: calendar)
+            Route::prefix('/calendar')->middleware('module:calendar')->group(function () {
+                Route::get('/events', [CalendarController::class, 'events']);
+                Route::post('/events', [CalendarController::class, 'storeEvent']);
+                Route::put('/events/{familyEvent}', [CalendarController::class, 'updateEvent']);
+                Route::delete('/events/{familyEvent}', [CalendarController::class, 'destroyEvent']);
+                Route::get('/connections', [CalendarController::class, 'connections']);
+                Route::post('/connect', [CalendarController::class, 'connect']);
+                Route::delete('/connections/{connection}', [CalendarController::class, 'disconnect']);
+                Route::post('/subscribe', [CalendarController::class, 'subscribe']);
+                Route::post('/sync', [CalendarController::class, 'sync']);
+            });
 
-            // Staples
-            Route::get('/staples', [ShoppingListController::class, 'listStaples']);
-            Route::post('/staples', [ShoppingListController::class, 'addStaple']);
-            Route::put('/staples/{staple}', [ShoppingListController::class, 'updateStaple']);
-            Route::delete('/staples/{staple}', [ShoppingListController::class, 'removeStaple']);
-            Route::patch('/staples/{staple}/toggle', [ShoppingListController::class, 'toggleStaple']);
+            // Chat (module: chat)
+            Route::prefix('/chat')->middleware('module:chat')->group(function () {
+                Route::post('/', [ChatController::class, 'send']);
+                Route::get('/history', [ChatController::class, 'history']);
+            });
 
-            // Shopping items (accessed directly by item ID)
-            Route::put('/items/{shoppingItem}', [ShoppingListController::class, 'updateItem']);
-            Route::delete('/items/{shoppingItem}', [ShoppingListController::class, 'removeItem']);
-            Route::patch('/items/{shoppingItem}/check', [ShoppingListController::class, 'checkItem']);
-            Route::patch('/items/{shoppingItem}/uncheck', [ShoppingListController::class, 'uncheckItem']);
-            Route::patch('/items/{shoppingItem}/on-hand', [ShoppingListController::class, 'markOnHand']);
-            Route::patch('/items/{shoppingItem}/need', [ShoppingListController::class, 'clearOnHand']);
-            Route::post('/items/{shoppingItem}/move', [ShoppingListController::class, 'moveItem']);
-            Route::patch('/items/{shoppingItem}/toggle-recurring', [ShoppingListController::class, 'toggleRecurring']);
+            // Points (module: points)
+            Route::prefix('/points')->middleware('module:points')->group(function () {
+                Route::get('/bank', [PointsController::class, 'bank']);
+                Route::get('/leaderboard', [PointsController::class, 'leaderboard']);
+                Route::get('/feed', [PointsController::class, 'feed']);
+                Route::post('/kudos', [PointsController::class, 'kudos']);
+                Route::post('/deduct', [PointsController::class, 'deduct']);
+                Route::get('/requests', [PointRequestController::class, 'index']);
+                Route::post('/request', [PointRequestController::class, 'store']);
+                Route::post('/requests/{pointRequest}/approve', [PointRequestController::class, 'approve']);
+                Route::post('/requests/{pointRequest}/deny', [PointRequestController::class, 'deny']);
+            });
 
-            // Shopping lists
-            Route::get('/lists', [ShoppingListController::class, 'index']);
-            Route::post('/lists', [ShoppingListController::class, 'store']);
-            Route::get('/lists/{shoppingList}', [ShoppingListController::class, 'show']);
-            Route::put('/lists/{shoppingList}', [ShoppingListController::class, 'update']);
-            Route::delete('/lists/{shoppingList}', [ShoppingListController::class, 'destroy']);
-            Route::post('/lists/{shoppingList}/clear-checked', [ShoppingListController::class, 'clearChecked']);
-            Route::post('/lists/{shoppingList}/items', [ShoppingListController::class, 'addItem']);
-            Route::post('/lists/{shoppingList}/add-recipe', [ShoppingListController::class, 'addRecipeToList']);
-        });
+            // Rewards (module: points)
+            Route::prefix('/rewards')->middleware('module:points')->group(function () {
+                Route::get('/', [RewardsController::class, 'index']);
+                Route::post('/', [RewardsController::class, 'store']);
+                Route::put('/{reward}', [RewardsController::class, 'update']);
+                Route::delete('/{reward}', [RewardsController::class, 'destroy']);
+                Route::post('/{reward}/purchase', [RewardsController::class, 'purchase']);
+                Route::post('/{reward}/bid', [RewardsController::class, 'bid']);
+                Route::get('/{reward}/bids', [RewardsController::class, 'bids']);
+                Route::post('/{reward}/close-auction', [RewardsController::class, 'closeAuction']);
+                Route::post('/{reward}/cancel-auction', [RewardsController::class, 'cancelAuction']);
+                Route::get('/purchases', [RewardsController::class, 'purchases']);
+            });
 
-        // Meal Plans (module: food)
-        Route::prefix('/meal-plans')->middleware('module:food')->group(function () {
-            Route::get('/', [MealPlanController::class, 'index']);
-            Route::get('/current', [MealPlanController::class, 'current']);
-            Route::post('/', [MealPlanController::class, 'store']);
-            Route::get('/presets', [MealPlanController::class, 'presets']);
-            Route::post('/presets', [MealPlanController::class, 'storePreset']);
-            Route::put('/presets/{preset}', [MealPlanController::class, 'updatePreset']);
-            Route::delete('/presets/{preset}', [MealPlanController::class, 'deletePreset']);
-            Route::get('/{plan}', [MealPlanController::class, 'show']);
-            Route::post('/{plan}/entries', [MealPlanController::class, 'addEntry']);
-            Route::get('/{plan}/shopping-preview', [MealPlanController::class, 'previewShoppingList']);
-            Route::post('/{plan}/add-to-shopping-list', [MealPlanController::class, 'addToShoppingList']);
-            Route::post('/{plan}/generate-shopping-list', [MealPlanController::class, 'generateShoppingList']);
-        });
+            // Badges (module: badges)
+            Route::prefix('/badges')->middleware('module:badges')->group(function () {
+                Route::get('/', [BadgesController::class, 'index']);
+                Route::post('/', [BadgesController::class, 'store']);
+                Route::put('/{badge}', [BadgesController::class, 'update']);
+                Route::delete('/{badge}', [BadgesController::class, 'destroy']);
+                Route::post('/{badge}/award', [BadgesController::class, 'award']);
+                Route::delete('/{badge}/revoke/{user}', [BadgesController::class, 'revoke']);
+                Route::get('/earned', [BadgesController::class, 'earned']);
+                Route::post('/easter-egg', [BadgesController::class, 'easterEgg']);
+            });
 
-        // Meal Plan Entries (module: food) — top-level for entry-specific operations
-        Route::prefix('/meal-plan-entries')->middleware('module:food')->group(function () {
-            Route::put('/{entry}', [MealPlanController::class, 'updateEntry']);
-            Route::delete('/{entry}', [MealPlanController::class, 'removeEntry']);
-            Route::post('/{entry}/move', [MealPlanController::class, 'moveEntry']);
-        });
+            // Recipes (module: food)
+            Route::prefix('/recipes')->middleware('module:food')->group(function () {
+                Route::get('/', [RecipeController::class, 'index']);
+                Route::post('/', [RecipeController::class, 'store']);
 
-        // Restaurants (module: food)
-        Route::prefix('/restaurants')->middleware('module:food')->group(function () {
-            Route::get('/', [RestaurantController::class, 'index']);
-            Route::post('/', [RestaurantController::class, 'store']);
-            Route::post('/import', [RestaurantController::class, 'import']);
-            Route::post('/upload-image', [RestaurantController::class, 'uploadImage']);
-            Route::get('/{restaurant}', [RestaurantController::class, 'show']);
-            Route::put('/{restaurant}', [RestaurantController::class, 'update']);
-            Route::delete('/{restaurant}', [RestaurantController::class, 'destroy']);
-            Route::post('/{restaurant}/rate', [RestaurantController::class, 'rate']);
-        });
+                // Import routes (rate-limited, parent-only via form request)
+                Route::middleware(['throttle:recipe-import'])->group(function () {
+                    Route::post('/import/url', [RecipeController::class, 'importFromUrl']);
+                    Route::post('/import/photo', [RecipeController::class, 'importFromPhoto']);
+                    Route::post('/import/social', [RecipeController::class, 'importFromSocialMedia']);
+                });
 
-        // Featured Events (unified — reads from family_events table)
-        Route::prefix('/featured-events')->group(function () {
-            Route::get('/', [FeaturedEventController::class, 'index']);
-            Route::get('/countdown', [FeaturedEventController::class, 'countdown']);
-            Route::post('/', [FeaturedEventController::class, 'store']);
-            Route::put('/{familyEvent}', [FeaturedEventController::class, 'update']);
-            Route::put('/{familyEvent}/countdown', [FeaturedEventController::class, 'setCountdown']);
-            Route::delete('/{familyEvent}', [FeaturedEventController::class, 'destroy']);
-        });
+                Route::post('/upload-image', [RecipeController::class, 'uploadImage']);
 
-        // Settings
+                Route::get('/{recipe}', [RecipeController::class, 'show']);
+                Route::put('/{recipe}', [RecipeController::class, 'update']);
+                Route::delete('/{recipe}', [RecipeController::class, 'destroy']);
+                Route::post('/{recipe}/restore', [RecipeController::class, 'restore']);
+                Route::post('/{recipe}/favorite', [RecipeController::class, 'toggleFavorite']);
+                Route::get('/{recipe}/cook-logs', [RecipeController::class, 'cookLogs']);
+                Route::post('/{recipe}/cook-logs', [RecipeController::class, 'addCookLog']);
+                Route::post('/{recipe}/rate', [RecipeController::class, 'rate']);
+                Route::get('/{recipe}/ratings', [RecipeController::class, 'ratings']);
+            });
+
+            // Shopping (module: food)
+            Route::prefix('/shopping')->middleware('module:food')->group(function () {
+                // Product catalog autocomplete (read-only global data)
+                Route::get('/catalog/search', [ShoppingListController::class, 'searchCatalog']);
+
+                // Staples
+                Route::get('/staples', [ShoppingListController::class, 'listStaples']);
+                Route::post('/staples', [ShoppingListController::class, 'addStaple']);
+                Route::put('/staples/{staple}', [ShoppingListController::class, 'updateStaple']);
+                Route::delete('/staples/{staple}', [ShoppingListController::class, 'removeStaple']);
+                Route::patch('/staples/{staple}/toggle', [ShoppingListController::class, 'toggleStaple']);
+
+                // Shopping items (accessed directly by item ID)
+                Route::put('/items/{shoppingItem}', [ShoppingListController::class, 'updateItem']);
+                Route::delete('/items/{shoppingItem}', [ShoppingListController::class, 'removeItem']);
+                Route::patch('/items/{shoppingItem}/check', [ShoppingListController::class, 'checkItem']);
+                Route::patch('/items/{shoppingItem}/uncheck', [ShoppingListController::class, 'uncheckItem']);
+                Route::patch('/items/{shoppingItem}/on-hand', [ShoppingListController::class, 'markOnHand']);
+                Route::patch('/items/{shoppingItem}/need', [ShoppingListController::class, 'clearOnHand']);
+                Route::post('/items/{shoppingItem}/move', [ShoppingListController::class, 'moveItem']);
+                Route::patch('/items/{shoppingItem}/toggle-recurring', [ShoppingListController::class, 'toggleRecurring']);
+
+                // Shopping lists
+                Route::get('/lists', [ShoppingListController::class, 'index']);
+                Route::post('/lists', [ShoppingListController::class, 'store']);
+                Route::get('/lists/{shoppingList}', [ShoppingListController::class, 'show']);
+                Route::put('/lists/{shoppingList}', [ShoppingListController::class, 'update']);
+                Route::delete('/lists/{shoppingList}', [ShoppingListController::class, 'destroy']);
+                Route::post('/lists/{shoppingList}/clear-checked', [ShoppingListController::class, 'clearChecked']);
+                Route::post('/lists/{shoppingList}/items', [ShoppingListController::class, 'addItem']);
+                Route::post('/lists/{shoppingList}/add-recipe', [ShoppingListController::class, 'addRecipeToList']);
+            });
+
+            // Meal Plans (module: food)
+            Route::prefix('/meal-plans')->middleware('module:food')->group(function () {
+                Route::get('/', [MealPlanController::class, 'index']);
+                Route::get('/current', [MealPlanController::class, 'current']);
+                Route::post('/', [MealPlanController::class, 'store']);
+                Route::get('/presets', [MealPlanController::class, 'presets']);
+                Route::post('/presets', [MealPlanController::class, 'storePreset']);
+                Route::put('/presets/{preset}', [MealPlanController::class, 'updatePreset']);
+                Route::delete('/presets/{preset}', [MealPlanController::class, 'deletePreset']);
+                Route::get('/{plan}', [MealPlanController::class, 'show']);
+                Route::post('/{plan}/entries', [MealPlanController::class, 'addEntry']);
+                Route::get('/{plan}/shopping-preview', [MealPlanController::class, 'previewShoppingList']);
+                Route::post('/{plan}/add-to-shopping-list', [MealPlanController::class, 'addToShoppingList']);
+                Route::post('/{plan}/generate-shopping-list', [MealPlanController::class, 'generateShoppingList']);
+            });
+
+            // Meal Plan Entries (module: food) — top-level for entry-specific operations
+            Route::prefix('/meal-plan-entries')->middleware('module:food')->group(function () {
+                Route::put('/{entry}', [MealPlanController::class, 'updateEntry']);
+                Route::delete('/{entry}', [MealPlanController::class, 'removeEntry']);
+                Route::post('/{entry}/move', [MealPlanController::class, 'moveEntry']);
+            });
+
+            // Restaurants (module: food)
+            Route::prefix('/restaurants')->middleware('module:food')->group(function () {
+                Route::get('/', [RestaurantController::class, 'index']);
+                Route::post('/', [RestaurantController::class, 'store']);
+                Route::post('/import', [RestaurantController::class, 'import']);
+                Route::post('/upload-image', [RestaurantController::class, 'uploadImage']);
+                Route::get('/{restaurant}', [RestaurantController::class, 'show']);
+                Route::put('/{restaurant}', [RestaurantController::class, 'update']);
+                Route::delete('/{restaurant}', [RestaurantController::class, 'destroy']);
+                Route::post('/{restaurant}/rate', [RestaurantController::class, 'rate']);
+            });
+
+            // Featured Events (unified — reads from family_events table)
+            Route::prefix('/featured-events')->group(function () {
+                Route::get('/', [FeaturedEventController::class, 'index']);
+                Route::get('/countdown', [FeaturedEventController::class, 'countdown']);
+                Route::post('/', [FeaturedEventController::class, 'store']);
+                Route::put('/{familyEvent}', [FeaturedEventController::class, 'update']);
+                Route::put('/{familyEvent}/countdown', [FeaturedEventController::class, 'setCountdown']);
+                Route::delete('/{familyEvent}', [FeaturedEventController::class, 'destroy']);
+            });
+
+        }); // end billing.required group (#264)
+
+        // Settings — NOT under billing.required so paywalled users can still
+        // export their data and delete their account (GDPR/CCPA, #265).
         Route::prefix('/settings')->group(function () {
             Route::get('/', [SettingsController::class, 'index']);
             Route::put('/', [SettingsController::class, 'update']);


### PR DESCRIPTION
## Summary

Targets `staging` so we can shake this out with `BILLING_ENABLED=true` before flipping prod. Coordinated with [#267](https://github.com/gregqualls/kinhold/pull/267) — these five issues all touch the paywall path and need to ship together to avoid partial states.

- **#245** — Existing families (no Stripe customer, billing_owner_id set) now return paywall reason `needs_onboarding`. The SPA redirects the billing owner to the onboarding wizard so they land on BillingStep; non-owner family members see a "Subscription pending" overlay until the owner subscribes. Demo families and `BILLING_ENABLED=false` instances bypass entirely.
- **#262** — `handleCheckoutSessionCompleted` now sets `invoice_settings.default_payment_method` on the customer using the PM from the checkout session (or falling back to the subscription's default). Wrapped in try/catch so a Stripe API blip can't trigger webhook retry storms.
- **#264** — New `BillingRequired` middleware (alias `billing.required`) returns 402 when the family's subscription has lapsed. Applied to all feature route groups (tasks, vault, calendar, chat, points, rewards, badges, food, shopping, meal-plans, restaurants, featured-events). Auth, billing management, settings (incl. GDPR), onboarding, family, push, and MCP routes are intentionally outside the gate. Axios interceptor refreshes `family.billing` on 402 so the SPA re-mounts the paywall.
- **#265** — GDPR data export (`POST /api/v1/settings/account/data-export`) and account deletion (`DELETE /api/v1/account`) are confirmed outside `billing.required` via `php artisan route:list -v`. Paywalled users can still exercise their right to access and erasure.

> **Follow-up flagged separately:** `AccountDeletionService` does not currently cancel Stripe subscriptions when a billing owner deletes their account. Spawned a session task for that.

## Test plan

After merge, on the staging Upsun environment:

- [ ] Log in as an existing user with no `stripe_id` (e.g., Greg's account on the cloned-from-prod staging DB) — billing owner is redirected to `/onboarding` at BillingStep
- [ ] Log in as a non-billing-owner member of the same family — sees "Subscription pending" overlay, no paywall splash
- [ ] Demo family login still works without any overlay
- [ ] Complete a Stripe Checkout — Dashboard → Customer → Payment Methods shows a default
- [ ] DevTools: remove paywall overlay from DOM while in `past_due` state, fire `GET /api/v1/tasks` — server returns 402 and Axios re-renders the paywall
- [ ] While paywalled (`past_due`), call `POST /api/v1/settings/account/data-export` — returns 200 + zip
- [ ] While paywalled, call `DELETE /api/v1/account` — succeeds (note: Stripe sub still tickling, see follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)