### PR TITLE
feat: Docker Hub publishing + README accuracy audit

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,52 @@
+name: Publish Docker image
+
+on:
+  push:
+    branches:
+      - main
+  release:
+    types: [published]
+
+jobs:
+  build-and-push:
+    name: Build and push to Docker Hub
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU (for multi-arch builds)
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Extract metadata (tags and labels)
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: gregqualls/kinhold
+          tags: |
+            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
+            type=semver,pattern={{version}},enable=${{ github.event_name == 'release' }}
+            type=semver,pattern={{major}}.{{minor}},enable=${{ github.event_name == 'release' }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Turn chores into a game your kids actually want to play.
 - **Points** — Earn points by completing tasks. Parents can give kudos (+1 pt) or deduct points. Ledger-based architecture — every point is traceable, no balance mutations.
 - **Leaderboard** — Family rankings over configurable periods (daily/weekly/monthly). Resets each period without touching point banks.
 - **Rewards Store** — Parents create prizes with point costs (Sweets = 10 pts, Movie Pick = 40 pts). Kids purchase instantly.
-- **Badges** — Steam-style achievements with hexagonal icons. 29 default badges auto-created for every family. Auto-triggered by milestones (first task completed, 7-day streak, 1000 points earned) or manually awarded by parents. Hidden badges show as "???" until earned.
+- **Badges** — Steam-style achievements with hexagonal icons. 27 default badges auto-created for every family. Auto-triggered by milestones (first task completed, 7-day streak, 1000 points earned) or manually awarded by parents. Hidden badges show as "???" until earned.
 - **Activity Feed** — Family-wide feed showing task completions, kudos, purchases, and badge unlocks.
 
 ### Quality of Life
@@ -68,14 +68,14 @@ Turn chores into a game your kids actually want to play.
 |-------|-----------|
 | Backend | Laravel 11, PHP 8.2+ |
 | Frontend | Vue 3 (Composition API, `<script setup>`) |
-| State | Pinia (8 stores) |
+| State | Pinia (16 stores) |
 | Styling | Tailwind CSS |
 | Database | PostgreSQL 16 (production) or SQLite (simple setup), UUIDs |
 | Cache/Queue | Redis 7 |
 | Auth | Laravel Sanctum + Google OAuth via Socialite |
 | AI | Anthropic Claude API (multi-provider ready) |
 | MCP Server | Laravel-native (PHP, 7 grouped tools) |
-| Build | Vite 5 |
+| Build | Vite 6 |
 | Hosting | [Upsun](https://upsun.com) |
 
 ## Quick Start
@@ -92,11 +92,31 @@ That's it. Open [http://localhost:8000](http://localhost:8000) and log in with `
 
 This runs Kinhold with SQLite in a single container — no PostgreSQL or Redis needed. Great for trying it out or running for a small family. To upgrade to the full production stack (PostgreSQL + Redis), see Option 2 below.
 
+### Home Server (Unraid, Portainer, TrueNAS, Synology, CasaOS, etc.)
+
+No `git clone` or local build required. Pull the pre-built image directly from Docker Hub:
+
+```bash
+docker pull gregqualls/kinhold:latest
+```
+
+Then use the self-contained compose file from the repo:
+
+```bash
+# Download the compose file (no other source files needed)
+curl -O https://raw.githubusercontent.com/gregqualls/kinhold/main/docker-compose.homeserver.yml
+docker compose -f docker-compose.homeserver.yml up -d
+```
+
+Or paste the contents of [`docker-compose.homeserver.yml`](docker-compose.homeserver.yml) directly into your home server platform's "custom app" / "stack" / "compose" UI.
+
+Open [http://your-server-ip:8000](http://your-server-ip:8000) and register your family. `APP_KEY` generates automatically on first boot. Data persists in named Docker volumes.
+
 ### Option 1: Native (macOS — Recommended)
 
 ```bash
 # Install dependencies
-brew install php@8.3 composer postgresql@16 redis node
+brew install php@8.4 composer postgresql@16 redis node
 brew services start postgresql@16
 brew services start redis
 
@@ -151,6 +171,7 @@ Copy `.env.example` to `.env` and configure:
 | `REDIS_*` | Redis connection |
 | `GOOGLE_CLIENT_ID` / `GOOGLE_CLIENT_SECRET` | Google OAuth + Calendar |
 | `ANTHROPIC_API_KEY` | AI chat (optional). Self-hosters bring their own Anthropic key; Kinhold supports BYOK out of the box. |
+| `SELF_HOSTED` | Set to `true` on self-hosted instances. Disables Stripe billing and hides the hosted-service pricing UI. |
 
 ### Google Calendar + OAuth
 
@@ -224,18 +245,18 @@ kinhold/
 ├── app/
 │   ├── Console/Commands/       # Artisan commands (recurring tasks, badge seeding)
 │   ├── Enums/                  # FamilyRole, TaskPriority, PointTransactionType, BadgeTriggerType
-│   ├── Http/Controllers/Api/   # 16 REST controllers
+│   ├── Http/Controllers/Api/   # 23 REST controllers
 │   ├── Mcp/                    # Laravel-native MCP server
 │   │   ├── Servers/            # MCP server registration
-│   │   └── Tools/              # 20 MCP tool classes
-│   ├── Models/                 # 17 Eloquent models
+│   │   └── Tools/              # 7 MCP tool classes
+│   ├── Models/                 # 38 Eloquent models
 │   ├── Policies/               # Authorization policies
 │   └── Services/               # Business logic (Points, Badges, Calendar, Vault, Chat)
-├── database/migrations/        # 30 migrations
+├── database/migrations/        # 78 migrations
 ├── resources/js/
 │   ├── components/             # Vue components (layout, common, tasks, vault, points, badges, etc.)
-│   ├── views/                  # 19 page views across 10 modules
-│   ├── stores/                 # 8 Pinia stores
+│   ├── views/                  # Page views across 12 modules (auth, tasks, vault, calendar, chat, food, points, badges, dashboard, settings, onboarding, design-system)
+│   ├── stores/                 # 16 Pinia stores
 │   ├── composables/            # Vue composables (notifications, dark mode, themes, colors)
 │   └── router/                 # Vue Router with auth guards
 ├── .upsun/                     # Production deployment config
@@ -255,7 +276,7 @@ Kinhold is designed to be self-hosted. See **[SELF-HOSTING.md](SELF-HOSTING.md)*
 **Quick version:**
 
 1. Fork this repo on GitHub
-2. Run `./setup-simple.sh` for a single-container SQLite setup, or use `docker compose up` for the full PostgreSQL + Redis stack
+2. Run `./setup-simple.sh` for a single-container SQLite setup, use `docker-compose.homeserver.yml` for a home server install without cloning, or use `docker compose up` for the full PostgreSQL + Redis stack
 3. Set your environment variables (Google OAuth, Anthropic key are optional)
 4. To pull upstream updates: `git remote add upstream https://github.com/gregqualls/kinhold.git && git pull upstream main`
 

--- a/docker-compose.homeserver.yml
+++ b/docker-compose.homeserver.yml
@@ -1,0 +1,101 @@
+# Kinhold — Home Server Install
+#
+# Designed for Unraid, Portainer, TrueNAS, Synology, CasaOS, and any
+# Docker host where you don't have a local copy of the source code.
+#
+# No git clone or local build required. The pre-built image is pulled
+# directly from Docker Hub.
+#
+# Quick install:
+#   docker compose -f docker-compose.homeserver.yml up -d
+#   Open http://your-server-ip:8000
+#
+# For platforms with a "paste compose" or "custom app" UI, copy everything
+# below the dashed line and paste it in.
+#
+# APP_KEY is generated automatically on first boot and persisted to the
+# kinhold-data volume. Do not set it manually.
+#
+# To load demo accounts on first run:
+#   docker compose -f docker-compose.homeserver.yml exec app php artisan db:seed
+#
+# -----------------------------------------------------------------------
+
+name: kinhold
+
+services:
+  app:
+    image: gregqualls/kinhold:latest
+    ports:
+      - "8000:8000"
+    environment:
+      APP_NAME: Kinhold
+      APP_ENV: production
+      APP_DEBUG: "false"
+      # Change this to your server's hostname or IP for remote access.
+      # Example: http://192.168.1.100:8000 or https://kinhold.yourdomain.com
+      APP_URL: http://localhost:8000
+
+      LOG_CHANNEL: single
+      LOG_LEVEL: warning
+
+      # Database — SQLite, stored in the kinhold-data volume
+      DB_CONNECTION: sqlite
+      DB_DATABASE: /data/kinhold.sqlite
+
+      # Cache and queue — file-based, no Redis needed
+      CACHE_STORE: file
+      QUEUE_CONNECTION: sync
+      SESSION_DRIVER: database
+      SESSION_LIFETIME: 120
+
+      # Self-hosted mode — disables Stripe billing and marketing UI
+      SELF_HOSTED: "true"
+
+      # -----------------------------------------------------------------------
+      # Optional integrations — uncomment and fill in values to enable.
+      # -----------------------------------------------------------------------
+
+      # Google OAuth + Calendar sync (same credentials for both)
+      # GOOGLE_CLIENT_ID: your-client-id
+      # GOOGLE_CLIENT_SECRET: your-client-secret
+      # GOOGLE_REDIRECT_URI: http://your-server-ip:8000/auth/google/callback
+      # GOOGLE_CALENDAR_REDIRECT_URI: http://your-server-ip:8000/api/v1/calendar/callback
+
+      # AI chat assistant (get a key at console.anthropic.com)
+      # ANTHROPIC_API_KEY: sk-ant-...
+
+      # Email notifications (SMTP — any provider works)
+      # MAIL_MAILER: smtp
+      # MAIL_HOST: smtp.example.com
+      # MAIL_PORT: 587
+      # MAIL_USERNAME: your-username
+      # MAIL_PASSWORD: your-password
+      # MAIL_ENCRYPTION: tls
+      # MAIL_FROM_ADDRESS: kinhold@yourdomain.com
+      # MAIL_FROM_NAME: Kinhold
+
+      # Web push notifications (generate with: docker compose exec app php artisan webpush:vapid)
+      # VAPID_PUBLIC_KEY:
+      # VAPID_PRIVATE_KEY:
+      # VAPID_SUBJECT: mailto:admin@yourdomain.com
+
+    volumes:
+      # Persists the SQLite database and auto-generated APP_KEY across restarts
+      - kinhold-data:/data
+      # Persists vault document uploads
+      - kinhold-storage:/app/storage/app
+    command: ["php", "artisan", "serve", "--host=0.0.0.0", "--port=8000"]
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8000"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 60s
+    restart: unless-stopped
+
+volumes:
+  kinhold-data:
+    driver: local
+  kinhold-storage:
+    driver: local

--- a/docker-compose.simple.yml
+++ b/docker-compose.simple.yml
@@ -5,19 +5,20 @@
 #
 # Quick start:
 #   cp .env.docker-simple .env
-#   docker compose -f docker-compose.simple.yml up -d --build
+#   docker compose -f docker-compose.simple.yml up -d
 #   docker compose -f docker-compose.simple.yml exec app php artisan db:seed
 #   Open http://localhost:8000
 #
 # Or use the setup script: ./setup-simple.sh
+#
+# For home servers (Unraid, Portainer, TrueNAS, CasaOS, etc.) without
+# a local copy of the source, use docker-compose.homeserver.yml instead.
 
 name: kinhold
 
 services:
   app:
-    build:
-      context: .
-      dockerfile: Dockerfile
+    image: gregqualls/kinhold:latest
     ports:
       - "8000:8000"
     env_file:


### PR DESCRIPTION
## Summary

- Adds a GitHub Actions workflow that builds and pushes `gregqualls/kinhold:latest` to Docker Hub on every push to `main`, and tagged semver releases on `v*` tags. Multi-arch: `linux/amd64` + `linux/arm64` (covers Intel, Raspberry Pi, and most NAS hardware).
- Adds `docker-compose.homeserver.yml`: a fully self-contained compose file for home server installs (Unraid, Portainer, TrueNAS, Synology, CasaOS, etc.) — no git clone or local build required. Users paste it into their platform's UI or `curl` it down.
- Updates `docker-compose.simple.yml` to pull the pre-built image from Docker Hub instead of building from source.
- Fixes 10 stale items in README.md found during a line-by-line audit: controller/model/migration/store/tool counts, Vite 5→6, badges 29→27, PHP brew 8.3→8.4, views section description, `SELF_HOSTED` env var now documented.
- Adds a "Home Server" quick-start section to the README.

## Before merging

Add two repository secrets (already done):
- `DOCKER_USERNAME` = `gregqualls`
- `DOCKER_PASSWORD` = Docker Hub personal access token

## Test plan

- [ ] PR CI passes
- [ ] After merge, confirm "Publish Docker image" workflow runs in Actions tab
- [ ] Confirm `gregqualls/kinhold:latest` appears on Docker Hub after workflow completes
- [ ] On a clean machine (no source), run `docker compose -f docker-compose.homeserver.yml up -d` and confirm Kinhold starts at the configured port

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>