### PR TITLE
fix: KinModalSheet body scrolls, footer pinned (#246)

### DIFF
--- a/resources/js/components/design-system/KinModalSheet.vue
+++ b/resources/js/components/design-system/KinModalSheet.vue
@@ -67,7 +67,7 @@ onBeforeUnmount(() => {
 
 const widthStyle = computed(() => {
   if (props.size === 'sm') return { maxWidth: '380px' }
-  if (props.size === 'lg') return { maxWidth: '640px' }
+  if (props.size === 'lg') return { maxWidth: '720px' }
   return { maxWidth: props.desktopWidth }
 })
 </script>
@@ -93,7 +93,7 @@ const widthStyle = computed(() => {
         <Transition name="kin-ms-surface" appear>
           <div
             v-if="modelValue"
-            class="kin-ms-surface relative w-full md:w-auto"
+            class="kin-ms-surface relative w-full md:w-auto flex flex-col max-h-[90vh] md:max-h-[85vh]"
             :class="[
               'rounded-t-sheet md:rounded-card',
               'bg-surface-overlay',
@@ -101,7 +101,7 @@ const widthStyle = computed(() => {
             :style="widthStyle"
           >
             <!-- Mobile grab handle -->
-            <div class="md:hidden flex justify-center pt-3 pb-1" aria-hidden="true">
+            <div class="md:hidden flex justify-center pt-3 pb-1 flex-shrink-0" aria-hidden="true">
               <div class="w-9 h-1 rounded-full bg-border-strong"></div>
             </div>
 
@@ -109,7 +109,7 @@ const widthStyle = computed(() => {
             <slot name="header">
               <div
                 v-if="title"
-                class="flex items-center justify-between px-5 pt-4 md:pt-5 pb-3 border-b border-border-subtle"
+                class="flex items-center justify-between px-5 pt-4 md:pt-5 pb-3 border-b border-border-subtle flex-shrink-0"
               >
                 <p class="text-[14px] font-semibold text-ink-primary">{{ title }}</p>
                 <button
@@ -126,15 +126,16 @@ const widthStyle = computed(() => {
               </div>
             </slot>
 
-            <!-- Body -->
-            <div class="px-5 py-4 text-ink-secondary text-[13px]">
+            <!-- Body — scrolls when content overflows the surface (#246) -->
+            <div class="px-5 py-4 text-ink-secondary text-[13px] overflow-y-auto flex-1 min-h-0">
               <slot></slot>
             </div>
 
-            <!-- Footer (actions) -->
+            <!-- Footer (actions) — pinned to surface bottom so submit/cancel
+                 buttons stay reachable even when the body scrolls. -->
             <div
               v-if="$slots.actions"
-              class="px-5 pb-5 pt-1"
+              class="px-5 pb-5 pt-3 flex-shrink-0 border-t border-border-subtle"
             >
               <slot name="actions"></slot>
             </div>


### PR DESCRIPTION
## Summary

The calendar event modal extended below the viewport with no scroll on shorter desktop heights — the Save button was unreachable. Root cause was in the design-system primitive `KinModalSheet`: no max-height, body didn't scroll, footer wasn't pinned.

Fix at the primitive level so every modal in the app benefits, not just the calendar one:

- Surface gets `max-h-[90vh]` mobile / `max-h-[85vh]` desktop
- Surface becomes a flex column; header + footer are `flex-shrink-0`
- Body slot gets `overflow-y-auto flex-1 min-h-0` so long forms scroll
- Footer (`#actions`) gets a top border and stays pinned at the bottom

Also bumps the `lg` desktop width from 640px → 720px since the EventModal felt cramped.

## Test plan

- [ ] Resize desktop window to 700px tall, open Calendar → Add Event — Save/Update buttons reachable, body scrolls
- [ ] Mobile viewport (375px) — modal still slides up from the bottom, body still scrolls if content is long
- [ ] Other modals using `BaseModal` / `KinModalSheet` (delete confirms, billing modals, widget picker, etc.) — no regression in layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)