### PR TITLE
feat: cancel-anytime copy + 14-day trial display fix

### DIFF
--- a/resources/js/views/onboarding/steps/BillingStep.vue
+++ b/resources/js/views/onboarding/steps/BillingStep.vue
@@ -85,6 +85,9 @@
           </span>
           <span class="text-sm text-ink-secondary">— no card charged until the trial ends.</span>
         </div>
+        <p class="text-xs text-ink-secondary">
+          Cancel anytime in Settings → Billing. No long-term commitment.
+        </p>
         <p v-if="billing.lastError" class="text-xs text-rose-700 dark:text-rose-300">
           {{ billing.lastError }}
         </p>


### PR DESCRIPTION
## Summary

Two checkout polish fixes from the v1.9.0 production smoke test:

1. **Trial showed "13 days free"** instead of 14 on Stripe Checkout. Stripe displays the trial as whole UTC days remaining, so a session created mid-day shows trialDays-1. Already documented as a known case in \`BillingService::createBaseCheckout()\`. Fix: set \`BILLING_TRIAL_DAYS=15\` as a project-level Upsun variable so Stripe displays 14 while granting ~24h of buffer. Already deployed.

2. **Cancel-anytime copy** added below the total on BillingStep. Sets customer expectations before they click through to Stripe Checkout.

## Test plan

- [ ] After deploy, sign up a fresh family on app.kinhold.app
- [ ] Confirm BillingStep shows "Cancel anytime in Settings → Billing"
- [ ] Confirm Stripe Checkout shows "14 days free"