### PR TITLE
fix: do not cache authenticated API responses in service worker

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -118,13 +118,17 @@ export default defineConfig({
         ],
         runtimeCaching: [
           {
+            // Authenticated API: never serve from cache. Caching `/api/v1/user`
+            // and other session-bound responses meant a returning visitor could
+            // see another user's session payload after sign-out (#278 follow-up:
+            // auto-login as a previously-cached user, plus CSRF mismatches when
+            // the cached index.html's CSRF meta no longer matched the live
+            // session). Background-sync is overkill for our current use; offline
+            // reads can come back later when we actually need them.
             urlPattern: ({ url }) => url.pathname.startsWith('/api/'),
-            handler: 'NetworkFirst',
+            handler: 'NetworkOnly',
             options: {
               cacheName: 'kinhold-api',
-              networkTimeoutSeconds: 4,
-              expiration: { maxEntries: 64, maxAgeSeconds: 60 * 60 * 24 },
-              cacheableResponse: { statuses: [0, 200] },
             },
           },
           {


### PR DESCRIPTION
## Summary
- `/api/*` runtime cache strategy was `NetworkFirst`, which wrote successful API responses (including `/api/v1/user`) into the SW cache
- Returning visitors could get auto-logged-in as a previously-cached user, and POSTs failed with CSRF mismatches because the cached index.html had a stale meta token
- Switched to `NetworkOnly`. Static asset + upload caches untouched

## Test plan
- [ ] Deploy, sign in as user A, sign out, sign in as user B
- [ ] Confirm user B sees user B's data, not user A's
- [ ] POST endpoints (chat, etc.) succeed without CSRF mismatch errors