### PR TITLE
fix: cancel Stripe sub on account/family deletion (#269)

### DIFF
--- a/app/Services/AccountDeletionService.php
+++ b/app/Services/AccountDeletionService.php
@@ -6,6 +6,7 @@ use App\Models\Family;
 use App\Models\User;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
+use Stripe\Exception\ApiErrorException;
 
 class AccountDeletionService
 {
@@ -68,6 +69,16 @@ class AccountDeletionService
                     return 'You are the last parent in this family. Transfer the parent role to another member first, or delete the entire family.';
                 }
             }
+
+            // Billing-owner force-transfer (#269). If this user owns the
+            // family's Stripe subscription and the family will *survive*
+            // their deletion (other parents remain), require them to hand
+            // off billing first so we don't silently abandon a paid sub.
+            if ((string) $family->billing_owner_id === (string) $user->id
+                && $otherParents > 0
+                && $family->subscription('default')?->valid()) {
+                return 'You are the billing owner for this family. Transfer billing ownership to another parent before deleting your account, or delete the entire family.';
+            }
         }
 
         return null;
@@ -116,8 +127,58 @@ class AccountDeletionService
         $remainingMembers = User::where('family_id', $familyId)->count();
 
         if ($remainingMembers === 0) {
-            // Eloquent delete fires model events and cascades properly
-            Family::where('id', $familyId)->first()?->delete();
+            $family = Family::where('id', $familyId)->first();
+            if ($family) {
+                // Cancel any active Stripe subscription before the family
+                // record is destroyed (#269). Otherwise the customer keeps
+                // being billed for a family that no longer exists.
+                $this->cancelStripeSubscription($family);
+                // Eloquent delete fires model events and cascades properly
+                $family->delete();
+            }
+        }
+    }
+
+    /**
+     * Best-effort cancellation of the family's Stripe subscription before its
+     * record is deleted. Called from both account-deletion (orphan cleanup)
+     * and family-deletion paths so users who exercise their GDPR right to
+     * erasure don't keep accruing Stripe charges.
+     *
+     * Failures are logged but do NOT block deletion — a Stripe outage must
+     * not prevent a user from deleting their account, or we'd be holding
+     * GDPR-protected data hostage to a third-party API. Operators can
+     * reconcile orphaned Stripe customers manually via the Dashboard.
+     */
+    public function cancelStripeSubscription(Family $family): void
+    {
+        if (! $family->stripe_id) {
+            return;
+        }
+
+        $subscription = $family->subscription('default');
+        if (! $subscription) {
+            return;
+        }
+
+        try {
+            $subscription->cancelNow();
+            Log::info('Stripe subscription cancelled before family deletion', [
+                'family_id' => $family->id,
+                'stripe_id' => $family->stripe_id,
+                'subscription_id' => $subscription->stripe_id,
+            ]);
+        } catch (ApiErrorException $e) {
+            Log::warning('Failed to cancel Stripe subscription before family deletion', [
+                'family_id' => $family->id,
+                'stripe_id' => $family->stripe_id,
+                'error' => $e->getMessage(),
+            ]);
+        } catch (\Throwable $e) {
+            Log::warning('Unexpected error cancelling Stripe subscription before family deletion', [
+                'family_id' => $family->id,
+                'error' => $e->getMessage(),
+            ]);
         }
     }
 }

--- a/app/Services/FamilyDeletionService.php
+++ b/app/Services/FamilyDeletionService.php
@@ -17,6 +17,12 @@ class FamilyDeletionService
      */
     public function deleteFamily(Family $family): void
     {
+        // Cancel any active Stripe subscription BEFORE the transaction (#269).
+        // Stripe is an external API call — keeping it outside the DB
+        // transaction means a Stripe hiccup can't dirty local state, and the
+        // cancellation is best-effort anyway (logged on failure).
+        $this->accountDeletionService->cancelStripeSubscription($family);
+
         DB::transaction(function () use ($family) {
             // Delete all members (handles file cleanup, token revocation, etc.)
             foreach ($family->members as $member) {


### PR DESCRIPTION
## Summary

Closes the GDPR/billing gap where deleting a user or family didn't cancel their Stripe subscription, so the customer kept being charged for a record that no longer exists.

Two paths now reach the same best-effort cancellation helper on `AccountDeletionService::cancelStripeSubscription`:

- `AccountDeletionService::cleanupOrphanedFamily` — when the last user deletes their account and the family is about to be destroyed.
- `FamilyDeletionService::deleteFamily` — explicit `DELETE /api/v1/family`.

The helper wraps `subscription->cancelNow()` in try/catch and logs on failure. Stripe outages must NOT block GDPR-mandated deletion, so cancellation is best-effort; operators can reconcile orphaned Stripe customers via the Dashboard.

Also adds a force-transfer guard in `canDeleteSelf`: if the user is the billing owner, other parents remain (family survives), AND there's an active subscription, the API returns 403 with "Transfer billing ownership before deleting your account." Prevents silently abandoning a paid sub.

## Test plan

- [ ] Billing owner of a multi-parent family with an active sub tries to delete account → 403 with the transfer message
- [ ] Last-parent or solo billing-owner can still delete their account; the orphan-cleanup path cancels the sub before destroying the family
- [ ] `DELETE /api/v1/family` cancels the subscription before deleting the family record (verify in Stripe Dashboard test mode)
- [ ] Stripe API failure on cancellation is logged but doesn't 500 the request — deletion still completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)