### PR TITLE
fix: phase B ops cleanup — failed_jobs, logger guard, FPM scaling

### DIFF
--- a/.upsun/config.yaml
+++ b/.upsun/config.yaml
@@ -3,10 +3,14 @@ applications:
     source:
       root: "/"
     type: "php:8.4"
+    container_profile: BALANCED
     runtime:
       extensions:
         - redis
         - pdo_pgsql
+      sizing_hints:
+        request_memory: 35
+        reserved_memory: 70
     relationships:
       database: "db:postgresql"
       redis: "cache:redis"

--- a/config/logging.php
+++ b/config/logging.php
@@ -9,7 +9,7 @@ return [
     | Default Log Channel
     |--------------------------------------------------------------------------
     */
-    'default' => env('LOG_CHANNEL', 'stack'),
+    'default' => in_array(env('LOG_CHANNEL'), [null, '', 'null'], true) ? 'stack' : env('LOG_CHANNEL'),
 
     /*
     |--------------------------------------------------------------------------

--- a/database/migrations/2026_05_13_091745_create_failed_jobs_table.php
+++ b/database/migrations/2026_05_13_091745_create_failed_jobs_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('failed_jobs', function (Blueprint $table) {
+            $table->id();
+            $table->string('uuid')->unique();
+            $table->text('connection');
+            $table->text('queue');
+            $table->longText('payload');
+            $table->longText('exception');
+            $table->timestamp('failed_at')->useCurrent();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('failed_jobs');
+    }
+};

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -160,6 +160,7 @@ These features are live and working:
 > Ideas captured from competitive analysis and brainstorming. Not planned yet.
 
 - Google OAuth + invite codes — `GoogleAuthController::findOrCreateUser` creates a new family for every first-time OAuth user, so on a self-hosted instance a spouse signing in via Google ends up in their own family rather than joining the existing one. Should accept an invite-code query param. Follow-up from #138.
+- Notification PII audit (follow-up from #305): `WeeklyDigestNotification::__construct(public array $digest)` and possibly others take raw arrays instead of model keys. With `failed_jobs` restored, that data lands in `failed_jobs.payload` on dispatch (bounded to 72h by the new prune schedule, but the structural fix is to refactor to model-only constructor args so SerializesModels handles the payload).
 - Plugin/module system for community extensions (under investigation)
 - Staging environment strategy (discussion pending)
 - Vault overhaul (explore Obsidian-like or Standard Notes integration)

--- a/routes/console.php
+++ b/routes/console.php
@@ -24,3 +24,9 @@ Schedule::command('kinhold:tally-storage')->dailyAt('02:00');
 
 // Grace period sweep — day-3 reminders + day-7 downgrades (#221 / 70-H)
 Schedule::command('kinhold:enforce-grace-period')->dailyAt('03:00');
+
+// Bound failed_jobs retention. The payload column can contain serialised job
+// args (e.g. WeeklyDigestNotification's aggregated $digest array), so cap the
+// exposure window for any PII that lands there via an exception or a job that
+// constructs without SerializesModels.
+Schedule::command('queue:prune-failed --hours=72')->dailyAt('04:00');

--- a/tests/Feature/Queue/FailedJobsTableTest.php
+++ b/tests/Feature/Queue/FailedJobsTableTest.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace Tests\Feature\Queue;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Queue;
+use Illuminate\Support\Facades\Schema;
+use Tests\TestCase;
+
+class FailedJobsTableTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Production uses the Redis queue driver, so there is no committed `jobs`
+        // migration. This test exercises queue:work via the database driver to
+        // keep the suite Redis-free; the failed_jobs write path is identical
+        // regardless of which driver dispatched the original job.
+        if (! Schema::hasTable('jobs')) {
+            Schema::create('jobs', function (Blueprint $table) {
+                $table->bigIncrements('id');
+                $table->string('queue')->index();
+                $table->longText('payload');
+                $table->unsignedTinyInteger('attempts');
+                $table->unsignedInteger('reserved_at')->nullable();
+                $table->unsignedInteger('available_at');
+                $table->unsignedInteger('created_at');
+            });
+        }
+
+        config()->set('queue.default', 'database');
+        config()->set('queue.connections.database', [
+            'driver' => 'database',
+            'connection' => null,
+            'table' => 'jobs',
+            'queue' => 'default',
+            'retry_after' => 90,
+            'after_commit' => false,
+        ]);
+    }
+
+    public function test_failing_job_is_logged_to_failed_jobs_table(): void
+    {
+        Queue::push(new AlwaysThrowingTestJob);
+
+        $this->assertDatabaseCount('jobs', 1);
+        $this->assertDatabaseCount('failed_jobs', 0);
+
+        $this->artisan('queue:work', [
+            '--once' => true,
+            '--tries' => 1,
+        ])->assertExitCode(0);
+
+        $this->assertDatabaseCount('failed_jobs', 1);
+
+        $failure = DB::table('failed_jobs')->first();
+
+        $this->assertSame('database', $failure->connection);
+        $this->assertSame('default', $failure->queue);
+        $this->assertStringContainsString('Job blew up on purpose', $failure->exception);
+    }
+}
+
+class AlwaysThrowingTestJob implements ShouldQueue
+{
+    use Dispatchable;
+    use InteractsWithQueue;
+    use Queueable;
+    use SerializesModels;
+
+    public function handle(): void
+    {
+        throw new \RuntimeException('Job blew up on purpose');
+    }
+}

--- a/tests/Unit/Config/LoggingDefaultTest.php
+++ b/tests/Unit/Config/LoggingDefaultTest.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Tests\Unit\Config;
+
+use Tests\TestCase;
+
+class LoggingDefaultTest extends TestCase
+{
+    private ?string $originalLogChannel = null;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $value = getenv('LOG_CHANNEL');
+        $this->originalLogChannel = $value === false ? null : $value;
+    }
+
+    protected function tearDown(): void
+    {
+        $this->setLogChannel($this->originalLogChannel);
+        parent::tearDown();
+    }
+
+    public function test_defaults_to_stack_when_env_unset(): void
+    {
+        $this->setLogChannel(null);
+        $this->assertSame('stack', $this->resolveDefault());
+    }
+
+    public function test_defaults_to_stack_when_env_empty_string(): void
+    {
+        $this->setLogChannel('');
+        $this->assertSame('stack', $this->resolveDefault());
+    }
+
+    public function test_defaults_to_stack_when_env_is_literal_null_string(): void
+    {
+        $this->setLogChannel('null');
+        $this->assertSame('stack', $this->resolveDefault());
+    }
+
+    public function test_uses_single_when_env_is_single(): void
+    {
+        $this->setLogChannel('single');
+        $this->assertSame('single', $this->resolveDefault());
+    }
+
+    public function test_uses_stack_when_env_is_stack(): void
+    {
+        $this->setLogChannel('stack');
+        $this->assertSame('stack', $this->resolveDefault());
+    }
+
+    private function setLogChannel(?string $value): void
+    {
+        if ($value === null) {
+            putenv('LOG_CHANNEL');
+            unset($_ENV['LOG_CHANNEL'], $_SERVER['LOG_CHANNEL']);
+
+            return;
+        }
+        putenv('LOG_CHANNEL='.$value);
+        $_ENV['LOG_CHANNEL'] = $value;
+        $_SERVER['LOG_CHANNEL'] = $value;
+    }
+
+    private function resolveDefault(): string
+    {
+        $config = require base_path('config/logging.php');
+
+        return $config['default'];
+    }
+}


### PR DESCRIPTION
## Summary

Closes the remaining three production-reliability issues in Phase B. Bundled into one PR to keep preview-env spend down.

### 1. `failed_jobs` migration (Closes #211)

Production `php artisan queue:failed` errored with `SQLSTATE[42P01]: Undefined table` because no `create_failed_jobs_table` migration was committed. Any queued job that threw was silently dropped, no audit trail, no retry option. Risk grows with the push-notification fan-out from #69.

- New: `database/migrations/2026_05_13_091745_create_failed_jobs_table.php` — Laravel's canonical scaffolding from `queue:failed-table`. Works with the `database-uuids` driver configured at `config/queue.php:74` (Postgres BIGSERIAL auto-fills `id` when Laravel inserts without it).
- New: `tests/Feature/Queue/FailedJobsTableTest.php` — dispatches an inline throwing job through the database driver, runs `queue:work --once`, asserts the row written to `failed_jobs`.

### 2. Logger null-driver guard (Closes #212)

On 2026-04-29 20:57 UTC, `LOG_CHANNEL` was briefly unset or empty during a deploy, resolving `env('LOG_CHANNEL', 'stack')` to the literal string `'null'`, which selected the null-driver channel at `config/logging.php:77-79` and silenced production logs for ~24h.

- `config/logging.php:12` now guards the resolution: empty, missing, or `'null'` values fall back to `'stack'`.
- New: `tests/Unit/Config/LoggingDefaultTest.php` (5 cases). Passes under PHPUnit 11.5.55.
- Post-merge: pin `LOG_CHANNEL=stack` on Upsun env so the var is explicitly set.

### 3. PHP-FPM scaling (Closes #213)

Production app container was 128MB at size 0.25, which capped `pm.max_children` at 3. Daily `WARNING: [pool web] server reached max_children setting (3)` warnings would worsen under push-notification cron load.

- `.upsun/config.yaml`: added `container_profile: BALANCED` (raises floor to ~640MB at current CPU band, scales proportionally with autoscaler).
- Added `runtime.sizing_hints` (`request_memory: 35`, `reserved_memory: 70`). Upsun computes `pm.max_children = ceil((container_memory - reserved_memory) / request_memory)`, yielding ~16 workers at 640MB. Literal `pm.*` overrides are not supported by the platform — sizing_hints is the documented mechanism (https://developer.upsun.com/docs/languages/php/fpm).

### 4. Bound failed_jobs PII exposure (review follow-up)

Restoring `failed_jobs` introduces a sensitive-data surface: payloads of notifications that take non-model constructor args (e.g. `WeeklyDigestNotification(public array $digest)`) get serialised verbatim. Mitigation:

- `routes/console.php`: scheduled `queue:prune-failed --hours=72` daily at 04:00 so the exposure window is bounded.
- Structural follow-up parked in `docs/ROADMAP.md` parking lot: refactor non-model notification constructors so SerializesModels handles the payload.

## Test plan

- [ ] CI green (PHPUnit + Pint).
- [ ] On the preview env: `php artisan queue:failed` returns `No failed jobs!` (not SQL error).
- [ ] On the preview env: `php artisan tinker --execute="echo config('logging.default');"` returns `stack`.
- [ ] On the preview env: `upsun ssh -- "grep -e '^pm.max_children' /etc/php/*/fpm/php-fpm.conf"` shows >3.
- [ ] `php artisan schedule:list` shows the new `queue:prune-failed` entry at 04:00 daily.
- [ ] After merge to main + Upsun deploy: pin `LOG_CHANNEL=stack` on prod env via `upsun var:create`.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>