### PR TITLE
fix: v1.9.0 batch-2 onboarding polish (#249, #250, #252, #254, #258, #259, #260)

### DIFF
--- a/resources/js/components/dashboard/WidgetPickerModal.vue
+++ b/resources/js/components/dashboard/WidgetPickerModal.vue
@@ -169,7 +169,7 @@ const categoryLabels = {
   calendar: 'Calendar',
   points: 'Points & Gamification',
   rewards: 'Rewards',
-  badges: 'Badges',
+  badges: 'Achievement Badges',
 }
 
 function categoryLabel(key) {

--- a/resources/js/components/dashboard/widgetRegistry.js
+++ b/resources/js/components/dashboard/widgetRegistry.js
@@ -105,7 +105,7 @@ export const widgetTypes = {
   },
   'badge-collection': {
     component: () => import('./widgets/BadgesWidget.vue'),
-    name: 'Badges',
+    name: 'Achievement Badges',
     description: 'Badge collection with earned status',
     icon: 'ShieldCheckIcon',
     category: 'badges',

--- a/resources/js/components/dashboard/widgets/BadgesWidget.vue
+++ b/resources/js/components/dashboard/widgets/BadgesWidget.vue
@@ -4,7 +4,7 @@
     <div class="flex items-center justify-between mb-3 flex-shrink-0">
       <h3 class="text-sm font-semibold text-ink-primary flex items-center gap-2">
         <ShieldCheckIcon class="w-4 h-4 text-accent-lavender-bold" />
-        {{ config.title || 'Badges' }}
+        {{ config.title || 'Achievement Badges' }}
       </h3>
       <RouterLink
         to="/badges"

--- a/resources/js/components/layout/MoreSheet.vue
+++ b/resources/js/components/layout/MoreSheet.vue
@@ -54,7 +54,7 @@ const { enabledModules } = storeToRefs(authStore)
 const ALL_ITEMS = [
   { key: 'points',   label: 'Points',   to: '/points',         icon: TrophyIcon,               module: 'points' },
   { key: 'rewards',  label: 'Rewards',  to: '/points/rewards', icon: GiftIcon,                 module: 'points' },
-  { key: 'badges',   label: 'Badges',   to: '/badges',         icon: ShieldCheckIcon,          module: 'badges' },
+  { key: 'badges',   label: 'Achievements', to: '/badges',     icon: ShieldCheckIcon,          module: 'badges' },
   { key: 'vault',    label: 'Vault',    to: '/vault',          icon: LockClosedIcon,           module: 'vault' },
   { key: 'settings', label: 'Settings', to: '/settings',       icon: Cog6ToothIcon,            module: null },
 ]

--- a/resources/js/components/layout/Sidebar.vue
+++ b/resources/js/components/layout/Sidebar.vue
@@ -97,7 +97,7 @@ const navItems = [
   { key: 'shopping',  label: 'Shopping',  to: '/shopping',  icon: ClipboardDocumentListIcon, module: 'food' },
   { key: 'points',    label: 'Points',    to: '/points',    icon: TrophyIcon, module: 'points' },
   { key: 'rewards',   label: 'Rewards',   to: '/points/rewards', icon: GiftIcon, module: 'points' },
-  { key: 'badges',    label: 'Badges',    to: '/badges',    icon: ShieldCheckIcon, module: 'badges' },
+  { key: 'badges',    label: 'Achievements', to: '/badges', icon: ShieldCheckIcon, module: 'badges' },
   { key: 'vault',     label: 'Vault',     to: '/vault',     icon: LockClosedIcon, module: 'vault' },
 ]
 

--- a/resources/js/views/onboarding/OnboardingView.vue
+++ b/resources/js/views/onboarding/OnboardingView.vue
@@ -19,7 +19,13 @@
 
     <!-- Step Content -->
     <div class="flex-1 flex flex-col px-4 pb-4 max-w-lg mx-auto w-full">
-      <Transition name="step-fade" mode="out-in">
+      <!-- Hold off on rendering steps until status is fetched + Stripe-return
+           routing is resolved (#258). Otherwise step 0 flashes for ~200ms after
+           a Stripe Checkout success before we jump to CompleteStep. -->
+      <div v-if="!isReady" class="flex-1 flex items-center justify-center">
+        <div class="w-6 h-6 rounded-full border-2 border-accent-lavender-bold/30 border-t-accent-lavender-bold animate-spin"></div>
+      </div>
+      <Transition v-else name="step-fade" mode="out-in">
         <component :is="activeSteps[store.currentStep]" :key="store.currentStep" />
       </Transition>
 
@@ -88,6 +94,7 @@ const route = useRoute()
 const authStore = useAuthStore()
 const store = useOnboardingStore()
 const stepLoading = ref(false)
+const isReady = ref(false)
 
 // Parents get the full wizard; joining members get a simplified flow.
 // BillingStep is appended for the billing owner (who is always a parent
@@ -166,6 +173,9 @@ onMounted(async () => {
     const billingIdx = activeSteps.value.indexOf(BillingStep)
     if (billingIdx >= 0) store.goToStep(billingIdx)
   }
+
+  // Step routing is now correct — render.
+  isReady.value = true
 })
 </script>
 

--- a/resources/js/views/onboarding/steps/CompleteStep.vue
+++ b/resources/js/views/onboarding/steps/CompleteStep.vue
@@ -28,26 +28,76 @@
 </template>
 
 <script setup>
-import { computed } from 'vue'
+import { computed, onMounted } from 'vue'
 import { useOnboardingStore } from '@/stores/onboarding'
+import { useAuthStore } from '@/stores/auth'
+import { useBillingStore } from '@/stores/billing'
 import { CheckIcon, CheckCircleIcon, MinusCircleIcon } from '@heroicons/vue/24/outline'
 
 const store = useOnboardingStore()
+const authStore = useAuthStore()
+const billing = useBillingStore()
 
-const summaryItems = computed(() => [
-  {
-    label: 'Family created',
-    done: true,
-  },
-  {
-    label: 'Calendar connected',
-    done: store.status?.calendar_connected || false,
-  },
-  {
-    label: store.selectedPresets.size > 0
-      ? `${store.selectedPresets.size} tag${store.selectedPresets.size > 1 ? 's' : ''} created`
-      : 'Tags',
-    done: store.selectedPresets.size > 0,
-  },
-])
+const billingEnabled = computed(() => !!authStore.appConfig?.billing_enabled)
+const isBillingOwner = computed(() => authStore.user?.id === authStore.family?.billing_owner_id)
+const showBilling = computed(() => billingEnabled.value && isBillingOwner.value && !authStore.family?.is_demo)
+
+const onTrial = computed(() => !!billing.summary?.on_trial)
+const trialEndsAt = computed(() => billing.summary?.trial_ends_at)
+const subStatus = computed(() => billing.summary?.status)
+const aiTier = computed(() => billing.summary?.ai_tier?.plan || null)
+const aiTierLabel = computed(() => {
+  const slug = aiTier.value
+  if (!slug) return null
+  const tiers = billing.summary?.ai_tier?.tiers || []
+  const tier = tiers.find(t => t.slug === slug)
+  if (!tier) return slug.charAt(0).toUpperCase() + slug.slice(1)
+  return `AI ${tier.name} — ${tier.daily_messages} msg/day`
+})
+
+function formatDate(iso) {
+  if (!iso) return ''
+  try {
+    return new Date(iso).toLocaleDateString(undefined, {
+      year: 'numeric', month: 'short', day: 'numeric',
+    })
+  } catch {
+    return iso
+  }
+}
+
+const summaryItems = computed(() => {
+  const items = [
+    { label: 'Family created', done: true },
+    { label: 'Calendar connected', done: store.status?.calendar_connected || false },
+    {
+      label: store.selectedPresets.size > 0
+        ? `${store.selectedPresets.size} tag${store.selectedPresets.size > 1 ? 's' : ''} created`
+        : 'Tags',
+      done: store.selectedPresets.size > 0,
+    },
+  ]
+
+  if (showBilling.value && (subStatus.value === 'trialing' || subStatus.value === 'active')) {
+    if (onTrial.value && trialEndsAt.value) {
+      items.push({
+        label: `Free trial started — ends ${formatDate(trialEndsAt.value)}`,
+        done: true,
+      })
+    } else if (subStatus.value === 'active') {
+      items.push({ label: 'Subscription active', done: true })
+    }
+    if (aiTierLabel.value) {
+      items.push({ label: `${aiTierLabel.value} active`, done: true })
+    }
+  }
+
+  return items
+})
+
+onMounted(async () => {
+  if (showBilling.value) {
+    try { await billing.fetch() } catch { /* surface inline if needed */ }
+  }
+})
 </script>

--- a/resources/js/views/onboarding/steps/FeaturesExplainerStep.vue
+++ b/resources/js/views/onboarding/steps/FeaturesExplainerStep.vue
@@ -101,7 +101,7 @@ const allFeatures = [
   },
   {
     key: 'badges',
-    name: 'Badges',
+    name: 'Achievement Badges',
     icon: StarIcon,
     explainer: 'Unlock badges by hitting milestones — complete tasks, build streaks, earn points. Some badges are hidden until you discover them.',
   },

--- a/resources/js/views/onboarding/steps/FeaturesStep.vue
+++ b/resources/js/views/onboarding/steps/FeaturesStep.vue
@@ -122,8 +122,8 @@ const features = [
   },
   {
     key: 'badges',
-    name: 'Badges',
-    description: 'Achievements that unlock automatically — task streaks, point milestones, and more. Parents can also create and award custom badges.',
+    name: 'Achievement Badges',
+    description: 'Unlock automatically — task streaks, point milestones, and more. Parents can also create and award custom badges.',
     icon: StarIcon,
   },
   {

--- a/resources/js/views/onboarding/steps/InviteStep.vue
+++ b/resources/js/views/onboarding/steps/InviteStep.vue
@@ -9,6 +9,35 @@
       </p>
     </div>
 
+    <!-- Reassurance: optional step (#254) -->
+    <KinFlatCard padding="sm" class="mb-4 bg-surface-sunken">
+      <p class="text-xs text-ink-secondary leading-relaxed">
+        You can do this anytime — many families fill in their calendar, tasks, and recipes first so the rest of the household joins a hub that already feels like home. Skip this step if you'd rather come back to it.
+      </p>
+    </KinFlatCard>
+
+    <!-- Existing family members (#260) -->
+    <div v-if="existingMembers.length > 0" class="mb-4 space-y-2">
+      <p class="text-xs font-semibold uppercase tracking-wide text-ink-tertiary">Already in your family</p>
+      <KinFlatCard
+        v-for="member in existingMembers"
+        :key="member.id"
+        padding="sm"
+        class="bg-surface-sunken"
+      >
+        <div class="flex items-center gap-3">
+          <div class="w-8 h-8 rounded-full flex items-center justify-center text-sm font-semibold text-white flex-shrink-0" :style="{ backgroundColor: '#7B6B9C' }">
+            {{ member.name.charAt(0).toUpperCase() }}
+          </div>
+          <div class="flex-1 min-w-0">
+            <p class="text-sm font-medium text-ink-primary">{{ member.name }}</p>
+            <p class="text-xs text-ink-secondary">{{ (member.family_role || member.role) === 'parent' ? 'Parent' : 'Child' }}{{ member.is_managed ? ' (managed)' : '' }}</p>
+          </div>
+          <CheckCircleIcon class="w-5 h-5 text-status-success flex-shrink-0" />
+        </div>
+      </KinFlatCard>
+    </div>
+
     <!-- Added members list -->
     <div v-if="addedMembers.length > 0" class="mb-4 space-y-2">
       <KinFlatCard
@@ -137,6 +166,13 @@ const isParent = authStore.isParent
 const inviteCode = computed(() => store.status?.invite_code || authStore.family?.invite_code)
 const copied = ref(false)
 const showingInviteCode = ref(false)
+
+// Members already on the family — shown when restarting onboarding so the user
+// sees state, not a blank slate (#260). Excludes the current user.
+const existingMembers = computed(() => {
+  const members = authStore.family?.members || []
+  return members.filter(m => m.id !== authStore.user?.id)
+})
 
 const memberName = ref('')
 const memberEmail = ref('')

--- a/resources/js/views/onboarding/steps/TagsStep.vue
+++ b/resources/js/views/onboarding/steps/TagsStep.vue
@@ -2,7 +2,7 @@
   <div class="flex-1 flex flex-col">
     <div class="text-center mb-6">
       <h1 class="text-2xl font-heading font-bold text-ink-primary mb-2">
-        Organize With Tags
+        Organize Tasks With Tags
       </h1>
       <p class="text-base text-ink-secondary">
         Tags help you filter and group tasks. Pick some to get started.
@@ -42,7 +42,7 @@
 </template>
 
 <script setup>
-import { ref, inject } from 'vue'
+import { ref, inject, onMounted } from 'vue'
 import { useOnboardingStore } from '@/stores/onboarding'
 import api from '@/services/api'
 import KinFlatCard from '@/components/design-system/KinFlatCard.vue'
@@ -60,11 +60,20 @@ const presets = [
   { name: 'Errands', color: '#7B6B9C', description: 'Things to do outside' },
 ]
 
+// Track tags that already exist on the family so we (a) don't try to create
+// duplicates on Continue and (b) show them as selected in the UI when the user
+// re-runs onboarding from settings (#260).
+const existingTagNames = ref(new Set())
+
 function isSelected(name) {
-  return store.selectedPresets.has(name)
+  return store.selectedPresets.has(name) || existingTagNames.value.has(name)
 }
 
 function togglePreset(name) {
+  // Tags that already exist on the family are read-only — toggling them off
+  // would imply deletion, which onboarding shouldn't do.
+  if (existingTagNames.value.has(name)) return
+
   const updated = new Set(store.selectedPresets)
   if (updated.has(name)) {
     updated.delete(name)
@@ -81,6 +90,8 @@ registerContinue(async () => {
   error.value = ''
   try {
     for (const presetName of store.selectedPresets) {
+      // Skip presets that already exist on the family (re-running onboarding).
+      if (existingTagNames.value.has(presetName)) continue
       const preset = presets.find(p => p.name === presetName)
       if (preset) {
         await api.post('/tags', {
@@ -96,6 +107,16 @@ registerContinue(async () => {
     return false
   } finally {
     setStepLoading(false)
+  }
+})
+
+onMounted(async () => {
+  try {
+    const res = await api.get('/tags', { params: { scope: 'task' } })
+    const tags = res.data?.data || res.data || []
+    existingTagNames.value = new Set(tags.map(t => t.name))
+  } catch {
+    // Non-fatal — leave the existing-tag set empty and let the user start fresh.
   }
 })
 </script>

--- a/resources/js/views/onboarding/steps/WelcomeStep.vue
+++ b/resources/js/views/onboarding/steps/WelcomeStep.vue
@@ -14,7 +14,7 @@
         v-model="familyName"
         type="text"
         label="Family Name"
-        placeholder="The Qualls Family"
+        placeholder="e.g. The Smith Family"
         :disabled="!isParent"
       />
 
@@ -40,8 +40,12 @@ const authStore = useAuthStore()
 const { setStepLoading, registerContinue } = inject('onboarding')
 
 const isParent = authStore.isParent
-const familyName = ref('')
-const timezone = ref(Intl.DateTimeFormat().resolvedOptions().timeZone)
+// Pre-fill from auth store immediately (it's already loaded from /api/v1/user
+// before the wizard mounts). store.status hydrates a moment later via the
+// onMounted hook and refreshes this value if the server has a more recent
+// name.
+const familyName = ref(authStore.family?.name || '')
+const timezone = ref(authStore.user?.timezone || Intl.DateTimeFormat().resolvedOptions().timeZone)
 
 const commonTimezones = [
   'America/New_York',

--- a/resources/js/views/settings/SettingsView.vue
+++ b/resources/js/views/settings/SettingsView.vue
@@ -1803,7 +1803,7 @@ const availableModules = [
   { id: 'vault', name: 'Family Vault', description: 'Secure information storage' },
   { id: 'chat', name: 'Kinhold AI', description: 'AI-powered assistant' },
   { id: 'points', name: 'Points & Rewards', description: 'Earn points, give kudos, purchase rewards' },
-  { id: 'badges', name: 'Badges', description: 'Achievement badges and milestones' },
+  { id: 'badges', name: 'Achievement Badges', description: 'Earned by completing tasks, hitting streaks, and discovering hidden milestones' },
   { id: 'avatars', name: 'Avatar Changes', description: 'Who can change profile avatars' },
 ]
 const tasksPointsModules = computed(() =>


### PR DESCRIPTION
## Summary

Seven onboarding-wizard polish issues from the v1.9.0 staging smoke test.

- **#249** Family name pre-fills from auth store on the welcome step. Placeholder is generic ("e.g. The Smith Family") instead of leaking "The Qualls Family".
- **#250** Tags step heading: "Organize With Tags" → "Organize Tasks With Tags".
- **#252** Sweep of user-facing "Badges" → "Achievement Badges" (or short "Achievements" in tight nav contexts). Internal identifiers/routes unchanged.
- **#254** Invite step opens with reassurance copy that the step is optional and many families set up content first.
- **#258** Holds back step rendering until status fetch + Stripe return routing resolve. No more flash of step 0 after successful Checkout.
- **#259** CompleteStep adds trial-end and AI tier confirmation rows when the user just subscribed.
- **#260** TagsStep pre-loads existing family tags and shows matching presets as already-selected (read-only). InviteStep shows existing members above the add-member form.

## Test plan

On the staging Upsun environment after merge:

- [ ] Register a new family — WelcomeStep pre-fills the name you typed on /register, placeholder reads "e.g. The Smith Family"
- [ ] Reach TagsStep — heading reads "Organize Tasks With Tags"
- [ ] Reach InviteStep — opens with the reassurance message and (if any members already exist) shows them above the form
- [ ] Sidebar / More Sheet show "Achievements", widget picker shows "Achievement Badges"
- [ ] Onboarding FeaturesStep shows "Achievement Badges" with updated description
- [ ] Settings → Modules shows "Achievement Badges"
- [ ] Complete a Stripe Checkout — wizard does not flash step 1 before landing on Complete; Complete shows trial-end date and AI tier
- [ ] Restart onboarding from Settings — TagsStep shows existing tags as locked-selected, InviteStep shows existing members at top

🤖 Generated with [Claude Code](https://claude.com/claude-code)