### PR TITLE
feat: allergen foundation — schema, member profiles, family settings

### DIFF
--- a/app/Http/Controllers/Api/V1/AllergenController.php
+++ b/app/Http/Controllers/Api/V1/AllergenController.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace App\Http\Controllers\Api\V1;
+
+use App\Http\Controllers\Controller;
+use App\Models\Allergen;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Str;
+
+class AllergenController extends Controller
+{
+    /**
+     * List allergens available to the current family (global Big 9 + family customs).
+     */
+    public function index(Request $request): JsonResponse
+    {
+        $user = $request->user();
+        $family = $user->currentFamily()->firstOrFail();
+
+        $allergens = Allergen::availableToFamily($family->id)
+            ->orderByDesc('is_big_nine')
+            ->orderBy('name')
+            ->get(['id', 'family_id', 'name', 'slug', 'is_big_nine']);
+
+        return response()->json(['allergens' => $allergens]);
+    }
+
+    /**
+     * Add a family-scoped custom allergen (parent only).
+     */
+    public function store(Request $request): JsonResponse
+    {
+        $this->authorize('create', Allergen::class);
+
+        $user = $request->user();
+        $family = $user->currentFamily()->firstOrFail();
+
+        $validated = $request->validate([
+            'name' => ['required', 'string', 'max:80'],
+        ]);
+
+        $slug = Str::slug($validated['name']);
+
+        if ($slug === '') {
+            return response()->json(['message' => 'Name must contain at least one alphanumeric character.'], 422);
+        }
+
+        $duplicate = Allergen::availableToFamily($family->id)->where('slug', $slug)->exists();
+        if ($duplicate) {
+            return response()->json(['message' => 'An allergen with that name already exists.'], 422);
+        }
+
+        $allergen = Allergen::create([
+            'family_id' => $family->id,
+            'name' => $validated['name'],
+            'slug' => $slug,
+            'is_big_nine' => false,
+        ]);
+
+        return response()->json(['allergen' => $allergen->only(['id', 'family_id', 'name', 'slug', 'is_big_nine'])], 201);
+    }
+
+    /**
+     * Rename a family-scoped custom allergen (parent only). Big 9 are immutable.
+     */
+    public function update(Request $request, Allergen $allergen): JsonResponse
+    {
+        $this->authorize('update', $allergen);
+
+        $validated = $request->validate([
+            'name' => ['required', 'string', 'max:80'],
+        ]);
+
+        $slug = Str::slug($validated['name']);
+
+        if ($slug === '') {
+            return response()->json(['message' => 'Name must contain at least one alphanumeric character.'], 422);
+        }
+
+        $duplicate = Allergen::availableToFamily((string) $allergen->family_id)
+            ->where('slug', $slug)
+            ->where('id', '!=', $allergen->id)
+            ->exists();
+        if ($duplicate) {
+            return response()->json(['message' => 'An allergen with that name already exists.'], 422);
+        }
+
+        $allergen->update([
+            'name' => $validated['name'],
+            'slug' => $slug,
+        ]);
+
+        return response()->json(['allergen' => $allergen->only(['id', 'family_id', 'name', 'slug', 'is_big_nine'])]);
+    }
+
+    /**
+     * Delete a family-scoped custom allergen (parent only). Big 9 are immutable.
+     */
+    public function destroy(Allergen $allergen): JsonResponse
+    {
+        $this->authorize('delete', $allergen);
+
+        $allergen->delete();
+
+        return response()->json(['deleted' => true]);
+    }
+}

--- a/app/Http/Controllers/Api/V1/UserAllergenController.php
+++ b/app/Http/Controllers/Api/V1/UserAllergenController.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace App\Http\Controllers\Api\V1;
+
+use App\Http\Controllers\Controller;
+use App\Models\Allergen;
+use App\Models\User;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class UserAllergenController extends Controller
+{
+    /**
+     * Read a member's allergy profile. Auth: any family member can read any other
+     * family member's profile (allergies are not private within a family).
+     */
+    public function index(Request $request, User $user): JsonResponse
+    {
+        $this->assertSameFamily($request, $user);
+
+        return response()->json([
+            'allergen_ids' => $user->allergens()->pluck('allergens.id')->values(),
+            'reviewed_at' => optional($user->allergen_profile_reviewed_at)->toIso8601String(),
+        ]);
+    }
+
+    /**
+     * Replace a member's allergy profile. Auth: parents may edit anyone in the
+     * family; members may edit only their own. Setting any IDs counts as a review.
+     */
+    public function update(Request $request, User $user): JsonResponse
+    {
+        $this->assertSameFamily($request, $user);
+        $this->assertCanEdit($request, $user);
+
+        $validated = $request->validate([
+            'allergen_ids' => ['present', 'array'],
+            'allergen_ids.*' => ['uuid'],
+        ]);
+
+        $family = $request->user()->currentFamily()->firstOrFail();
+
+        // All submitted IDs must be available to this family (global Big 9 or family customs).
+        $valid = Allergen::availableToFamily($family->id)
+            ->whereIn('id', $validated['allergen_ids'])
+            ->pluck('id')
+            ->all();
+
+        if (count($valid) !== count($validated['allergen_ids'])) {
+            return response()->json(['message' => 'One or more allergens are not available to this family.'], 422);
+        }
+
+        $user->allergens()->sync($valid);
+        $user->forceFill(['allergen_profile_reviewed_at' => now()])->save();
+
+        return response()->json([
+            'allergen_ids' => $user->allergens()->pluck('allergens.id')->values(),
+            'reviewed_at' => $user->allergen_profile_reviewed_at->toIso8601String(),
+        ]);
+    }
+
+    /**
+     * Mark a member's allergy profile as reviewed without changing it (e.g., to
+     * confirm "no allergies" and clear the dashboard prompt).
+     */
+    public function markReviewed(Request $request, User $user): JsonResponse
+    {
+        $this->assertSameFamily($request, $user);
+        $this->assertCanEdit($request, $user);
+
+        $user->forceFill(['allergen_profile_reviewed_at' => now()])->save();
+
+        return response()->json([
+            'reviewed_at' => $user->allergen_profile_reviewed_at->toIso8601String(),
+        ]);
+    }
+
+    private function assertSameFamily(Request $request, User $user): void
+    {
+        $current = $request->user();
+        if ($current->family_id !== $user->family_id) {
+            abort(404);
+        }
+    }
+
+    private function assertCanEdit(Request $request, User $user): void
+    {
+        $current = $request->user();
+        if ($current->isParent()) {
+            return;
+        }
+        if ((string) $current->id === (string) $user->id) {
+            return;
+        }
+        abort(403, 'Only parents can edit another member\'s allergy profile.');
+    }
+}

--- a/app/Models/Allergen.php
+++ b/app/Models/Allergen.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Support\Str;
+
+class Allergen extends Model
+{
+    use HasFactory, HasUuids;
+
+    protected $fillable = [
+        'family_id',
+        'name',
+        'slug',
+        'is_big_nine',
+    ];
+
+    protected $casts = [
+        'is_big_nine' => 'boolean',
+    ];
+
+    protected static function booted(): void
+    {
+        static::creating(function (Allergen $allergen): void {
+            if (empty($allergen->slug) && ! empty($allergen->name)) {
+                $allergen->slug = Str::slug($allergen->name);
+            }
+        });
+    }
+
+    public function family(): BelongsTo
+    {
+        return $this->belongsTo(Family::class);
+    }
+
+    public function members(): BelongsToMany
+    {
+        return $this->belongsToMany(User::class, 'member_allergens')->using(MemberAllergen::class)->withTimestamps();
+    }
+
+    /**
+     * Global Big 9 (family_id is null) plus the given family's customs.
+     */
+    public function scopeAvailableToFamily($query, string $familyId)
+    {
+        return $query->where(function ($q) use ($familyId) {
+            $q->whereNull('family_id')->orWhere('family_id', $familyId);
+        });
+    }
+}

--- a/app/Models/MemberAllergen.php
+++ b/app/Models/MemberAllergen.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Relations\Pivot;
+
+class MemberAllergen extends Pivot
+{
+    use HasUuids;
+
+    protected $table = 'member_allergens';
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -19,6 +19,7 @@ use NotificationChannels\WebPush\HasPushSubscriptions;
  * @property array<string, mixed>|null $dashboard_config
  * @property array<string, mixed>|null $email_preferences
  * @property array<string, mixed>|null $notification_preferences
+ * @property Carbon|null $allergen_profile_reviewed_at
  */
 class User extends Authenticatable implements MustVerifyEmail
 {
@@ -47,6 +48,7 @@ class User extends Authenticatable implements MustVerifyEmail
         'notification_preferences',
         'easter_eggs_found',
         'onboarding_completed_at',
+        'allergen_profile_reviewed_at',
     ];
 
     /**
@@ -90,7 +92,13 @@ class User extends Authenticatable implements MustVerifyEmail
             'easter_eggs_found' => 'array',
             'dashboard_config' => 'json',
             'onboarding_completed_at' => 'datetime',
+            'allergen_profile_reviewed_at' => 'datetime',
         ];
+    }
+
+    public function allergens(): BelongsToMany
+    {
+        return $this->belongsToMany(Allergen::class, 'member_allergens')->using(MemberAllergen::class)->withTimestamps();
     }
 
     /**

--- a/app/Policies/AllergenPolicy.php
+++ b/app/Policies/AllergenPolicy.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\Allergen;
+use App\Models\User;
+
+class AllergenPolicy
+{
+    public function viewAny(User $user): bool
+    {
+        return true;
+    }
+
+    public function create(User $user): bool
+    {
+        return $user->isParent();
+    }
+
+    /**
+     * Updates are restricted to family-scoped customs by a parent in the same family.
+     * Global Big 9 rows (family_id null) are immutable.
+     */
+    public function update(User $user, Allergen $allergen): bool
+    {
+        if ($allergen->family_id === null) {
+            return false;
+        }
+
+        return $user->isParent() && $allergen->family_id === $user->family_id;
+    }
+
+    public function delete(User $user, Allergen $allergen): bool
+    {
+        return $this->update($user, $allergen);
+    }
+}

--- a/database/migrations/2026_05_21_000002_create_allergens_table.php
+++ b/database/migrations/2026_05_21_000002_create_allergens_table.php
@@ -1,0 +1,54 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Str;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('allergens', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->foreignUuid('family_id')->nullable()->constrained()->cascadeOnDelete();
+            $table->string('name');
+            $table->string('slug');
+            $table->boolean('is_big_nine')->default(false);
+            $table->timestamps();
+
+            $table->unique(['family_id', 'slug']);
+            $table->index('family_id');
+        });
+
+        // Seed the Big 9 as global rows (family_id = null).
+        $now = now();
+        $bigNine = [
+            ['slug' => 'milk',       'name' => 'Milk'],
+            ['slug' => 'eggs',       'name' => 'Eggs'],
+            ['slug' => 'fish',       'name' => 'Fish'],
+            ['slug' => 'shellfish',  'name' => 'Shellfish'],
+            ['slug' => 'tree-nuts',  'name' => 'Tree nuts'],
+            ['slug' => 'peanuts',    'name' => 'Peanuts'],
+            ['slug' => 'wheat',      'name' => 'Wheat / gluten'],
+            ['slug' => 'soy',        'name' => 'Soy'],
+            ['slug' => 'sesame',     'name' => 'Sesame'],
+        ];
+
+        DB::table('allergens')->insert(array_map(fn ($row) => [
+            'id' => (string) Str::uuid(),
+            'family_id' => null,
+            'name' => $row['name'],
+            'slug' => $row['slug'],
+            'is_big_nine' => true,
+            'created_at' => $now,
+            'updated_at' => $now,
+        ], $bigNine));
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('allergens');
+    }
+};

--- a/database/migrations/2026_05_21_000003_create_member_allergens_table.php
+++ b/database/migrations/2026_05_21_000003_create_member_allergens_table.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('member_allergens', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->foreignUuid('user_id')->constrained()->cascadeOnDelete();
+            $table->foreignUuid('allergen_id')->constrained()->cascadeOnDelete();
+            $table->timestamps();
+
+            $table->unique(['user_id', 'allergen_id']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('member_allergens');
+    }
+};

--- a/database/migrations/2026_05_21_000004_add_allergen_profile_reviewed_at_to_users_table.php
+++ b/database/migrations/2026_05_21_000004_add_allergen_profile_reviewed_at_to_users_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->timestamp('allergen_profile_reviewed_at')->nullable()->after('notification_preferences');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('allergen_profile_reviewed_at');
+        });
+    }
+};

--- a/resources/js/components/allergens/AllergenSelector.vue
+++ b/resources/js/components/allergens/AllergenSelector.vue
@@ -1,0 +1,67 @@
+<!--
+  AllergenSelector — chip-based multi-select for allergens.
+  Used by AllergyProfileEditor and (in PR2) the recipe form.
+  Parents-only when allowAddCustom is true.
+-->
+<script setup>
+import { computed } from 'vue'
+import KinChip from '@/components/design-system/KinChip.vue'
+
+const props = defineProps({
+  allergens: { type: Array, required: true },
+  modelValue: { type: Array, required: true },
+  disabled: { type: Boolean, default: false },
+})
+
+const emit = defineEmits(['update:modelValue'])
+
+const selectedSet = computed(() => new Set(props.modelValue))
+
+const bigNine = computed(() => props.allergens.filter((a) => a.is_big_nine))
+const customs = computed(() => props.allergens.filter((a) => !a.is_big_nine))
+
+const toggle = (id) => {
+  if (props.disabled) return
+  const next = new Set(selectedSet.value)
+  if (next.has(id)) next.delete(id)
+  else next.add(id)
+  emit('update:modelValue', Array.from(next))
+}
+</script>
+
+<template>
+  <div class="space-y-3">
+    <div>
+      <p class="text-xs font-medium text-ink-secondary mb-2">Common allergens</p>
+      <div class="flex flex-wrap gap-2">
+        <KinChip
+          v-for="allergen in bigNine"
+          :key="allergen.id"
+          variant="filter"
+          :active="selectedSet.has(allergen.id)"
+          :disabled="disabled"
+          @click="toggle(allergen.id)"
+        >
+          {{ allergen.name }}
+        </KinChip>
+      </div>
+    </div>
+
+    <div v-if="customs.length">
+      <p class="text-xs font-medium text-ink-secondary mb-2">Your family's allergens</p>
+      <div class="flex flex-wrap gap-2">
+        <KinChip
+          v-for="allergen in customs"
+          :key="allergen.id"
+          variant="filter"
+          color="lavender"
+          :active="selectedSet.has(allergen.id)"
+          :disabled="disabled"
+          @click="toggle(allergen.id)"
+        >
+          {{ allergen.name }}
+        </KinChip>
+      </div>
+    </div>
+  </div>
+</template>

--- a/resources/js/components/allergens/AllergyProfileEditor.vue
+++ b/resources/js/components/allergens/AllergyProfileEditor.vue
@@ -1,0 +1,99 @@
+<!--
+  AllergyProfileEditor — per-member allergy profile editor. Wraps AllergenSelector,
+  surfaces Save and "I have no allergies" (mark reviewed) actions.
+-->
+<script setup>
+import { ref, computed, watch } from 'vue'
+import { useAllergensStore } from '@/stores/allergens'
+import AllergenSelector from './AllergenSelector.vue'
+import KinButton from '@/components/design-system/KinButton.vue'
+
+const props = defineProps({
+  user: { type: Object, required: true }, // { id, name }
+  canEdit: { type: Boolean, default: true },
+})
+
+const allergens = useAllergensStore()
+
+const selectedIds = ref([])
+const saving = ref(false)
+const markingReviewed = ref(false)
+const lastError = ref('')
+const lastSavedAt = ref(null)
+
+const profile = computed(() => allergens.profileFor(props.user.id))
+const reviewed = computed(() => Boolean(profile.value?.reviewed_at))
+
+const loadProfile = async () => {
+  await allergens.fetchMemberProfile(props.user.id)
+  selectedIds.value = [...(profile.value?.allergen_ids ?? [])]
+}
+
+watch(() => props.user.id, loadProfile, { immediate: true })
+
+const save = async () => {
+  if (!props.canEdit) return
+  saving.value = true
+  lastError.value = ''
+  const result = await allergens.saveMemberProfile(props.user.id, selectedIds.value)
+  saving.value = false
+  if (!result.success) {
+    lastError.value = result.error
+  } else {
+    lastSavedAt.value = new Date()
+  }
+}
+
+const markNoAllergies = async () => {
+  if (!props.canEdit) return
+  markingReviewed.value = true
+  lastError.value = ''
+  selectedIds.value = []
+  const save = await allergens.saveMemberProfile(props.user.id, [])
+  markingReviewed.value = false
+  if (!save.success) {
+    lastError.value = save.error
+  } else {
+    lastSavedAt.value = new Date()
+  }
+}
+</script>
+
+<template>
+  <div class="space-y-4">
+    <div class="flex items-baseline justify-between gap-3">
+      <h3 class="text-sm font-semibold text-ink-primary">{{ user.name }}</h3>
+      <p v-if="!reviewed" class="text-xs text-status-warning font-medium">
+        Not yet reviewed
+      </p>
+      <p v-else class="text-xs text-ink-tertiary">
+        Reviewed
+      </p>
+    </div>
+
+    <AllergenSelector
+      v-model="selectedIds"
+      :allergens="allergens.allergens"
+      :disabled="!canEdit"
+    />
+
+    <p v-if="lastError" class="text-xs text-status-error" role="alert">
+      {{ lastError }}
+    </p>
+
+    <div v-if="canEdit" class="flex flex-wrap items-center gap-2 pt-1">
+      <KinButton variant="primary" size="sm" :loading="saving" @click="save">
+        Save profile
+      </KinButton>
+      <KinButton
+        v-if="!reviewed && selectedIds.length === 0"
+        variant="secondary"
+        size="sm"
+        :loading="markingReviewed"
+        @click="markNoAllergies"
+      >
+        Confirm: no allergies
+      </KinButton>
+    </div>
+  </div>
+</template>

--- a/resources/js/components/allergens/AllergyProfileReviewBanner.vue
+++ b/resources/js/components/allergens/AllergyProfileReviewBanner.vue
@@ -1,0 +1,53 @@
+<!--
+  AllergyProfileReviewBanner — dashboard prompt shown until a member's allergy
+  profile has been explicitly reviewed (even if reviewed-as-empty).
+  Hidden when food module is off or when the profile is already reviewed.
+-->
+<script setup>
+import { computed, onMounted } from 'vue'
+import { useRouter } from 'vue-router'
+import { useAuthStore } from '@/stores/auth'
+import { useAllergensStore } from '@/stores/allergens'
+import KinButton from '@/components/design-system/KinButton.vue'
+import { ShieldExclamationIcon } from '@heroicons/vue/24/outline'
+
+const router = useRouter()
+const auth = useAuthStore()
+const allergens = useAllergensStore()
+
+const foodEnabled = computed(() => auth.userCanAccessModule('food'))
+const userId = computed(() => auth.user?.id)
+
+const profile = computed(() => (userId.value ? allergens.profileFor(userId.value) : null))
+const reviewed = computed(() => Boolean(profile.value?.reviewed_at))
+const visible = computed(() => foodEnabled.value && userId.value && profile.value !== null && !reviewed.value)
+
+onMounted(async () => {
+  if (foodEnabled.value && userId.value) {
+    await allergens.fetchMemberProfile(userId.value)
+  }
+})
+
+const goToSettings = () => {
+  router.push({ name: 'Settings', hash: '#allergens' })
+}
+</script>
+
+<template>
+  <div
+    v-if="visible"
+    class="flex items-start gap-3 p-4 rounded-lg bg-status-warning/10 border border-status-warning/30"
+    role="status"
+  >
+    <ShieldExclamationIcon class="w-5 h-5 text-status-warning shrink-0 mt-0.5" />
+    <div class="flex-1 min-w-0">
+      <p class="text-sm font-medium text-ink-primary">Set up your allergy profile</p>
+      <p class="text-xs text-ink-secondary mt-0.5">
+        Tell Kinhold about any food allergies so the meal planner can warn you. Takes about 30 seconds.
+      </p>
+    </div>
+    <KinButton variant="secondary" size="sm" @click="goToSettings">
+      Set up
+    </KinButton>
+  </div>
+</template>

--- a/resources/js/components/allergens/FamilyAllergenSettings.vue
+++ b/resources/js/components/allergens/FamilyAllergenSettings.vue
@@ -1,0 +1,157 @@
+<!--
+  FamilyAllergenSettings — admin view of family-custom allergens.
+  Parents can add, rename, delete; Big 9 are shown read-only.
+-->
+<script setup>
+import { ref, computed, onMounted } from 'vue'
+import { useAllergensStore } from '@/stores/allergens'
+import { useAuthStore } from '@/stores/auth'
+import KinChip from '@/components/design-system/KinChip.vue'
+import KinButton from '@/components/design-system/KinButton.vue'
+import KinInput from '@/components/design-system/KinInput.vue'
+import { TrashIcon, PencilSquareIcon, CheckIcon, XMarkIcon } from '@heroicons/vue/24/outline'
+
+const allergens = useAllergensStore()
+const auth = useAuthStore()
+
+const newName = ref('')
+const adding = ref(false)
+const addError = ref('')
+const editingId = ref(null)
+const editName = ref('')
+const editError = ref('')
+const saving = ref(false)
+
+const isParent = computed(() => auth.isParent)
+
+onMounted(async () => {
+  if (allergens.allergens.length === 0) await allergens.fetchAllergens()
+})
+
+const addCustom = async () => {
+  if (!newName.value.trim()) return
+  adding.value = true
+  addError.value = ''
+  const result = await allergens.createCustom(newName.value.trim())
+  adding.value = false
+  if (result.success) {
+    newName.value = ''
+  } else {
+    addError.value = result.error
+  }
+}
+
+const startEdit = (allergen) => {
+  editingId.value = allergen.id
+  editName.value = allergen.name
+  editError.value = ''
+}
+
+const cancelEdit = () => {
+  editingId.value = null
+  editName.value = ''
+  editError.value = ''
+}
+
+const saveEdit = async () => {
+  if (!editName.value.trim()) return
+  saving.value = true
+  editError.value = ''
+  const result = await allergens.renameCustom(editingId.value, editName.value.trim())
+  saving.value = false
+  if (result.success) {
+    cancelEdit()
+  } else {
+    editError.value = result.error
+  }
+}
+
+const remove = async (allergen) => {
+  if (!confirm(`Remove "${allergen.name}" from your family's allergen list? This won't change anyone's profile.`)) {
+    return
+  }
+  await allergens.deleteCustom(allergen.id)
+}
+</script>
+
+<template>
+  <div class="space-y-5">
+    <div>
+      <p class="text-xs font-medium text-ink-secondary mb-2">Big 9 (always available)</p>
+      <div class="flex flex-wrap gap-2">
+        <KinChip v-for="a in allergens.bigNine" :key="a.id" variant="category" color="neutral">
+          {{ a.name }}
+        </KinChip>
+      </div>
+    </div>
+
+    <div>
+      <p class="text-xs font-medium text-ink-secondary mb-2">Your family's allergens</p>
+      <div v-if="allergens.customs.length === 0" class="text-xs text-ink-tertiary italic">
+        No custom allergens yet.
+      </div>
+      <ul class="space-y-2">
+        <li
+          v-for="a in allergens.customs"
+          :key="a.id"
+          class="flex items-center gap-2 p-2 rounded-md bg-surface-sunken"
+        >
+          <template v-if="editingId === a.id">
+            <KinInput v-model="editName" class="flex-1" @keyup.enter="saveEdit" />
+            <button
+              class="p-1.5 text-status-success hover:bg-status-success/10 rounded"
+              aria-label="Save"
+              :disabled="saving"
+              @click="saveEdit"
+            >
+              <CheckIcon class="w-4 h-4" />
+            </button>
+            <button
+              class="p-1.5 text-ink-tertiary hover:bg-surface-raised rounded"
+              aria-label="Cancel"
+              @click="cancelEdit"
+            >
+              <XMarkIcon class="w-4 h-4" />
+            </button>
+          </template>
+          <template v-else>
+            <span class="flex-1 text-sm text-ink-primary">{{ a.name }}</span>
+            <template v-if="isParent">
+              <button
+                class="p-1.5 text-ink-tertiary hover:bg-surface-raised rounded"
+                aria-label="Rename"
+                @click="startEdit(a)"
+              >
+                <PencilSquareIcon class="w-4 h-4" />
+              </button>
+              <button
+                class="p-1.5 text-status-error hover:bg-status-error/10 rounded"
+                aria-label="Delete"
+                @click="remove(a)"
+              >
+                <TrashIcon class="w-4 h-4" />
+              </button>
+            </template>
+          </template>
+        </li>
+      </ul>
+      <p v-if="editError" class="text-xs text-status-error mt-2" role="alert">{{ editError }}</p>
+    </div>
+
+    <div v-if="isParent" class="pt-2 border-t border-border-subtle">
+      <p class="text-xs font-medium text-ink-secondary mb-2">Add a custom allergen</p>
+      <div class="flex flex-wrap gap-2">
+        <KinInput
+          v-model="newName"
+          placeholder="e.g. Corn, Kiwi, Mustard"
+          class="flex-1 min-w-[200px]"
+          @keyup.enter="addCustom"
+        />
+        <KinButton variant="primary" size="sm" :loading="adding" @click="addCustom">
+          Add
+        </KinButton>
+      </div>
+      <p v-if="addError" class="text-xs text-status-error mt-2" role="alert">{{ addError }}</p>
+    </div>
+  </div>
+</template>

--- a/resources/js/stores/allergens.js
+++ b/resources/js/stores/allergens.js
@@ -1,0 +1,110 @@
+import { defineStore } from 'pinia'
+import { ref, computed } from 'vue'
+import api from '@/services/api'
+
+export const useAllergensStore = defineStore('allergens', () => {
+  const allergens = ref([])
+  const isLoading = ref(false)
+  const profiles = ref({})
+
+  const bigNine = computed(() => allergens.value.filter((a) => a.is_big_nine))
+  const customs = computed(() => allergens.value.filter((a) => !a.is_big_nine))
+
+  const fetchAllergens = async () => {
+    isLoading.value = true
+    try {
+      const response = await api.get('/allergens')
+      allergens.value = response.data.allergens
+      return { success: true }
+    } catch (err) {
+      return { success: false, error: err.response?.data?.message || 'Failed to load allergens' }
+    } finally {
+      isLoading.value = false
+    }
+  }
+
+  const createCustom = async (name) => {
+    try {
+      const response = await api.post('/allergens', { name })
+      allergens.value.push(response.data.allergen)
+      return { success: true, allergen: response.data.allergen }
+    } catch (err) {
+      return { success: false, error: err.response?.data?.message || 'Failed to add allergen' }
+    }
+  }
+
+  const renameCustom = async (id, name) => {
+    try {
+      const response = await api.patch(`/allergens/${id}`, { name })
+      const idx = allergens.value.findIndex((a) => a.id === id)
+      if (idx !== -1) allergens.value[idx] = response.data.allergen
+      return { success: true }
+    } catch (err) {
+      return { success: false, error: err.response?.data?.message || 'Failed to rename allergen' }
+    }
+  }
+
+  const deleteCustom = async (id) => {
+    try {
+      await api.delete(`/allergens/${id}`)
+      allergens.value = allergens.value.filter((a) => a.id !== id)
+      return { success: true }
+    } catch (err) {
+      return { success: false, error: err.response?.data?.message || 'Failed to delete allergen' }
+    }
+  }
+
+  const fetchMemberProfile = async (userId) => {
+    try {
+      const response = await api.get(`/users/${userId}/allergens`)
+      profiles.value[userId] = response.data
+      return { success: true, profile: response.data }
+    } catch (err) {
+      return { success: false, error: err.response?.data?.message || 'Failed to load profile' }
+    }
+  }
+
+  const saveMemberProfile = async (userId, allergenIds) => {
+    try {
+      const response = await api.put(`/users/${userId}/allergens`, { allergen_ids: allergenIds })
+      profiles.value[userId] = response.data
+      return { success: true, profile: response.data }
+    } catch (err) {
+      return { success: false, error: err.response?.data?.message || 'Failed to save profile' }
+    }
+  }
+
+  const markReviewed = async (userId) => {
+    try {
+      const response = await api.post(`/users/${userId}/allergens/mark-reviewed`)
+      if (profiles.value[userId]) {
+        profiles.value[userId].reviewed_at = response.data.reviewed_at
+      } else {
+        profiles.value[userId] = { allergen_ids: [], reviewed_at: response.data.reviewed_at }
+      }
+      return { success: true }
+    } catch (err) {
+      return { success: false, error: err.response?.data?.message || 'Failed to mark reviewed' }
+    }
+  }
+
+  const profileFor = (userId) => profiles.value[userId] || null
+  const isReviewed = (userId) => Boolean(profiles.value[userId]?.reviewed_at)
+
+  return {
+    allergens,
+    isLoading,
+    profiles,
+    bigNine,
+    customs,
+    fetchAllergens,
+    createCustom,
+    renameCustom,
+    deleteCustom,
+    fetchMemberProfile,
+    saveMemberProfile,
+    markReviewed,
+    profileFor,
+    isReviewed,
+  }
+})

--- a/resources/js/views/dashboard/DashboardView.vue
+++ b/resources/js/views/dashboard/DashboardView.vue
@@ -1,5 +1,8 @@
 <template>
   <div class="p-4 md:p-6 max-w-6xl">
+    <!-- Allergy profile review prompt (food module only, hidden when reviewed) -->
+    <AllergyProfileReviewBanner class="mb-4" />
+
     <!-- Edit mode toolbar -->
     <DashboardToolbar
       v-if="dashboardStore.editMode"
@@ -84,6 +87,7 @@ import WidgetPickerModal from '@/components/dashboard/WidgetPickerModal.vue'
 import KinButton from '@/components/design-system/KinButton.vue'
 import KinSkeleton from '@/components/design-system/KinSkeleton.vue'
 import KinEmptyState from '@/components/design-system/KinEmptyState.vue'
+import AllergyProfileReviewBanner from '@/components/allergens/AllergyProfileReviewBanner.vue'
 import { useNotification } from '@/composables/useNotification'
 import { PencilSquareIcon, PlusIcon, Squares2X2Icon } from '@heroicons/vue/24/outline'
 

--- a/resources/js/views/settings/SettingsView.vue
+++ b/resources/js/views/settings/SettingsView.vue
@@ -967,6 +967,33 @@
           </BaseButton>
         </SettingsSection>
 
+        <!-- Section 5b: Allergens (food module only) -->
+        <SettingsSection
+          v-if="foodModuleEnabled"
+          id="allergens"
+          title="Allergens"
+          description="Family allergens and per-member allergy profiles"
+          :icon="ShieldExclamationIcon"
+          :model-value="expandedSections.has('allergens')"
+          @update:model-value="val => toggleSection('allergens', val)"
+        >
+          <div class="space-y-8">
+            <FamilyAllergenSettings />
+
+            <div class="space-y-6 pt-2 border-t border-border-subtle">
+              <div>
+                <h3 class="text-base font-semibold text-ink-primary">Member profiles</h3>
+                <p class="text-xs text-ink-secondary mt-1">
+                  Tag each family member's allergies so the meal planner can warn you when a recipe is unsafe.
+                </p>
+              </div>
+              <div v-for="member in familyMembers" :key="member.id" class="p-4 bg-surface-sunken rounded-lg">
+                <AllergyProfileEditor :user="member" :can-edit="true" />
+              </div>
+            </div>
+          </div>
+        </SettingsSection>
+
         <!-- Section 6: Appearance -->
         <SettingsSection
           id="appearance"
@@ -1206,6 +1233,15 @@
     <!-- CHILD VIEW — Flat cards (unchanged)          -->
     <!-- ============================================ -->
     <template v-if="!isParent">
+      <!-- My Allergies (food module only) -->
+      <div v-if="foodModuleEnabled" id="allergens" class="card-lg mb-6">
+        <div class="flex items-center gap-2 mb-4">
+          <ShieldExclamationIcon class="w-5 h-5 text-accent-lavender-bold" />
+          <h2 class="text-lg font-semibold font-heading text-ink-primary">My Allergies</h2>
+        </div>
+        <AllergyProfileEditor :user="currentUser" :can-edit="true" />
+      </div>
+
       <!-- Appearance -->
       <div class="card-lg mb-6">
         <h2 class="text-lg font-semibold font-heading text-ink-primary mb-4">Appearance</h2>
@@ -1594,6 +1630,8 @@ import KinInput from '@/components/design-system/KinInput.vue'
 import KinSelect from '@/components/design-system/KinSelect.vue'
 import KinSwitch from '@/components/design-system/KinSwitch.vue'
 import SettingsSection from '@/components/settings/SettingsSection.vue'
+import FamilyAllergenSettings from '@/components/allergens/FamilyAllergenSettings.vue'
+import AllergyProfileEditor from '@/components/allergens/AllergyProfileEditor.vue'
 import {
   PlusIcon,
   TrashIcon,
@@ -1609,6 +1647,7 @@ import {
   CloudIcon,
   CakeIcon,
   ShieldCheckIcon,
+  ShieldExclamationIcon,
   SwatchIcon,
   BellIcon,
   CreditCardIcon,
@@ -1648,6 +1687,7 @@ const memberRoleOptions = [
 ]
 
 // ---- Version & Update Check ----
+const foodModuleEnabled = computed(() => authStore.userCanAccessModule('food'))
 const appVersion = computed(() => appConfig.value?.version ?? '—')
 const updateAvailable = computed(() => appConfig.value?.update_available ?? null)
 const updateDismissed = ref(false)

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Http\Controllers\Api\V1\AllergenController;
 use App\Http\Controllers\Api\V1\AuthController;
 use App\Http\Controllers\Api\V1\BadgesController;
 use App\Http\Controllers\Api\V1\BillingController;
@@ -22,6 +23,7 @@ use App\Http\Controllers\Api\V1\SettingsController;
 use App\Http\Controllers\Api\V1\ShoppingListController;
 use App\Http\Controllers\Api\V1\TagController;
 use App\Http\Controllers\Api\V1\TaskController;
+use App\Http\Controllers\Api\V1\UserAllergenController;
 use App\Http\Controllers\Api\V1\VaultController;
 use App\Models\Family;
 use App\Models\User;
@@ -228,6 +230,21 @@ Route::prefix('v1')->group(function () {
                 Route::post('/{recipe}/cook-logs', [RecipeController::class, 'addCookLog']);
                 Route::post('/{recipe}/rate', [RecipeController::class, 'rate']);
                 Route::get('/{recipe}/ratings', [RecipeController::class, 'ratings']);
+            });
+
+            // Allergens (module: food)
+            Route::prefix('/allergens')->middleware('module:food')->group(function () {
+                Route::get('/', [AllergenController::class, 'index']);
+                Route::post('/', [AllergenController::class, 'store']);
+                Route::patch('/{allergen}', [AllergenController::class, 'update']);
+                Route::delete('/{allergen}', [AllergenController::class, 'destroy']);
+            });
+
+            // Member allergy profiles (module: food)
+            Route::prefix('/users/{user}/allergens')->middleware('module:food')->group(function () {
+                Route::get('/', [UserAllergenController::class, 'index']);
+                Route::put('/', [UserAllergenController::class, 'update']);
+                Route::post('/mark-reviewed', [UserAllergenController::class, 'markReviewed']);
             });
 
             // Shopping (module: food)

--- a/tests/Feature/AllergenTest.php
+++ b/tests/Feature/AllergenTest.php
@@ -1,0 +1,271 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Enums\FamilyRole;
+use App\Models\Allergen;
+use App\Models\Family;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Sanctum\Sanctum;
+use Tests\TestCase;
+
+class AllergenTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private Family $family;
+
+    private Family $otherFamily;
+
+    private User $parent;
+
+    private User $child;
+
+    private User $otherParent;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->family = Family::create([
+            'name' => 'Test Family',
+            'slug' => 'test-family',
+            'invite_code' => 'TEST01',
+            'settings' => ['modules' => ['food' => true]],
+        ]);
+
+        $this->otherFamily = Family::create([
+            'name' => 'Other Family',
+            'slug' => 'other-family',
+            'invite_code' => 'OTHER1',
+            'settings' => ['modules' => ['food' => true]],
+        ]);
+
+        $this->parent = $this->makeUser('Parent', 'parent@test.com', $this->family, FamilyRole::Parent);
+        $this->child = $this->makeUser('Child', 'child@test.com', $this->family, FamilyRole::Child);
+        $this->otherParent = $this->makeUser('Other Parent', 'other@test.com', $this->otherFamily, FamilyRole::Parent);
+    }
+
+    // ---------- Allergen list / CRUD ----------
+
+    public function test_big_nine_seeded_globally(): void
+    {
+        $bigNine = Allergen::whereNull('family_id')->where('is_big_nine', true)->get();
+
+        $this->assertCount(9, $bigNine);
+        $this->assertEqualsCanonicalizing(
+            ['milk', 'eggs', 'fish', 'shellfish', 'tree-nuts', 'peanuts', 'wheat', 'soy', 'sesame'],
+            $bigNine->pluck('slug')->all()
+        );
+    }
+
+    public function test_index_returns_big_nine_plus_family_customs(): void
+    {
+        Allergen::create(['family_id' => $this->family->id, 'name' => 'Corn', 'slug' => 'corn']);
+        Allergen::create(['family_id' => $this->otherFamily->id, 'name' => 'Kiwi', 'slug' => 'kiwi']);
+
+        Sanctum::actingAs($this->parent);
+        $response = $this->getJson('/api/v1/allergens')->assertOk();
+
+        $slugs = collect($response->json('allergens'))->pluck('slug')->all();
+        $this->assertContains('milk', $slugs);
+        $this->assertContains('corn', $slugs);
+        $this->assertNotContains('kiwi', $slugs);
+    }
+
+    public function test_parent_can_create_custom_allergen(): void
+    {
+        Sanctum::actingAs($this->parent);
+
+        $this->postJson('/api/v1/allergens', ['name' => 'Corn'])
+            ->assertCreated()
+            ->assertJsonPath('allergen.slug', 'corn')
+            ->assertJsonPath('allergen.family_id', $this->family->id)
+            ->assertJsonPath('allergen.is_big_nine', false);
+    }
+
+    public function test_child_cannot_create_custom_allergen(): void
+    {
+        Sanctum::actingAs($this->child);
+
+        $this->postJson('/api/v1/allergens', ['name' => 'Corn'])->assertForbidden();
+    }
+
+    public function test_duplicate_custom_name_rejected(): void
+    {
+        Allergen::create(['family_id' => $this->family->id, 'name' => 'Corn', 'slug' => 'corn']);
+        Sanctum::actingAs($this->parent);
+
+        $this->postJson('/api/v1/allergens', ['name' => 'Corn'])
+            ->assertStatus(422)
+            ->assertJson(['message' => 'An allergen with that name already exists.']);
+    }
+
+    public function test_custom_cannot_collide_with_big_nine_slug(): void
+    {
+        Sanctum::actingAs($this->parent);
+
+        $this->postJson('/api/v1/allergens', ['name' => 'Milk'])
+            ->assertStatus(422)
+            ->assertJson(['message' => 'An allergen with that name already exists.']);
+    }
+
+    public function test_parent_can_rename_their_family_custom(): void
+    {
+        $allergen = Allergen::create(['family_id' => $this->family->id, 'name' => 'Corn', 'slug' => 'corn']);
+        Sanctum::actingAs($this->parent);
+
+        $this->patchJson("/api/v1/allergens/{$allergen->id}", ['name' => 'Corn (sweet)'])
+            ->assertOk()
+            ->assertJsonPath('allergen.slug', 'corn-sweet');
+    }
+
+    public function test_parent_cannot_rename_big_nine(): void
+    {
+        $milk = Allergen::where('slug', 'milk')->whereNull('family_id')->firstOrFail();
+        Sanctum::actingAs($this->parent);
+
+        $this->patchJson("/api/v1/allergens/{$milk->id}", ['name' => 'Dairy'])->assertForbidden();
+    }
+
+    public function test_parent_cannot_modify_another_familys_custom(): void
+    {
+        $allergen = Allergen::create(['family_id' => $this->otherFamily->id, 'name' => 'Kiwi', 'slug' => 'kiwi']);
+        Sanctum::actingAs($this->parent);
+
+        $this->patchJson("/api/v1/allergens/{$allergen->id}", ['name' => 'Kiwi fruit'])->assertForbidden();
+        $this->deleteJson("/api/v1/allergens/{$allergen->id}")->assertForbidden();
+    }
+
+    public function test_parent_can_delete_their_family_custom(): void
+    {
+        $allergen = Allergen::create(['family_id' => $this->family->id, 'name' => 'Corn', 'slug' => 'corn']);
+        Sanctum::actingAs($this->parent);
+
+        $this->deleteJson("/api/v1/allergens/{$allergen->id}")->assertOk();
+        $this->assertDatabaseMissing('allergens', ['id' => $allergen->id]);
+    }
+
+    // ---------- Member allergy profile ----------
+
+    public function test_member_profile_starts_empty_and_unreviewed(): void
+    {
+        Sanctum::actingAs($this->parent);
+
+        $response = $this->getJson("/api/v1/users/{$this->child->id}/allergens")->assertOk();
+        $this->assertEquals([], $response->json('allergen_ids'));
+        $this->assertNull($response->json('reviewed_at'));
+    }
+
+    public function test_parent_can_set_any_members_profile_and_it_marks_reviewed(): void
+    {
+        $peanuts = Allergen::where('slug', 'peanuts')->whereNull('family_id')->firstOrFail();
+        Sanctum::actingAs($this->parent);
+
+        $response = $this->putJson("/api/v1/users/{$this->child->id}/allergens", [
+            'allergen_ids' => [$peanuts->id],
+        ])->assertOk();
+
+        $this->assertEquals([$peanuts->id], $response->json('allergen_ids'));
+        $this->assertNotNull($response->json('reviewed_at'));
+        $this->assertDatabaseHas('member_allergens', [
+            'user_id' => $this->child->id,
+            'allergen_id' => $peanuts->id,
+        ]);
+    }
+
+    public function test_member_can_edit_their_own_profile(): void
+    {
+        $peanuts = Allergen::where('slug', 'peanuts')->whereNull('family_id')->firstOrFail();
+        Sanctum::actingAs($this->child);
+
+        $this->putJson("/api/v1/users/{$this->child->id}/allergens", [
+            'allergen_ids' => [$peanuts->id],
+        ])->assertOk();
+    }
+
+    public function test_member_cannot_edit_anothers_profile(): void
+    {
+        $peanuts = Allergen::where('slug', 'peanuts')->whereNull('family_id')->firstOrFail();
+        Sanctum::actingAs($this->child);
+
+        $this->putJson("/api/v1/users/{$this->parent->id}/allergens", [
+            'allergen_ids' => [$peanuts->id],
+        ])->assertForbidden();
+    }
+
+    public function test_cannot_view_or_edit_member_in_other_family(): void
+    {
+        Sanctum::actingAs($this->parent);
+
+        $this->getJson("/api/v1/users/{$this->otherParent->id}/allergens")->assertNotFound();
+        $this->putJson("/api/v1/users/{$this->otherParent->id}/allergens", ['allergen_ids' => []])->assertNotFound();
+    }
+
+    public function test_cannot_set_allergen_not_available_to_family(): void
+    {
+        $otherFamilyAllergen = Allergen::create([
+            'family_id' => $this->otherFamily->id,
+            'name' => 'Kiwi',
+            'slug' => 'kiwi',
+        ]);
+
+        Sanctum::actingAs($this->parent);
+
+        $this->putJson("/api/v1/users/{$this->child->id}/allergens", [
+            'allergen_ids' => [$otherFamilyAllergen->id],
+        ])->assertStatus(422);
+    }
+
+    public function test_mark_reviewed_clears_prompt_without_changing_profile(): void
+    {
+        Sanctum::actingAs($this->parent);
+
+        $response = $this->postJson("/api/v1/users/{$this->child->id}/allergens/mark-reviewed")->assertOk();
+        $this->assertNotNull($response->json('reviewed_at'));
+        $this->assertEquals(0, $this->child->fresh()->allergens()->count());
+    }
+
+    public function test_replacing_with_empty_set_still_counts_as_reviewed(): void
+    {
+        $peanuts = Allergen::where('slug', 'peanuts')->whereNull('family_id')->firstOrFail();
+        $this->child->allergens()->attach($peanuts->id);
+
+        Sanctum::actingAs($this->parent);
+
+        $response = $this->putJson("/api/v1/users/{$this->child->id}/allergens", [
+            'allergen_ids' => [],
+        ])->assertOk();
+
+        $this->assertEquals([], $response->json('allergen_ids'));
+        $this->assertNotNull($response->json('reviewed_at'));
+    }
+
+    // ---------- Module gating ----------
+
+    public function test_module_gating_blocks_allergen_routes_when_food_disabled(): void
+    {
+        $this->family->settings = ['modules' => ['food' => false]];
+        $this->family->save();
+
+        Sanctum::actingAs($this->parent);
+
+        $this->getJson('/api/v1/allergens')->assertForbidden();
+        $this->postJson('/api/v1/allergens', ['name' => 'Corn'])->assertForbidden();
+        $this->getJson("/api/v1/users/{$this->child->id}/allergens")->assertForbidden();
+        $this->putJson("/api/v1/users/{$this->child->id}/allergens", ['allergen_ids' => []])->assertForbidden();
+        $this->postJson("/api/v1/users/{$this->child->id}/allergens/mark-reviewed")->assertForbidden();
+    }
+
+    private function makeUser(string $name, string $email, Family $family, FamilyRole $role): User
+    {
+        return User::create([
+            'name' => $name,
+            'email' => $email,
+            'password' => bcrypt('password'),
+            'family_id' => $family->id,
+            'family_role' => $role,
+        ]);
+    }
+}


### PR DESCRIPTION
## Summary
PR 1 of 4+1 toward v1.10.0. Lays the allergen foundation: schema, models, policies, member allergy profile, and family allergen settings. **No recipe tagging, no filtering, no AI** — those land in #315 / #316 / #317.

## Linked Issues
Closes #314
Part of #312 (parent)

## What ships
**Schema:**
- `allergens` table with Big 9 seeded as global rows (`family_id` null) + per-family customs
- `member_allergens` pivot (UUID-keyed via `MemberAllergen` pivot model)
- `users.allergen_profile_reviewed_at` nullable timestamp

**Backend:**
- `Allergen` model with `availableToFamily()` scope (Big 9 union family customs)
- `AllergenPolicy` — parents create; only the owning family may modify their own customs; Big 9 immutable
- `AllergenController` (CRUD on customs) + `UserAllergenController` (member profile + mark-reviewed)
- All routes gated by `module:food` middleware (food off → 403 everywhere)
- Cross-family access returns 404

**Vue (Composition API, design-system aligned, mobile-first):**
- Pinia `allergens` store
- `AllergenSelector` — reusable chip-based multi-select (used by recipe form in PR 2)
- `AllergyProfileEditor` — wraps selector + Save / "Confirm: no allergies"
- `AllergyProfileReviewBanner` — dashboard banner shown until current member's profile is reviewed
- `FamilyAllergenSettings` — Big 9 read-only + customs list with inline rename/delete + add form
- Settings: new "Allergens" section (parents) and "My Allergies" card (members)
- Dashboard: review banner mounted above widget grid

## Test Plan
- [x] Migrations run cleanly with reversible `down()`
- [x] Big 9 seeded as global rows
- [x] 19 new tests in `AllergenTest` covering Big 9 seed, CRUD permission matrix, member profile read/write/mark-reviewed, cross-family scoping, module gating
- [x] Full suite: 383 tests, 1004 assertions, green
- [x] Pint clean, PHPStan clean, ESLint clean on new files
- [x] **Manual verification in preview env**: demo-login as Adaeze (parent) → dashboard shows review banner → "Set up" navigates to `/settings#allergens` → add "Cinnamon" persists → toggle "Peanuts" on Adaeze + Save → status flips to "Reviewed" → banner disappears on dashboard

## Checklist
- [x] Tested locally + in preview
- [x] Mobile-first verified (chip wrapping holds at 375px)
- [x] No credentials committed
- [x] API gated by module middleware (defense in depth)

## Target branch
`feature/allergens-v1.10.0` (integration branch; do NOT merge to main yet — see [docs/ALLERGENS-IMPLEMENTATION-PLAN.md](../blob/main/docs/ALLERGENS-IMPLEMENTATION-PLAN.md))

## Blocks
- #315 (recipe tagging — needs Allergen model and `availableToFamily` scope)