### PR TITLE
fix: hide Skip button on BillingStep

### DIFF
--- a/resources/js/views/onboarding/OnboardingView.vue
+++ b/resources/js/views/onboarding/OnboardingView.vue
@@ -42,7 +42,7 @@
         <div class="flex-1"></div>
 
         <KinButton
-          v-if="!isLastStep"
+          v-if="!isLastStep && !isBillingStep"
           variant="ghost"
           @click="handleSkip"
         >
@@ -117,6 +117,7 @@ const activeSteps = computed(() => {
 })
 
 const isLastStep = computed(() => store.currentStep === activeSteps.value.length - 1)
+const isBillingStep = computed(() => activeSteps.value[store.currentStep] === BillingStep)
 
 // Allow step components to set loading state and register continue handlers
 const stepContinueHandler = ref(null)


### PR DESCRIPTION
## Summary
- BillingStep gets `isBillingStep` check; the global "Skip for now" button hides on it
- Subscription is required on hosted instances, so allowing skip would let users bypass the paywall the wizard exists to enforce

## Test plan
- [x] Land on BillingStep in onboarding wizard, confirm no Skip button
- [x] Other steps still show Skip
- [x] CompleteStep is unaffected (already handled by isLastStep)