### PR TITLE
feat: recipe allergen tagging (manual) — pivot, badges, form, detail

### DIFF
--- a/app/Enums/AllergenPresence.php
+++ b/app/Enums/AllergenPresence.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Enums;
+
+enum AllergenPresence: string
+{
+    case Contains = 'contains';
+    case MayContain = 'may_contain';
+
+    public function label(): string
+    {
+        return match ($this) {
+            self::Contains => 'Contains',
+            self::MayContain => 'May contain',
+        };
+    }
+}

--- a/app/Enums/AllergenSource.php
+++ b/app/Enums/AllergenSource.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Enums;
+
+enum AllergenSource: string
+{
+    case AiAuto = 'ai_auto';
+    case AiSuggested = 'ai_suggested';
+    case HumanConfirmed = 'human_confirmed';
+    case Imported = 'imported';
+
+    public function label(): string
+    {
+        return match ($this) {
+            self::AiAuto => 'AI tagged',
+            self::AiSuggested => 'AI suggested',
+            self::HumanConfirmed => 'Confirmed',
+            self::Imported => 'From import',
+        };
+    }
+
+    public function isConfirmed(): bool
+    {
+        return $this === self::HumanConfirmed;
+    }
+}

--- a/app/Http/Controllers/Api/V1/RecipeAllergenController.php
+++ b/app/Http/Controllers/Api/V1/RecipeAllergenController.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace App\Http\Controllers\Api\V1;
+
+use App\Enums\AllergenSource;
+use App\Http\Controllers\Controller;
+use App\Models\Allergen;
+use App\Models\Recipe;
+use App\Models\RecipeAllergen;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Str;
+
+class RecipeAllergenController extends Controller
+{
+    /**
+     * Confirm or edit a single (recipe, allergen) row. Used by the recipe detail
+     * view to confirm an AI-suggested tag, change presence, or remove an entry.
+     * In PR 2 most edits go through the recipe form; this endpoint is the
+     * surface PR 4 will use for one-click AI confirmation.
+     */
+    public function update(Request $request, Recipe $recipe, RecipeAllergen $allergen): JsonResponse
+    {
+        $this->authorize('update', $recipe);
+
+        if ($allergen->recipe_id !== $recipe->id) {
+            abort(404);
+        }
+
+        $validated = $request->validate([
+            'presence' => ['sometimes', 'in:contains,may_contain'],
+            'action' => ['sometimes', 'in:confirm,remove'],
+        ]);
+
+        if (($validated['action'] ?? null) === 'remove') {
+            $allergen->delete();
+
+            return response()->json(['removed' => true]);
+        }
+
+        $update = ['source' => AllergenSource::HumanConfirmed->value,
+            'confirmed_by' => $request->user()->id,
+            'confirmed_at' => now()];
+
+        if (isset($validated['presence'])) {
+            $update['presence'] = $validated['presence'];
+        }
+
+        $allergen->update($update);
+
+        return response()->json(['allergen' => $allergen->fresh()]);
+    }
+
+    /**
+     * Add a single (recipe, allergen) row, used when the user wants to tag a
+     * recipe outside the full form (e.g., from the detail view's "Add allergen"
+     * action).
+     */
+    public function store(Request $request, Recipe $recipe): JsonResponse
+    {
+        $this->authorize('update', $recipe);
+
+        $validated = $request->validate([
+            'allergen_id' => ['required', 'uuid'],
+            'presence' => ['required', 'in:contains,may_contain'],
+        ]);
+
+        $allergen = Allergen::availableToFamily($recipe->family_id)
+            ->where('id', $validated['allergen_id'])
+            ->firstOrFail();
+
+        $row = RecipeAllergen::firstOrCreate([
+            'recipe_id' => $recipe->id,
+            'allergen_id' => $allergen->id,
+            'presence' => $validated['presence'],
+        ], [
+            'id' => (string) Str::uuid(),
+            'source' => AllergenSource::HumanConfirmed->value,
+            'confirmed_by' => $request->user()->id,
+            'confirmed_at' => now(),
+        ]);
+
+        return response()->json(['allergen' => $row], 201);
+    }
+}

--- a/app/Http/Controllers/Api/V1/RecipeController.php
+++ b/app/Http/Controllers/Api/V1/RecipeController.php
@@ -54,7 +54,7 @@ class RecipeController extends Controller
     {
         $this->authorize('view', $recipe);
 
-        $recipe->load(['ingredients', 'cookLogs.user', 'ratings.user', 'tags', 'creator']);
+        $recipe->load(['ingredients', 'cookLogs.user', 'ratings.user', 'tags', 'allergens', 'creator']);
 
         return response()->json(['recipe' => new RecipeResource($recipe)]);
     }

--- a/app/Http/Requests/Recipe/StoreRecipeRequest.php
+++ b/app/Http/Requests/Recipe/StoreRecipeRequest.php
@@ -65,6 +65,9 @@ class StoreRecipeRequest extends FormRequest
             'ingredients.*.is_optional' => ['nullable', 'boolean'],
             'tag_ids' => ['nullable', 'array'],
             'tag_ids.*' => [Rule::exists('tags', 'id')->where('family_id', $this->user()->family_id)],
+            'allergens' => ['nullable', 'array'],
+            'allergens.*.allergen_id' => ['required_with:allergens', 'uuid', 'exists:allergens,id'],
+            'allergens.*.presence' => ['required_with:allergens', 'in:contains,may_contain'],
         ];
     }
 }

--- a/app/Http/Requests/Recipe/UpdateRecipeRequest.php
+++ b/app/Http/Requests/Recipe/UpdateRecipeRequest.php
@@ -63,6 +63,9 @@ class UpdateRecipeRequest extends FormRequest
             'ingredients.*.is_optional' => ['nullable', 'boolean'],
             'tag_ids' => ['nullable', 'array'],
             'tag_ids.*' => [Rule::exists('tags', 'id')->where('family_id', $this->user()->family_id)],
+            'allergens' => ['nullable', 'array'],
+            'allergens.*.allergen_id' => ['required_with:allergens', 'uuid', 'exists:allergens,id'],
+            'allergens.*.presence' => ['required_with:allergens', 'in:contains,may_contain'],
         ];
     }
 }

--- a/app/Http/Resources/RecipeResource.php
+++ b/app/Http/Resources/RecipeResource.php
@@ -3,6 +3,7 @@
 namespace App\Http\Resources;
 
 use App\Models\Recipe;
+use App\Models\RecipeAllergen;
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\JsonResource;
 
@@ -37,6 +38,21 @@ class RecipeResource extends JsonResource
             'cook_logs' => RecipeCookLogResource::collection($this->whenLoaded('cookLogs')),
             'ratings' => RatingResource::collection($this->whenLoaded('ratings')),
             'tags' => TagResource::collection($this->whenLoaded('tags')),
+            'allergens' => $this->whenLoaded('allergens', fn () => $recipe->allergens->map(function ($a) {
+                /** @var RecipeAllergen $pivot */
+                $pivot = $a->getRelationValue('pivot');
+
+                return [
+                    'id' => $a->id,
+                    'name' => $a->name,
+                    'slug' => $a->slug,
+                    'is_big_nine' => (bool) $a->is_big_nine,
+                    'presence' => $pivot->presence->value,
+                    'source' => $pivot->source->value,
+                    'confidence' => $pivot->confidence !== null ? (float) $pivot->confidence : null,
+                    'confirmed_at' => $pivot->confirmed_at,
+                ];
+            })->values()),
             'creator' => new UserResource($this->whenLoaded('creator')),
             'created_at' => $this->created_at,
             'updated_at' => $this->updated_at,

--- a/app/Models/Recipe.php
+++ b/app/Models/Recipe.php
@@ -77,6 +77,14 @@ class Recipe extends Model
             ->withTimestamps();
     }
 
+    public function allergens(): BelongsToMany
+    {
+        return $this->belongsToMany(Allergen::class, 'recipe_allergens')
+            ->using(RecipeAllergen::class)
+            ->withPivot(['id', 'presence', 'source', 'confidence', 'confirmed_by', 'confirmed_at'])
+            ->withTimestamps();
+    }
+
     public function scopeForFamily($query, string $familyId): void
     {
         $query->where('family_id', $familyId);

--- a/app/Models/RecipeAllergen.php
+++ b/app/Models/RecipeAllergen.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Models;
+
+use App\Enums\AllergenPresence;
+use App\Enums\AllergenSource;
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Relations\Pivot;
+
+class RecipeAllergen extends Pivot
+{
+    use HasUuids;
+
+    protected $table = 'recipe_allergens';
+
+    protected $fillable = [
+        'recipe_id',
+        'allergen_id',
+        'presence',
+        'source',
+        'confidence',
+        'confirmed_by',
+        'confirmed_at',
+    ];
+
+    protected $casts = [
+        'presence' => AllergenPresence::class,
+        'source' => AllergenSource::class,
+        'confidence' => 'decimal:3',
+        'confirmed_at' => 'datetime',
+    ];
+}

--- a/app/Services/RecipeService.php
+++ b/app/Services/RecipeService.php
@@ -2,12 +2,15 @@
 
 namespace App\Services;
 
+use App\Enums\AllergenSource;
+use App\Models\Allergen;
 use App\Models\Family;
 use App\Models\Rating;
 use App\Models\Recipe;
 use App\Models\RecipeCookLog;
 use App\Models\User;
 use Illuminate\Contracts\Pagination\LengthAwarePaginator;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
 
 class RecipeService
@@ -39,7 +42,11 @@ class RecipeService
             $recipe->tags()->sync($data['tag_ids']);
         }
 
-        return $recipe->load(['ingredients', 'tags', 'creator']);
+        if (array_key_exists('allergens', $data)) {
+            $this->syncAllergens($recipe, $user, $data['allergens'] ?? []);
+        }
+
+        return $recipe->load(['ingredients', 'tags', 'allergens', 'creator']);
     }
 
     public function updateRecipe(Recipe $recipe, array $data): Recipe
@@ -67,7 +74,12 @@ class RecipeService
             $recipe->tags()->sync($data['tag_ids']);
         }
 
-        return $recipe->load(['ingredients', 'tags', 'creator']);
+        if (array_key_exists('allergens', $data)) {
+            $editor = $recipe->creator()->first() ?? auth()->user();
+            $this->syncAllergens($recipe, $editor, $data['allergens'] ?? []);
+        }
+
+        return $recipe->load(['ingredients', 'tags', 'allergens', 'creator']);
     }
 
     public function deleteRecipe(Recipe $recipe): void
@@ -144,7 +156,60 @@ class RecipeService
 
         $perPage = min((int) ($filters['per_page'] ?? 20), 100);
 
-        return $query->with(['ingredients', 'tags', 'creator', 'ratings'])->paginate($perPage);
+        return $query->with(['ingredients', 'tags', 'allergens', 'creator', 'ratings'])->paginate($perPage);
+    }
+
+    /**
+     * Replace a recipe's allergen tags. All entries written by this method are
+     * `human_confirmed`. AI-driven writes go through the import service in PR 4.
+     *
+     * Allergens must be available to the recipe's family (global Big 9 or family
+     * customs). Unknown allergens are silently skipped (form validation should
+     * catch them earlier).
+     */
+    private function syncAllergens(Recipe $recipe, ?User $editor, array $allergens): void
+    {
+        $allowed = Allergen::availableToFamily($recipe->family_id)
+            ->whereIn('id', collect($allergens)->pluck('allergen_id')->filter()->all())
+            ->pluck('id')
+            ->flip();
+
+        $now = now();
+        $rows = [];
+        $seen = [];
+
+        foreach ($allergens as $entry) {
+            $allergenId = $entry['allergen_id'] ?? null;
+            $presence = $entry['presence'] ?? null;
+            if (! $allergenId || ! $presence || ! isset($allowed[$allergenId])) {
+                continue;
+            }
+            $dedupeKey = $allergenId.'|'.$presence;
+            if (isset($seen[$dedupeKey])) {
+                continue;
+            }
+            $seen[$dedupeKey] = true;
+
+            $rows[$dedupeKey] = [
+                'id' => Str::uuid()->toString(),
+                'recipe_id' => $recipe->id,
+                'allergen_id' => $allergenId,
+                'presence' => $presence,
+                'source' => AllergenSource::HumanConfirmed->value,
+                'confidence' => null,
+                'confirmed_by' => $editor?->id,
+                'confirmed_at' => $now,
+                'created_at' => $now,
+                'updated_at' => $now,
+            ];
+        }
+
+        // Replace strategy: delete current rows, insert new. Future PRs (AI) will
+        // be smarter about preserving provenance on unchanged entries.
+        $recipe->allergens()->detach();
+        if ($rows) {
+            DB::table('recipe_allergens')->insert(array_values($rows));
+        }
     }
 
     private function insertIngredients(Recipe $recipe, array $ingredients): void

--- a/database/migrations/2026_05_21_000005_create_recipe_allergens_table.php
+++ b/database/migrations/2026_05_21_000005_create_recipe_allergens_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('recipe_allergens', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->foreignUuid('recipe_id')->constrained()->cascadeOnDelete();
+            $table->foreignUuid('allergen_id')->constrained()->cascadeOnDelete();
+            $table->string('presence', 20);          // AllergenPresence: contains | may_contain
+            $table->string('source', 20);            // AllergenSource: ai_auto | ai_suggested | human_confirmed | imported
+            $table->decimal('confidence', 4, 3)->nullable();
+            $table->foreignUuid('confirmed_by')->nullable()->constrained('users')->nullOnDelete();
+            $table->timestamp('confirmed_at')->nullable();
+            $table->timestamps();
+
+            $table->unique(['recipe_id', 'allergen_id', 'presence']);
+            $table->index(['recipe_id', 'presence']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('recipe_allergens');
+    }
+};

--- a/resources/js/components/allergens/AllergenBadge.vue
+++ b/resources/js/components/allergens/AllergenBadge.vue
@@ -1,0 +1,42 @@
+<!--
+  AllergenBadge — single allergen indicator shown on recipe cards and detail pages.
+  Two presence levels (contains, may_contain) get distinct visual treatments.
+  An optional `unconfirmed` flag dims the badge for AI-tagged-but-not-yet-reviewed
+  entries (used in PR 4 — accepts the prop now so AI tags can flow through).
+-->
+<script setup>
+import { computed } from 'vue'
+
+const props = defineProps({
+  name: { type: String, required: true },
+  presence: {
+    type: String,
+    default: 'contains',
+    validator: (v) => ['contains', 'may_contain'].includes(v),
+  },
+  unconfirmed: { type: Boolean, default: false },
+})
+
+const isContains = computed(() => props.presence === 'contains')
+
+// Token-aligned: contains uses status-error tint, may_contain uses status-warning.
+// Unconfirmed dims via reduced opacity + dashed outline.
+const classes = computed(() => {
+  const base = 'inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium border'
+  const tone = isContains.value
+    ? 'bg-status-error/10 text-status-error border-status-error/30'
+    : 'bg-status-warning/10 text-status-warning border-status-warning/40'
+  const confirmation = props.unconfirmed
+    ? 'border-dashed opacity-70'
+    : ''
+  return [base, tone, confirmation].join(' ')
+})
+
+const label = computed(() => (isContains.value ? props.name : `May contain ${props.name.toLowerCase()}`))
+</script>
+
+<template>
+  <span :class="classes" :title="unconfirmed ? 'AI tagged — not yet confirmed' : null">
+    {{ label }}
+  </span>
+</template>

--- a/resources/js/components/allergens/AllergenBadgeRow.vue
+++ b/resources/js/components/allergens/AllergenBadgeRow.vue
@@ -1,0 +1,42 @@
+<!--
+  AllergenBadgeRow — wraps a recipe's allergen list into a row of AllergenBadge
+  chips. Hides itself when there are no allergens. Optional `limit` truncates
+  to N badges with a "+N more" indicator, useful on dense cards.
+-->
+<script setup>
+import { computed } from 'vue'
+import AllergenBadge from './AllergenBadge.vue'
+
+const props = defineProps({
+  allergens: { type: Array, required: true },
+  limit: { type: Number, default: 0 }, // 0 = show all
+})
+
+const visible = computed(() => {
+  if (!props.limit || props.allergens.length <= props.limit) return props.allergens
+  return props.allergens.slice(0, props.limit)
+})
+
+const overflow = computed(() => {
+  if (!props.limit) return 0
+  return Math.max(0, props.allergens.length - props.limit)
+})
+</script>
+
+<template>
+  <div v-if="allergens.length" class="flex flex-wrap gap-1.5">
+    <AllergenBadge
+      v-for="row in visible"
+      :key="`${row.id}-${row.presence}`"
+      :name="row.name"
+      :presence="row.presence"
+      :unconfirmed="row.source && row.source !== 'human_confirmed'"
+    />
+    <span
+      v-if="overflow"
+      class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-surface-sunken text-ink-tertiary"
+    >
+      +{{ overflow }} more
+    </span>
+  </div>
+</template>

--- a/resources/js/components/allergens/FamilyAllergenSettings.vue
+++ b/resources/js/components/allergens/FamilyAllergenSettings.vue
@@ -6,7 +6,6 @@
 import { ref, computed, onMounted } from 'vue'
 import { useAllergensStore } from '@/stores/allergens'
 import { useAuthStore } from '@/stores/auth'
-import KinChip from '@/components/design-system/KinChip.vue'
 import KinButton from '@/components/design-system/KinButton.vue'
 import KinInput from '@/components/design-system/KinInput.vue'
 import { TrashIcon, PencilSquareIcon, CheckIcon, XMarkIcon } from '@heroicons/vue/24/outline'
@@ -76,14 +75,10 @@ const remove = async (allergen) => {
 
 <template>
   <div class="space-y-5">
-    <div>
-      <p class="text-xs font-medium text-ink-secondary mb-2">Big 9 (always available)</p>
-      <div class="flex flex-wrap gap-2">
-        <KinChip v-for="a in allergens.bigNine" :key="a.id" variant="category" color="neutral">
-          {{ a.name }}
-        </KinChip>
-      </div>
-    </div>
+    <p class="text-xs text-ink-secondary">
+      The Big 9 (milk, eggs, fish, shellfish, tree nuts, peanuts, wheat&nbsp;/&nbsp;gluten, soy, sesame) are
+      pre-loaded and always available. Pick them per family member in the profiles below.
+    </p>
 
     <div>
       <p class="text-xs font-medium text-ink-secondary mb-2">Your family's allergens</p>

--- a/resources/js/components/recipes/RecipeCard.vue
+++ b/resources/js/components/recipes/RecipeCard.vue
@@ -1,14 +1,22 @@
 <template>
-  <FoodCard
-    :title="recipe.title"
-    :image-url="recipe.image_path"
-    :fallback-gradient="fallbackGradient"
-    :is-favorite="!!recipe.is_favorite"
-    :meta-items="metaItems"
-    :tags="recipe.tags || []"
-    @click="$router.push({ name: 'RecipeDetail', params: { id: recipe.id } })"
-    @toggle-favorite="$emit('toggleFavorite', recipe.id)"
-  />
+  <div>
+    <FoodCard
+      :title="recipe.title"
+      :image-url="recipe.image_path"
+      :fallback-gradient="fallbackGradient"
+      :is-favorite="!!recipe.is_favorite"
+      :meta-items="metaItems"
+      :tags="recipe.tags || []"
+      @click="$router.push({ name: 'RecipeDetail', params: { id: recipe.id } })"
+      @toggle-favorite="$emit('toggleFavorite', recipe.id)"
+    />
+    <AllergenBadgeRow
+      v-if="recipe.allergens && recipe.allergens.length"
+      :allergens="recipe.allergens"
+      :limit="3"
+      class="mt-2 px-1"
+    />
+  </div>
 </template>
 
 <script setup>
@@ -19,6 +27,7 @@ import {
   StarIcon,
 } from '@heroicons/vue/24/outline'
 import FoodCard from '@/components/food/FoodCard.vue'
+import AllergenBadgeRow from '@/components/allergens/AllergenBadgeRow.vue'
 
 const props = defineProps({
   recipe: { type: Object, required: true },

--- a/resources/js/components/recipes/RecipeForm.vue
+++ b/resources/js/components/recipes/RecipeForm.vue
@@ -215,6 +215,25 @@
       </div>
     </div>
 
+    <!-- Allergens -->
+    <div v-if="foodEnabled && allergensStore.allergens.length > 0">
+      <label class="block text-sm font-semibold text-ink-primary mb-1">Allergens</label>
+      <p class="text-xs text-ink-secondary mb-2">
+        Tap once for "contains", twice for "may contain", three times to clear.
+      </p>
+      <div class="flex flex-wrap gap-2">
+        <button
+          v-for="allergen in allergensStore.allergens"
+          :key="allergen.id"
+          type="button"
+          :class="allergenChipClass(allergen.id)"
+          @click="cycleAllergen(allergen.id)"
+        >
+          {{ allergenChipLabel(allergen) }}
+        </button>
+      </div>
+    </div>
+
     <!-- Notes -->
     <div>
       <label class="block text-sm font-medium text-ink-primary mb-1">Notes</label>
@@ -250,6 +269,8 @@
 import { ref, reactive, computed, onMounted, watch } from 'vue'
 import { storeToRefs } from 'pinia'
 import { useRecipesStore } from '@/stores/recipes'
+import { useAllergensStore } from '@/stores/allergens'
+import { useAuthStore } from '@/stores/auth'
 import { XMarkIcon } from '@heroicons/vue/24/outline'
 import PhotoUpload from '@/components/food/PhotoUpload.vue'
 
@@ -308,7 +329,11 @@ const props = defineProps({
 const emit = defineEmits(['save', 'cancel'])
 
 const recipesStore = useRecipesStore()
+const allergensStore = useAllergensStore()
+const authStore = useAuthStore()
 const { tags: allTags } = storeToRefs(recipesStore)
+
+const foodEnabled = computed(() => authStore.userCanAccessModule('food'))
 
 // Server returns only food-scoped tags via the recipes store.
 const recipeTags = computed(() => allTags.value)
@@ -329,6 +354,7 @@ const createEmptyForm = () => ({
   ingredients: [],
   instructions: [],
   tag_ids: [],
+  allergens: [], // [{ allergen_id, presence }]
 })
 
 const form = reactive(createEmptyForm())
@@ -358,6 +384,10 @@ const populateFromRecipe = (recipe) => {
     typeof step === 'string' ? step : (step.text || '')
   )
   form.tag_ids = (recipe.tags || []).map((t) => t.id)
+  form.allergens = (recipe.allergens || []).map((a) => ({
+    allergen_id: a.id,
+    presence: a.presence || 'contains',
+  }))
 }
 
 const populateFromImportPreview = (data) => {
@@ -384,6 +414,7 @@ const populateFromImportPreview = (data) => {
     typeof step === 'string' ? step : (step.text || '')
   )
   form.tag_ids = []
+  form.allergens = []
 }
 
 // ── Ingredient actions ──
@@ -429,6 +460,38 @@ const toggleTag = (tagId) => {
   }
 }
 
+// ── Allergen tri-state cycle: off → contains → may_contain → off ──
+
+const allergenState = (id) => {
+  const entry = form.allergens.find((a) => a.allergen_id === id)
+  return entry?.presence || 'off'
+}
+
+const cycleAllergen = (id) => {
+  const idx = form.allergens.findIndex((a) => a.allergen_id === id)
+  if (idx === -1) {
+    form.allergens.push({ allergen_id: id, presence: 'contains' })
+  } else if (form.allergens[idx].presence === 'contains') {
+    form.allergens[idx] = { allergen_id: id, presence: 'may_contain' }
+  } else {
+    form.allergens.splice(idx, 1)
+  }
+}
+
+const allergenChipClass = (id) => {
+  const base = 'px-3 py-1.5 text-xs font-medium rounded-full border transition-colors'
+  const state = allergenState(id)
+  if (state === 'contains') return `${base} bg-status-error/10 text-status-error border-status-error/40`
+  if (state === 'may_contain') return `${base} bg-status-warning/10 text-status-warning border-status-warning/40 border-dashed`
+  return `${base} bg-surface-sunken text-ink-secondary border-transparent hover:bg-surface-overlay`
+}
+
+const allergenChipLabel = (allergen) => {
+  const state = allergenState(allergen.id)
+  if (state === 'may_contain') return `May contain ${allergen.name.toLowerCase()}`
+  return allergen.name
+}
+
 // ── Submit ──
 
 const handleSubmit = () => {
@@ -461,6 +524,7 @@ const handleSubmit = () => {
       .filter((s) => s.trim())
       .map((text, idx) => ({ step: idx + 1, text: text.trim() })),
     tag_ids: form.tag_ids,
+    allergens: form.allergens,
   }
 
   emit('save', payload)
@@ -482,6 +546,11 @@ onMounted(() => {
   // Ensure tags are loaded
   if (allTags.value.length === 0) {
     recipesStore.fetchTags()
+  }
+
+  // Load allergens (food module gating already enforced at API level)
+  if (foodEnabled.value && allergensStore.allergens.length === 0) {
+    allergensStore.fetchAllergens()
   }
 })
 

--- a/resources/js/views/food/RecipeDetailView.vue
+++ b/resources/js/views/food/RecipeDetailView.vue
@@ -109,6 +109,12 @@
           </KinChip>
         </div>
 
+        <!-- Allergens -->
+        <AllergenBadgeRow
+          v-if="recipe.allergens?.length"
+          :allergens="recipe.allergens"
+        />
+
         <!-- Source -->
         <div v-if="recipe.source_url" class="flex items-center gap-1.5">
           <LinkIcon class="w-3.5 h-3.5 text-ink-tertiary" />
@@ -243,6 +249,7 @@ import StepList from '@/components/recipes/StepList.vue'
 import FamilyRating from '@/components/recipes/FamilyRating.vue'
 import CookLogEntry from '@/components/recipes/CookLogEntry.vue'
 import RecipeForm from '@/components/recipes/RecipeForm.vue'
+import AllergenBadgeRow from '@/components/allergens/AllergenBadgeRow.vue'
 import ConfirmDialog from '@/components/common/ConfirmDialog.vue'
 import LoadingSpinner from '@/components/common/LoadingSpinner.vue'
 import UserAvatar from '@/components/common/UserAvatar.vue'

--- a/routes/api.php
+++ b/routes/api.php
@@ -16,6 +16,7 @@ use App\Http\Controllers\Api\V1\OnboardingController;
 use App\Http\Controllers\Api\V1\PointRequestController;
 use App\Http\Controllers\Api\V1\PointsController;
 use App\Http\Controllers\Api\V1\PushSubscriptionController;
+use App\Http\Controllers\Api\V1\RecipeAllergenController;
 use App\Http\Controllers\Api\V1\RecipeController;
 use App\Http\Controllers\Api\V1\RestaurantController;
 use App\Http\Controllers\Api\V1\RewardsController;
@@ -230,6 +231,10 @@ Route::prefix('v1')->group(function () {
                 Route::post('/{recipe}/cook-logs', [RecipeController::class, 'addCookLog']);
                 Route::post('/{recipe}/rate', [RecipeController::class, 'rate']);
                 Route::get('/{recipe}/ratings', [RecipeController::class, 'ratings']);
+
+                // Fine-grained allergen edits (single-row confirm / change presence / remove)
+                Route::post('/{recipe}/allergens', [RecipeAllergenController::class, 'store']);
+                Route::patch('/{recipe}/allergens/{allergen}', [RecipeAllergenController::class, 'update']);
             });
 
             // Allergens (module: food)

--- a/tests/Feature/RecipeAllergenTaggingTest.php
+++ b/tests/Feature/RecipeAllergenTaggingTest.php
@@ -1,0 +1,388 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Enums\AllergenPresence;
+use App\Enums\AllergenSource;
+use App\Enums\FamilyRole;
+use App\Models\Allergen;
+use App\Models\Family;
+use App\Models\Recipe;
+use App\Models\RecipeAllergen;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Str;
+use Laravel\Sanctum\Sanctum;
+use Tests\TestCase;
+
+class RecipeAllergenTaggingTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private Family $family;
+
+    private Family $otherFamily;
+
+    private User $parent;
+
+    private User $otherParent;
+
+    private Allergen $peanuts;
+
+    private Allergen $milk;
+
+    private Allergen $familyCustom;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->family = Family::create([
+            'name' => 'Test Family',
+            'slug' => 'test-family',
+            'invite_code' => 'TEST01',
+            'settings' => ['modules' => ['food' => true]],
+        ]);
+
+        $this->otherFamily = Family::create([
+            'name' => 'Other Family',
+            'slug' => 'other-family',
+            'invite_code' => 'OTHER1',
+            'settings' => ['modules' => ['food' => true]],
+        ]);
+
+        $this->parent = $this->makeUser('Parent', 'parent@test.com', $this->family, FamilyRole::Parent);
+        $this->otherParent = $this->makeUser('Other Parent', 'other@test.com', $this->otherFamily, FamilyRole::Parent);
+
+        $this->peanuts = Allergen::where('slug', 'peanuts')->whereNull('family_id')->firstOrFail();
+        $this->milk = Allergen::where('slug', 'milk')->whereNull('family_id')->firstOrFail();
+        $this->familyCustom = Allergen::create([
+            'family_id' => $this->family->id,
+            'name' => 'Cinnamon',
+            'slug' => 'cinnamon',
+        ]);
+    }
+
+    public function test_recipe_can_be_created_with_allergens(): void
+    {
+        Sanctum::actingAs($this->parent);
+
+        $response = $this->postJson('/api/v1/recipes', [
+            'title' => 'Peanut Cookies',
+            'servings' => 12,
+            'allergens' => [
+                ['allergen_id' => $this->peanuts->id, 'presence' => 'contains'],
+                ['allergen_id' => $this->milk->id, 'presence' => 'may_contain'],
+            ],
+        ])->assertCreated();
+
+        $allergens = collect($response->json('recipe.allergens'));
+        $this->assertCount(2, $allergens);
+        $this->assertTrue($allergens->contains(fn ($a) => $a['slug'] === 'peanuts' && $a['presence'] === 'contains' && $a['source'] === AllergenSource::HumanConfirmed->value));
+        $this->assertTrue($allergens->contains(fn ($a) => $a['slug'] === 'milk' && $a['presence'] === 'may_contain'));
+    }
+
+    public function test_recipe_can_carry_same_allergen_at_both_presence_levels(): void
+    {
+        Sanctum::actingAs($this->parent);
+
+        $response = $this->postJson('/api/v1/recipes', [
+            'title' => 'Peanut Sauce (with cross-contamination warning)',
+            'allergens' => [
+                ['allergen_id' => $this->peanuts->id, 'presence' => 'contains'],
+                ['allergen_id' => $this->peanuts->id, 'presence' => 'may_contain'],
+            ],
+        ])->assertCreated();
+
+        $this->assertCount(2, $response->json('recipe.allergens'));
+        $presences = collect($response->json('recipe.allergens'))->pluck('presence')->all();
+        $this->assertEqualsCanonicalizing(['contains', 'may_contain'], $presences);
+    }
+
+    public function test_human_confirmed_provenance_is_stamped_on_form_save(): void
+    {
+        Sanctum::actingAs($this->parent);
+
+        $response = $this->postJson('/api/v1/recipes', [
+            'title' => 'PB&J',
+            'allergens' => [['allergen_id' => $this->peanuts->id, 'presence' => 'contains']],
+        ])->assertCreated();
+
+        $recipeId = $response->json('recipe.id');
+        $row = RecipeAllergen::where('recipe_id', $recipeId)->firstOrFail();
+
+        $this->assertEquals(AllergenSource::HumanConfirmed, $row->source);
+        $this->assertEquals($this->parent->id, $row->confirmed_by);
+        $this->assertNotNull($row->confirmed_at);
+    }
+
+    public function test_family_custom_allergen_can_be_used(): void
+    {
+        Sanctum::actingAs($this->parent);
+
+        $this->postJson('/api/v1/recipes', [
+            'title' => 'Cinnamon Roll',
+            'allergens' => [['allergen_id' => $this->familyCustom->id, 'presence' => 'contains']],
+        ])->assertCreated();
+
+        $this->assertDatabaseHas('recipe_allergens', [
+            'allergen_id' => $this->familyCustom->id,
+            'presence' => AllergenPresence::Contains->value,
+        ]);
+    }
+
+    public function test_cannot_use_allergen_from_another_family(): void
+    {
+        $otherCustom = Allergen::create(['family_id' => $this->otherFamily->id, 'name' => 'Kiwi', 'slug' => 'kiwi']);
+        Sanctum::actingAs($this->parent);
+
+        $response = $this->postJson('/api/v1/recipes', [
+            'title' => 'Mystery Bowl',
+            'allergens' => [['allergen_id' => $otherCustom->id, 'presence' => 'contains']],
+        ])->assertCreated();
+
+        // Allergens silently filtered out by the service's availableToFamily guard.
+        $this->assertCount(0, $response->json('recipe.allergens'));
+    }
+
+    public function test_update_replaces_allergen_list(): void
+    {
+        Sanctum::actingAs($this->parent);
+
+        $recipeId = $this->postJson('/api/v1/recipes', [
+            'title' => 'PB&J',
+            'allergens' => [
+                ['allergen_id' => $this->peanuts->id, 'presence' => 'contains'],
+                ['allergen_id' => $this->milk->id, 'presence' => 'contains'],
+            ],
+        ])->assertCreated()->json('recipe.id');
+
+        $this->putJson("/api/v1/recipes/{$recipeId}", [
+            'title' => 'PB&J (updated)',
+            'allergens' => [
+                ['allergen_id' => $this->peanuts->id, 'presence' => 'contains'],
+            ],
+        ])->assertOk();
+
+        $this->assertEquals(1, RecipeAllergen::where('recipe_id', $recipeId)->count());
+        $this->assertDatabaseHas('recipe_allergens', [
+            'recipe_id' => $recipeId,
+            'allergen_id' => $this->peanuts->id,
+        ]);
+    }
+
+    public function test_update_without_allergens_field_does_not_change_existing_tags(): void
+    {
+        Sanctum::actingAs($this->parent);
+
+        $recipeId = $this->postJson('/api/v1/recipes', [
+            'title' => 'PB&J',
+            'allergens' => [['allergen_id' => $this->peanuts->id, 'presence' => 'contains']],
+        ])->assertCreated()->json('recipe.id');
+
+        // Update title only; omit allergens key entirely.
+        $this->putJson("/api/v1/recipes/{$recipeId}", ['title' => 'PB&J Deluxe'])->assertOk();
+
+        $this->assertEquals(1, RecipeAllergen::where('recipe_id', $recipeId)->count());
+    }
+
+    public function test_empty_allergens_array_clears_existing_tags(): void
+    {
+        Sanctum::actingAs($this->parent);
+
+        $recipeId = $this->postJson('/api/v1/recipes', [
+            'title' => 'PB&J',
+            'allergens' => [['allergen_id' => $this->peanuts->id, 'presence' => 'contains']],
+        ])->assertCreated()->json('recipe.id');
+
+        $this->putJson("/api/v1/recipes/{$recipeId}", [
+            'title' => 'PB&J',
+            'allergens' => [],
+        ])->assertOk();
+
+        $this->assertEquals(0, RecipeAllergen::where('recipe_id', $recipeId)->count());
+    }
+
+    public function test_show_endpoint_returns_allergens(): void
+    {
+        $recipe = Recipe::create([
+            'family_id' => $this->family->id,
+            'created_by' => $this->parent->id,
+            'title' => 'PB&J',
+            'servings' => 1,
+        ]);
+        $recipe->allergens()->attach($this->peanuts->id, [
+            'id' => (string) Str::uuid(),
+            'presence' => AllergenPresence::Contains->value,
+            'source' => AllergenSource::HumanConfirmed->value,
+            'confirmed_by' => $this->parent->id,
+            'confirmed_at' => now(),
+        ]);
+
+        Sanctum::actingAs($this->parent);
+
+        $response = $this->getJson("/api/v1/recipes/{$recipe->id}")->assertOk();
+        $allergens = $response->json('recipe.allergens');
+
+        $this->assertCount(1, $allergens);
+        $this->assertEquals('peanuts', $allergens[0]['slug']);
+        $this->assertEquals('contains', $allergens[0]['presence']);
+    }
+
+    // ---------- Fine-grained edit endpoints ----------
+
+    public function test_post_single_allergen_to_recipe(): void
+    {
+        $recipe = Recipe::create([
+            'family_id' => $this->family->id,
+            'created_by' => $this->parent->id,
+            'title' => 'PB&J',
+        ]);
+
+        Sanctum::actingAs($this->parent);
+
+        $this->postJson("/api/v1/recipes/{$recipe->id}/allergens", [
+            'allergen_id' => $this->peanuts->id,
+            'presence' => 'contains',
+        ])->assertCreated();
+
+        $this->assertDatabaseHas('recipe_allergens', [
+            'recipe_id' => $recipe->id,
+            'allergen_id' => $this->peanuts->id,
+            'presence' => 'contains',
+        ]);
+    }
+
+    public function test_post_duplicate_single_allergen_is_idempotent(): void
+    {
+        $recipe = Recipe::create([
+            'family_id' => $this->family->id,
+            'created_by' => $this->parent->id,
+            'title' => 'PB&J',
+        ]);
+
+        Sanctum::actingAs($this->parent);
+
+        $this->postJson("/api/v1/recipes/{$recipe->id}/allergens", [
+            'allergen_id' => $this->peanuts->id,
+            'presence' => 'contains',
+        ])->assertCreated();
+
+        $this->postJson("/api/v1/recipes/{$recipe->id}/allergens", [
+            'allergen_id' => $this->peanuts->id,
+            'presence' => 'contains',
+        ])->assertCreated();
+
+        $this->assertEquals(1, RecipeAllergen::where('recipe_id', $recipe->id)->count());
+    }
+
+    public function test_patch_can_change_presence_and_confirm(): void
+    {
+        $recipe = Recipe::create([
+            'family_id' => $this->family->id,
+            'created_by' => $this->parent->id,
+            'title' => 'PB&J',
+        ]);
+        $row = RecipeAllergen::create([
+            'id' => (string) Str::uuid(),
+            'recipe_id' => $recipe->id,
+            'allergen_id' => $this->peanuts->id,
+            'presence' => AllergenPresence::MayContain->value,
+            'source' => AllergenSource::AiSuggested->value,
+        ]);
+
+        Sanctum::actingAs($this->parent);
+
+        $this->patchJson("/api/v1/recipes/{$recipe->id}/allergens/{$row->id}", [
+            'presence' => 'contains',
+        ])->assertOk();
+
+        $row->refresh();
+        $this->assertEquals(AllergenPresence::Contains, $row->presence);
+        $this->assertEquals(AllergenSource::HumanConfirmed, $row->source);
+        $this->assertEquals($this->parent->id, $row->confirmed_by);
+        $this->assertNotNull($row->confirmed_at);
+    }
+
+    public function test_patch_remove_action_deletes_row(): void
+    {
+        $recipe = Recipe::create([
+            'family_id' => $this->family->id,
+            'created_by' => $this->parent->id,
+            'title' => 'PB&J',
+        ]);
+        $row = RecipeAllergen::create([
+            'id' => (string) Str::uuid(),
+            'recipe_id' => $recipe->id,
+            'allergen_id' => $this->peanuts->id,
+            'presence' => AllergenPresence::Contains->value,
+            'source' => AllergenSource::HumanConfirmed->value,
+        ]);
+
+        Sanctum::actingAs($this->parent);
+
+        $this->patchJson("/api/v1/recipes/{$recipe->id}/allergens/{$row->id}", [
+            'action' => 'remove',
+        ])->assertOk();
+
+        $this->assertDatabaseMissing('recipe_allergens', ['id' => $row->id]);
+    }
+
+    public function test_cannot_edit_allergens_on_another_familys_recipe(): void
+    {
+        $foreignRecipe = Recipe::create([
+            'family_id' => $this->otherFamily->id,
+            'created_by' => $this->otherParent->id,
+            'title' => 'Stranger Stew',
+        ]);
+
+        Sanctum::actingAs($this->parent);
+
+        $this->postJson("/api/v1/recipes/{$foreignRecipe->id}/allergens", [
+            'allergen_id' => $this->peanuts->id,
+            'presence' => 'contains',
+        ])->assertForbidden();
+    }
+
+    // ---------- Validation + module gating ----------
+
+    public function test_invalid_presence_is_rejected(): void
+    {
+        Sanctum::actingAs($this->parent);
+
+        $this->postJson('/api/v1/recipes', [
+            'title' => 'Bad Recipe',
+            'allergens' => [['allergen_id' => $this->peanuts->id, 'presence' => 'definitely']],
+        ])->assertStatus(422);
+    }
+
+    public function test_module_gating_blocks_recipe_allergen_routes_when_food_off(): void
+    {
+        $recipe = Recipe::create([
+            'family_id' => $this->family->id,
+            'created_by' => $this->parent->id,
+            'title' => 'PB&J',
+        ]);
+
+        $this->family->settings = ['modules' => ['food' => false]];
+        $this->family->save();
+
+        Sanctum::actingAs($this->parent);
+
+        $this->postJson("/api/v1/recipes/{$recipe->id}/allergens", [
+            'allergen_id' => $this->peanuts->id,
+            'presence' => 'contains',
+        ])->assertForbidden();
+    }
+
+    private function makeUser(string $name, string $email, Family $family, FamilyRole $role): User
+    {
+        return User::create([
+            'name' => $name,
+            'email' => $email,
+            'password' => bcrypt('password'),
+            'family_id' => $family->id,
+            'family_role' => $role,
+        ]);
+    }
+}


### PR DESCRIPTION
## Summary
PR 2 of 4+1 toward v1.10.0. Tag recipes with allergens manually (no AI yet — that's #317). Renders badges on recipe cards and detail pages. Sets up the `RecipeAllergen` pivot infrastructure that #316 (filtering) and #317 (AI) will build on.

## Linked Issues
Closes #315
Part of #312

## What ships
**Schema:**
- `recipe_allergens` pivot: `(recipe_id, allergen_id, presence, source, confidence, confirmed_by, confirmed_at)`, UUID-keyed via `RecipeAllergen` pivot model
- Unique on `(recipe_id, allergen_id, presence)` so the same allergen can appear at both "contains" and "may_contain" on one recipe (a recipe that contains peanuts and may also have shared-equipment peanut traces — both rows valid)
- `AllergenPresence` enum: `contains | may_contain`
- `AllergenSource` enum: `ai_auto | ai_suggested | human_confirmed | imported` (only `human_confirmed` written in this PR; AI sources land in #317)

**Backend:**
- `Recipe::allergens()` BelongsToMany with full pivot shape
- `StoreRecipeRequest` + `UpdateRecipeRequest` accept `allergens: [{allergen_id, presence}]` with enum validation
- `RecipeService::syncAllergens` replaces a recipe's allergen list. All form-path rows stamped `human_confirmed` + `confirmed_by` + `confirmed_at`. `availableToFamily()` guard silently drops cross-family allergens.
- `RecipeAllergenController` for single-row edits: POST adds (idempotent on duplicate), PATCH confirms / changes presence / removes. Reserved for the AI-confirmation flow in #317.
- `RecipeResource` exposes allergens with full pivot shape (presence + source + confidence + confirmed_at)
- `show` + `searchRecipes` eager-load allergens

**Vue:**
- `AllergenBadge` — single chip. `contains` = status-error tint; `may_contain` = status-warning + dashed border. Optional `unconfirmed` prop reserved for #317.
- `AllergenBadgeRow` — wraps a recipe.allergens array. Optional `limit` + "+N more" indicator (used on dense cards).
- `RecipeForm` — new Allergens section with tri-state cycle per chip: tap once for contains, twice for may_contain, three times to clear. Auto-loads allergens on mount. Hidden when food module is off.
- `RecipeCard` — `AllergenBadgeRow` rendered below the card (limit 3 with "+N more")
- `RecipeDetailView` — full badge row in the meta block

## Test Plan
- [x] 16 new tests in `RecipeAllergenTaggingTest`: form save with allergens, human-confirmed provenance stamp, same allergen at both presence levels, family-custom allergens, cross-family rejection, update replaces vs omitted-key preserves vs empty clears, show returns allergens, single-row POST idempotency, PATCH confirm + change presence + remove, foreign-recipe forbidden, invalid presence rejected, module gating
- [x] Full suite green: 399 tests, 1048 assertions
- [x] Pint + PHPStan + ESLint clean
- [x] **Manual verification in preview**: demo-login as Adaeze → /food/Recipes → Banana Bread → Edit → cycle "Wheat" once (contains) + "Tree nuts" twice (may_contain) → Update → detail page shows "Wheat / gluten" + "May contain tree nuts" → list view also surfaces the badges on the card

## Checklist
- [x] Tested locally + in preview
- [x] Mobile-first verified (badge row wraps cleanly at 375px)
- [x] No credentials committed
- [x] Module gating enforced at route level

## Target branch
`feature/allergens-v1.10.0` (integration branch)

## Blocked by
- #314 ✅ merged

## Blocks
- #316 (filtering — needs the `recipe.allergens` data shape this PR provides)