### PR TITLE
fix: enlarge mobile task-complete tap target (#293)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,15 @@ After the v1.9.0 cutover, the `webhook_events` idempotency table stayed empty de
 - Dropped the redundant `api/v1` route registration and its now-unused import.
 - New regression test `test_first_delivery_records_webhook_event_with_processed_at` asserts the row is created with `processed_at` populated on first delivery. Updated existing webhook tests to use the new bare-path URL.
 
+## 2026-05-10 — Mobile task-complete fix ([#293](https://github.com/gregqualls/kinhold/issues/293))
+
+Production blocker: tapping the complete checkbox on a task did nothing on mobile (worked fine on desktop). Root cause: the 24×24 (`w-6 h-6`) checkbox button in `TaskCheckbox` is well below Apple's 44×44 HIG minimum, so mobile thumb taps frequently missed the button and landed on the row's `openDetail` click handler instead, presenting as "tap does nothing" since the detail panel opening visually replaced the row.
+
+- `touch-action: manipulation` added to `.checkbox-custom` to kill iOS Safari's 300ms double-tap-zoom delay so single taps register immediately.
+- Expanded the checkbox wrapper hit area in [TaskItem.vue](resources/js/components/tasks/TaskItem.vue) to 40×40 via `-m-2 p-2` with the toggle handler attached, so taps in the padding region also fire the toggle. The inner button keeps its own click-stop handler for direct taps.
+
+GitHub housekeeping: closed [#219](https://github.com/gregqualls/kinhold/issues/219), [#223](https://github.com/gregqualls/kinhold/issues/223), [#224](https://github.com/gregqualls/kinhold/issues/224) -- all functionally shipped pre-cutover but never closed. Reorganized post-launch bugs and ops issues into Phase B, moved inclusivity/i18n features ([#241](https://github.com/gregqualls/kinhold/issues/241), [#242](https://github.com/gregqualls/kinhold/issues/242), [#244](https://github.com/gregqualls/kinhold/issues/244)) to Phase D, parked [#229](https://github.com/gregqualls/kinhold/issues/229) (BYOK multi-provider) in Phase E.
+
 ---
 
 ## 2026-05-09 — v1.9.0 production cutover ([#286](https://github.com/gregqualls/kinhold/pull/286)–[#289](https://github.com/gregqualls/kinhold/pull/289))

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -328,6 +328,7 @@
   .checkbox-custom {
     @apply relative w-6 h-6 rounded-full border-2 flex-shrink-0 cursor-pointer;
     transition: background-color 0.2s, border-color 0.2s, transform 0.2s;
+    touch-action: manipulation;
   }
 
   .checkbox-custom:hover {

--- a/resources/js/components/tasks/TaskItem.vue
+++ b/resources/js/components/tasks/TaskItem.vue
@@ -7,7 +7,9 @@
     @click="$emit('click', task)"
   >
     <!-- Checkbox -->
-    <div class="pt-0.5" @click.stop>
+    <!-- Expanded hit area (-m-2 p-2) gives a 40x40 tap target around the 24x24 checkbox.
+         Without this, mobile thumbs miss the button and tap the row's openDetail handler instead (#293). -->
+    <div class="-m-2 p-2" @click.stop="$emit('toggle', task.id)">
       <TaskCheckbox
         :checked="!!task.completed_at"
         :priority="task.priority"


### PR DESCRIPTION
## Summary

- Production blocker: the 24×24 (`w-6 h-6`) checkbox button is well below Apple's 44×44 HIG minimum, so mobile thumb taps frequently miss it and land on the row's `openDetail` handler — looks like "tap does nothing" since the detail panel opening visually replaces the row.
- Add `touch-action: manipulation` to `.checkbox-custom` so iOS Safari skips the 300ms double-tap-zoom delay.
- Expand the wrapper hit area in `TaskItem.vue` to 40×40 via `-m-2 p-2` and attach the toggle handler so taps in the padding region also fire the toggle. Inner button keeps its own click-stop handler for direct taps.

Closes #293

## Test plan

- [x] ESLint clean on touched files
- [x] Existing tests pass (no JS test infra for these components)
- [ ] Manual test on a real phone via app.kinhold.app after merge — tap the checkbox in the Tasks list at multiple positions (center, edges, padding region) and confirm the row toggles to Completed in all cases without opening the detail panel
- [ ] Verify desktop behavior unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)