### PR TITLE
fix: recover from stale build after deploy (#278)

### DIFF
--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -5,6 +5,24 @@ import App from './App.vue'
 import router from './router'
 import '../css/app.css'
 
+// Stale-build recovery (#278). After a redeploy, hashed asset filenames
+// change. A returning user whose tab cached the old `index.html` (via SW or
+// browser cache) will try to dynamically import chunks that no longer exist;
+// the server returns the SPA fallback HTML, and the browser fails the
+// import with a MIME-type error. Reload once to pick up the fresh manifest.
+// sessionStorage guards against an infinite reload loop if the failure is
+// actually permanent (network down, real bug).
+const RELOAD_GUARD_KEY = 'kin-preload-reload-attempted'
+window.addEventListener('vite:preloadError', (event) => {
+  if (sessionStorage.getItem(RELOAD_GUARD_KEY)) return
+  sessionStorage.setItem(RELOAD_GUARD_KEY, String(Date.now()))
+  event.preventDefault()
+  window.location.reload()
+})
+window.addEventListener('load', () => {
+  setTimeout(() => sessionStorage.removeItem(RELOAD_GUARD_KEY), 5000)
+})
+
 const app = createApp(App)
 
 app.use(createPinia())
@@ -12,7 +30,8 @@ app.use(router)
 
 app.mount('#app')
 
-// PWA service worker registration (#68). `autoUpdate` here mirrors the
-// vite.config.js setting — new SW activates automatically on next reload, so
-// self-hosters with stale tabs don't have to manually click an "update" button.
+// PWA service worker registration (#68). `autoUpdate` + workbox's skipWaiting
+// + clientsClaim (vite.config.js) make a new SW take over immediately on the
+// next page load instead of waiting for every tab to close — required so
+// returning users don't get the stale shell after a deploy (#278).
 registerSW({ immediate: true })

--- a/vite.config.js
+++ b/vite.config.js
@@ -77,6 +77,14 @@ export default defineConfig({
         // at the top of the generated file. Update sw-push.js directly — it is
         // committed and loaded as-is at runtime, not bundled.
         importScripts: ['/sw-push.js'],
+        // After every deploy the SPA shell points at new hashed asset URLs.
+        // Without skipWaiting + clientsClaim the old SW keeps serving the
+        // stale shell until every tab closes, so returning users see blank
+        // pages with module-load errors (#278). Take over immediately and
+        // sweep precaches from prior builds on activation.
+        skipWaiting: true,
+        clientsClaim: true,
+        cleanupOutdatedCaches: true,
         // App shell fallback — the SPA owns every non-API route. workbox
         // resolves this URL against the precache, so '/' MUST be in the
         // precache (see additionalManifestEntries below) or offline


### PR DESCRIPTION
## Summary
Two compounding bugs caused returning users to see a blank page with module-load errors after every deploy.

- Workbox now skips the waiting phase and claims clients on activation, so the new SW takes over immediately instead of waiting for every tab to close
- `cleanupOutdatedCaches` sweeps precaches from prior builds
- New `vite:preloadError` listener in `app.js` reloads once on chunk-load failure, guarded by sessionStorage so a real failure doesn't loop

Closes #278.

## Test plan
- [ ] Deploy to staging, load app in tab A
- [ ] Push another deploy. After it lands, navigate within app in tab A
- [ ] Expect either no errors, or a single auto-reload that resolves cleanly (not a blank screen)
- [ ] Stripe Checkout return path also works without a manual hard refresh