### PR TITLE
fix: route Stripe webhooks through our subclass (#290)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 > Updated at the end of every working session. Newest entries first.
 
+## 2026-05-10 — Stripe webhook idempotency fix ([#290](https://github.com/gregqualls/kinhold/issues/290))
+
+After the v1.9.0 cutover, the `webhook_events` idempotency table stayed empty despite live Stripe deliveries — leaving us exposed to duplicate notifications and grace-period double-clocking on retries. Root cause: Cashier auto-registers `POST /stripe/webhook` named `cashier.webhook` in its service provider, while we registered the same URI inside the `api/v1` group at `/api/v1/stripe/webhook` — also named `cashier.webhook`. Stripe is configured to call `/stripe/webhook`, so all production traffic landed on Cashier's controller, which doesn't write the idempotency row or fire our lifecycle notifications.
+
+- `Cashier::ignoreRoutes()` in [AppServiceProvider::register](app/Providers/AppServiceProvider.php) so the package stops auto-registering the duplicate.
+- `POST /stripe/webhook` re-registered directly in `boot` with `VerifyWebhookSignature` middleware, so the bare path Stripe calls now lands on `StripeWebhookController`.
+- Dropped the redundant `api/v1` route registration and its now-unused import.
+- New regression test `test_first_delivery_records_webhook_event_with_processed_at` asserts the row is created with `processed_at` populated on first delivery. Updated existing webhook tests to use the new bare-path URL.
+
+---
+
 ## 2026-05-09 — v1.9.0 production cutover ([#286](https://github.com/gregqualls/kinhold/pull/286)–[#289](https://github.com/gregqualls/kinhold/pull/289))
 
 Stripe live mode wired, staging merged to main, `BILLING_ENABLED=true` flipped on production. Kinhold is open for real subscriptions at app.kinhold.app.

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace App\Providers;
 
+use App\Http\Controllers\Webhooks\StripeWebhookController;
 use App\Models\Family;
 use App\Models\MealPlanEntry;
 use App\Models\ShoppingItem;
@@ -10,9 +11,11 @@ use App\Policies\ShoppingListPolicy;
 use Illuminate\Cache\RateLimiting\Limit;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\Facades\RateLimiter;
+use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Facades\URL;
 use Illuminate\Support\ServiceProvider;
 use Laravel\Cashier\Cashier;
+use Laravel\Cashier\Http\Middleware\VerifyWebhookSignature;
 use Laravel\Passport\Passport;
 
 class AppServiceProvider extends ServiceProvider
@@ -22,7 +25,12 @@ class AppServiceProvider extends ServiceProvider
      */
     public function register(): void
     {
-        //
+        // Disable Cashier's auto-registered /stripe/webhook route so traffic
+        // hits our subclass (which writes idempotency rows to webhook_events
+        // and fires lifecycle notifications). Without this, both Cashier's
+        // route and ours register at /stripe/webhook with the same name and
+        // Cashier wins — webhooks 200 but skip our overrides (#290).
+        Cashier::ignoreRoutes();
     }
 
     /**
@@ -37,6 +45,14 @@ class AppServiceProvider extends ServiceProvider
         // Cashier bills the Family (one billing owner per family) rather than
         // individual users — see #70 / #214. The Billable trait lives on Family.
         Cashier::useCustomerModel(Family::class);
+
+        // Stripe webhook receiver. Registered here (not in routes/api.php) so
+        // it lives at the bare /stripe/webhook path — matching the URL Stripe
+        // is configured to call — instead of /api/v1/stripe/webhook. Pairs
+        // with Cashier::ignoreRoutes() above (#290).
+        Route::post('/stripe/webhook', [StripeWebhookController::class, 'handleWebhook'])
+            ->name('cashier.webhook')
+            ->middleware(VerifyWebhookSignature::class);
 
         // Passport OAuth configuration for MCP server
         Passport::tokensExpireIn(now()->addDays(15));

--- a/routes/api.php
+++ b/routes/api.php
@@ -23,7 +23,6 @@ use App\Http\Controllers\Api\V1\ShoppingListController;
 use App\Http\Controllers\Api\V1\TagController;
 use App\Http\Controllers\Api\V1\TaskController;
 use App\Http\Controllers\Api\V1\VaultController;
-use App\Http\Controllers\Webhooks\StripeWebhookController;
 use App\Models\Family;
 use App\Models\User;
 use App\Services\LicenseEnforcementService;
@@ -358,10 +357,8 @@ Route::prefix('v1')->group(function () {
     // Calendar OAuth callback (public, stateless — Google redirects via GET)
     Route::get('/calendar/callback', [CalendarController::class, 'handleCallback'])->name('api.calendar.callback');
 
-    // Stripe webhooks (#221 / 70-H). Public — signature verified by
-    // VerifyWebhookSignature middleware (auto-attached by Cashier when
-    // STRIPE_WEBHOOK_SECRET is set). Idempotency via webhook_events table.
-    Route::post('/stripe/webhook', [StripeWebhookController::class, 'handleWebhook'])
-        ->name('cashier.webhook')
-        ->withoutMiddleware('throttle:api');
 });
+
+// Stripe webhook lives at bare /stripe/webhook (registered in AppServiceProvider::boot)
+// to match the URL Stripe is configured to call, with Cashier::ignoreRoutes() preventing
+// the package's auto-registered duplicate (#290).

--- a/tests/Feature/Billing/TrialAiTierTest.php
+++ b/tests/Feature/Billing/TrialAiTierTest.php
@@ -103,7 +103,7 @@ class TrialAiTierTest extends TestCase
 
         return $this->call(
             'POST',
-            '/api/v1/stripe/webhook',
+            '/stripe/webhook',
             [],
             [],
             [],

--- a/tests/Feature/Billing/WebhookTest.php
+++ b/tests/Feature/Billing/WebhookTest.php
@@ -40,7 +40,7 @@ class WebhookTest extends TestCase
 
         return $this->call(
             'POST',
-            '/api/v1/stripe/webhook',
+            '/stripe/webhook',
             [],
             [],
             [],
@@ -197,6 +197,32 @@ class WebhookTest extends TestCase
         Notification::assertSentTo($owner, TrialEndingNotification::class);
     }
 
+    public function test_first_delivery_records_webhook_event_with_processed_at(): void
+    {
+        // Regression test for #290: live cutover landed Stripe webhooks on
+        // Cashier's auto-registered route (named cashier.webhook, same as
+        // ours) instead of our subclass, so webhook_events stayed empty.
+        // Cashier::ignoreRoutes() + bare-path registration in
+        // AppServiceProvider routes traffic through our handler.
+        Notification::fake();
+        [$family] = $this->familyWithOwnerAndStripeId();
+
+        $eventId = 'evt_test_idem_'.uniqid();
+        $this->postSignedWebhook([
+            'id' => $eventId,
+            'type' => 'invoice.payment_failed',
+            'data' => ['object' => ['customer' => $family->stripe_id]],
+        ])->assertStatus(200);
+
+        $row = WebhookEvent::query()
+            ->where('provider', 'stripe')
+            ->where('event_id', $eventId)
+            ->first();
+
+        $this->assertNotNull($row);
+        $this->assertNotNull($row->processed_at);
+    }
+
     public function test_replaying_same_event_id_is_idempotent(): void
     {
         Notification::fake();
@@ -229,7 +255,7 @@ class WebhookTest extends TestCase
 
         $response = $this->call(
             'POST',
-            '/api/v1/stripe/webhook',
+            '/stripe/webhook',
             [],
             [],
             [],


### PR DESCRIPTION
## Summary

- After the v1.9.0 cutover, `webhook_events` stayed empty despite live Stripe deliveries — Cashier auto-registers `POST /stripe/webhook` named `cashier.webhook` and our duplicate sat at `/api/v1/stripe/webhook`. Stripe calls the bare path, so traffic hit Cashier's controller (no idempotency, no lifecycle notifications).
- `Cashier::ignoreRoutes()` in `AppServiceProvider::register`, re-register `POST /stripe/webhook` in `boot` with `VerifyWebhookSignature` middleware. Drop the `api/v1` duplicate.
- Add regression test asserting the first delivery creates a `webhook_events` row with `processed_at` set.

Closes #290

## Test plan

- [x] `phpunit tests/Feature/Billing/` — 91 tests, all pass
- [x] `phpunit` full suite — 343 tests, all pass
- [x] `php artisan route:list --path=stripe` shows single route bound to our controller
- [x] Pint clean, PHPStan clean
- [ ] Stripe CLI event resend on prod after merge: confirm `\App\Models\WebhookEvent::count()` increments

🤖 Generated with [Claude Code](https://claude.com/claude-code)