### PR TITLE
fix: register flow fetches full user payload before onboarding

### DIFF
--- a/resources/js/stores/auth.js
+++ b/resources/js/stores/auth.js
@@ -174,6 +174,11 @@ export const useAuthStore = defineStore('auth', () => {
       family.value = response.data.family
       isAuthenticated.value = true
 
+      // Fetch the complete user + family payload so downstream views see
+      // billing_owner_id, is_demo, billing state, module_access, members —
+      // none of which are returned by /register's minimal family payload.
+      await fetchUser()
+
       return { success: true }
     } catch (err) {
       error.value = err.response?.data?.message || 'Registration failed'


### PR DESCRIPTION
## The bug

Smoke-testing v1.9.0 on the pr-286 Upsun environment, brand-new families bypassed the BillingStep entirely. They went Welcome → Invite → Calendar → Tags → Features → CompleteStep without ever seeing a plan picker, even with \`BILLING_ENABLED=true\`.

## Root cause

The \`/register\` endpoint returns a minimal family object:

\`\`\`php
'family' => [
    'id' => \$family->id,
    'name' => \$family->name,
    'invite_code' => \$family->invite_code,
],
\`\`\`

The SPA's \`register()\` action stored that directly into \`auth.family\` and never called \`fetchUser()\` afterwards (unlike \`login()\`, which does). So \`family.billing_owner_id\`, \`family.is_demo\`, \`family.billing\`, \`module_access\`, and \`members\` were all undefined.

\`OnboardingView.activeSteps\` checks \`authStore.user?.id === authStore.family?.billing_owner_id\` to decide whether to push BillingStep onto the wizard. Since the right-hand side was undefined, the check always failed and BillingStep got filtered out.

## The fix

One line: \`await fetchUser()\` after the initial register response, mirroring \`login()\`.

## Test plan

- [ ] Sign up a fresh family on the redeployed pr-286 env
- [ ] Confirm BillingStep appears between FeaturesStep and CompleteStep
- [ ] Confirm Stripe Checkout fires with the live price IDs