### PR TITLE
fix: bump demo session limit to 5

### DIFF
--- a/config/kinhold.php
+++ b/config/kinhold.php
@@ -131,7 +131,7 @@ return [
         // family-wide daily cap has remaining capacity, a single visitor can
         // only send this many messages per browser session before being asked
         // to sign up.
-        'demo_session_limit' => (int) env('CHATBOT_DEMO_SESSION_LIMIT', 3),
+        'demo_session_limit' => (int) env('CHATBOT_DEMO_SESSION_LIMIT', 5),
 
         // Monthly USD circuit-breaker for the shared demo family (#266). When
         // estimated month-to-date Anthropic spend exceeds this, demo AI is


### PR DESCRIPTION
## Summary
- Demo session cap was 3 (too tight to feel useful), prior plan suggested 10 (too generous on a shared family). Setting to 5.
- Single-line config change in `config/kinhold.php`; `CHATBOT_DEMO_SESSION_LIMIT` env still overrides.

## Test plan
- [x] Send 5 messages as the demo family → succeeds
- [x] 6th message returns 429 with the demo session message