### PR TITLE
fix: cancel subscription uses styled modal (#263)

### DIFF
--- a/resources/js/components/billing/BillingPanel.vue
+++ b/resources/js/components/billing/BillingPanel.vue
@@ -202,6 +202,30 @@
         </BaseButton>
       </template>
     </BaseModal>
+
+    <!-- Cancel-subscription confirmation (#263) — replaces window.confirm. -->
+    <BaseModal
+      :show="showCancelConfirm"
+      title="Cancel your subscription?"
+      size="md"
+      @close="showCancelConfirm = false"
+    >
+      <p class="text-sm text-ink-primary">
+        Your subscription stays active until the end of the current billing period
+        <template v-if="billing.summary.ends_at || billing.summary.trial_ends_at">
+          (<strong>{{ formatDate(billing.summary.ends_at || billing.summary.trial_ends_at) }}</strong>)
+        </template>.
+      </p>
+      <p class="text-xs text-ink-secondary mt-2">
+        You can resume any time before then. After that date you'll lose access to hosted features unless you start a new subscription.
+      </p>
+      <template #footer>
+        <BaseButton variant="ghost" :loading="billing.loading" @click="showCancelConfirm = false">Keep subscription</BaseButton>
+        <BaseButton variant="danger" :loading="billing.loading" @click="confirmCancel">
+          Cancel subscription
+        </BaseButton>
+      </template>
+    </BaseModal>
   </div>
 </template>
 
@@ -334,10 +358,14 @@ async function onPortal() {
   }
 }
 
-async function onCancel() {
-  if (!window.confirm('Cancel your subscription at the end of the current billing period?')) {
-    return
-  }
+const showCancelConfirm = ref(false)
+
+function onCancel() {
+  showCancelConfirm.value = true
+}
+
+async function confirmCancel() {
+  showCancelConfirm.value = false
   try {
     await billing.cancel()
   } catch {


### PR DESCRIPTION
## Summary

Replaces the lone `window.confirm()` in the SPA (BillingPanel cancel-subscription flow) with a `BaseModal`. Matches the existing trial-end confirmation modal pattern in the same file. Modal includes the end-of-period date and uses the danger button variant.

Verified by grep — no other `window.confirm` / unstyled `confirm(` calls remain in `resources/js/`.

## Test plan

- [ ] On a hosted instance with an active subscription, click Cancel subscription in Settings → Billing
- [ ] Styled modal opens with end-of-period date and "Keep subscription" / "Cancel subscription" buttons
- [ ] Clicking the danger Cancel button cancels and closes; clicking Keep dismisses without cancelling
- [ ] Resume flow still works for grace-period subs (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)