### PR TITLE
feat: allergen filtering + meal planner safety guard

### DIFF
--- a/app/Exceptions/AllergenAcknowledgementRequired.php
+++ b/app/Exceptions/AllergenAcknowledgementRequired.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Exceptions;
+
+use Illuminate\Http\JsonResponse;
+use RuntimeException;
+
+class AllergenAcknowledgementRequired extends RuntimeException
+{
+    /**
+     * @param  array<int, array{member_id: string, member_name: string, allergen_id: string, allergen_name: string, presence: string}>  $hits
+     */
+    public function __construct(public readonly array $hits)
+    {
+        parent::__construct('This recipe contains allergens for one or more family members. Acknowledge to proceed.');
+    }
+
+    public function render(): JsonResponse
+    {
+        return response()->json([
+            'message' => $this->getMessage(),
+            'requires_acknowledgement' => true,
+            'hits' => $this->hits,
+        ], 409);
+    }
+}

--- a/app/Http/Controllers/Api/V1/RecipeController.php
+++ b/app/Http/Controllers/Api/V1/RecipeController.php
@@ -30,7 +30,7 @@ class RecipeController extends Controller
     {
         $family = $request->user()->family;
 
-        $filters = $request->only(['search', 'tag', 'favorite', 'sort', 'per_page']);
+        $filters = $request->only(['search', 'tag', 'favorite', 'sort', 'per_page', 'safe_for', 'safe_for_members']);
 
         $recipes = $this->recipeService->searchRecipes($family, $filters);
 

--- a/app/Http/Requests/MealPlan/StoreMealPlanEntryRequest.php
+++ b/app/Http/Requests/MealPlan/StoreMealPlanEntryRequest.php
@@ -30,6 +30,7 @@ class StoreMealPlanEntryRequest extends FormRequest
             'assigned_cooks.*' => ['uuid', Rule::exists('users', 'id')->where('family_id', $familyId)],
             'notes' => ['nullable', 'string', 'max:255'],
             'sort_order' => ['nullable', 'integer'],
+            'acknowledge_allergens' => ['nullable', 'boolean'],
         ];
     }
 

--- a/app/Services/MealPlanService.php
+++ b/app/Services/MealPlanService.php
@@ -2,14 +2,17 @@
 
 namespace App\Services;
 
+use App\Exceptions\AllergenAcknowledgementRequired;
 use App\Models\Family;
 use App\Models\MealPlan;
 use App\Models\MealPlanEntry;
+use App\Models\Recipe;
 use App\Models\ShoppingList;
 use App\Models\Task;
 use App\Models\User;
 use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Support\Facades\DB;
 
 class MealPlanService
 {
@@ -49,9 +52,23 @@ class MealPlanService
 
     /**
      * Add an entry to a meal plan. Triggers shopping list and task cascades.
+     *
+     * Refuses with AllergenAcknowledgementRequired if the recipe carries any
+     * allergen for any family member with a reviewed profile, unless the
+     * caller has explicitly set `acknowledge_allergens => true`.
      */
     public function addEntry(MealPlan $plan, array $data, User $user): MealPlanEntry
     {
+        if (! empty($data['recipe_id']) && empty($data['acknowledge_allergens'])) {
+            $recipe = Recipe::with('allergens')->find($data['recipe_id']);
+            if ($recipe) {
+                $hits = $this->allergenHitsForFamily($plan->family_id, $recipe);
+                if (! empty($hits)) {
+                    throw new AllergenAcknowledgementRequired($hits);
+                }
+            }
+        }
+
         $entry = MealPlanEntry::create([
             'meal_plan_id' => $plan->id,
             'recipe_id' => $data['recipe_id'] ?? null,
@@ -247,6 +264,51 @@ class MealPlanService
             ->pluck('name')
             ->map(fn ($name) => strtolower(trim($name)))
             ->all();
+    }
+
+    /**
+     * Detect (member, allergen) hits between a recipe and the reviewed allergy
+     * profiles of the recipe's family. Members without a reviewed profile are
+     * never returned — silently filtering against an unknown profile would be
+     * worse than warning the user explicitly.
+     *
+     * @return array<int, array{member_id: string, member_name: string, allergen_id: string, allergen_name: string, presence: string}>
+     */
+    public function allergenHitsForFamily(string $familyId, Recipe $recipe): array
+    {
+        $recipe->loadMissing('allergens');
+
+        if ($recipe->allergens->isEmpty()) {
+            return [];
+        }
+
+        $recipeAllergenIds = $recipe->allergens->pluck('id');
+
+        $rows = DB::table('member_allergens')
+            ->join('users', 'users.id', '=', 'member_allergens.user_id')
+            ->join('allergens', 'allergens.id', '=', 'member_allergens.allergen_id')
+            ->where('users.family_id', $familyId)
+            ->whereNotNull('users.allergen_profile_reviewed_at')
+            ->whereIn('member_allergens.allergen_id', $recipeAllergenIds)
+            ->get([
+                'users.id as member_id',
+                'users.name as member_name',
+                'allergens.id as allergen_id',
+                'allergens.name as allergen_name',
+            ]);
+
+        $presenceByAllergen = $recipe->allergens
+            ->mapWithKeys(fn ($a) => [
+                $a->id => $a->getRelationValue('pivot')->presence->value,
+            ]);
+
+        return $rows->map(fn ($row) => [
+            'member_id' => (string) $row->member_id,
+            'member_name' => $row->member_name,
+            'allergen_id' => (string) $row->allergen_id,
+            'allergen_name' => $row->allergen_name,
+            'presence' => $presenceByAllergen[$row->allergen_id] ?? 'contains',
+        ])->all();
     }
 
     /**

--- a/app/Services/RecipeService.php
+++ b/app/Services/RecipeService.php
@@ -10,6 +10,7 @@ use App\Models\Recipe;
 use App\Models\RecipeCookLog;
 use App\Models\User;
 use Illuminate\Contracts\Pagination\LengthAwarePaginator;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
 
@@ -142,6 +143,17 @@ class RecipeService
             $query->favorites();
         }
 
+        // Allergen filtering: exclude recipes carrying any allergen for the given
+        // reviewed-profile members. `safe_for=all` resolves to every family member
+        // with a reviewed profile (skipping unreviewed to avoid false-safe filtering).
+        $unsafeAllergenIds = $this->unsafeAllergenIdsForFilter($family, $filters);
+        if ($unsafeAllergenIds !== null && $unsafeAllergenIds->isNotEmpty()) {
+            $query->whereDoesntHave(
+                'allergens',
+                fn ($q) => $q->whereIn('allergens.id', $unsafeAllergenIds)
+            );
+        }
+
         $sort = $filters['sort'] ?? 'recent';
         match ($sort) {
             'alpha' => $query->orderBy('title'),
@@ -157,6 +169,44 @@ class RecipeService
         $perPage = min((int) ($filters['per_page'] ?? 20), 100);
 
         return $query->with(['ingredients', 'tags', 'allergens', 'creator', 'ratings'])->paginate($perPage);
+    }
+
+    /**
+     * Resolve the set of allergen IDs that should disqualify a recipe given the
+     * `safe_for_members` filter. Returns null when no filtering is requested,
+     * or a (possibly empty) collection of allergen IDs otherwise.
+     *
+     * Members without a reviewed allergy profile are skipped, so a recipe is
+     * never silently considered "safe for someone we never asked about."
+     */
+    private function unsafeAllergenIdsForFilter(Family $family, array $filters): ?Collection
+    {
+        $memberIds = null;
+
+        if (($filters['safe_for'] ?? null) === 'all') {
+            $memberIds = User::where('family_id', $family->id)
+                ->whereNotNull('allergen_profile_reviewed_at')
+                ->pluck('id');
+        } elseif (! empty($filters['safe_for_members'])) {
+            $memberIds = User::where('family_id', $family->id)
+                ->whereIn('id', (array) $filters['safe_for_members'])
+                ->whereNotNull('allergen_profile_reviewed_at')
+                ->pluck('id');
+        }
+
+        if ($memberIds === null) {
+            return null;
+        }
+
+        if ($memberIds->isEmpty()) {
+            return collect();
+        }
+
+        return DB::table('member_allergens')
+            ->whereIn('user_id', $memberIds)
+            ->pluck('allergen_id')
+            ->unique()
+            ->values();
     }
 
     /**

--- a/resources/js/components/allergens/AllergenBadge.vue
+++ b/resources/js/components/allergens/AllergenBadge.vue
@@ -19,12 +19,12 @@ const props = defineProps({
 
 const isContains = computed(() => props.presence === 'contains')
 
-// Token-aligned: contains uses status-error tint, may_contain uses status-warning.
+// Token-aligned: contains uses status-failed tint, may_contain uses status-warning.
 // Unconfirmed dims via reduced opacity + dashed outline.
 const classes = computed(() => {
   const base = 'inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium border'
   const tone = isContains.value
-    ? 'bg-status-error/10 text-status-error border-status-error/30'
+    ? 'bg-status-failed/10 text-status-failed border-status-failed/30'
     : 'bg-status-warning/10 text-status-warning border-status-warning/40'
   const confirmation = props.unconfirmed
     ? 'border-dashed opacity-70'

--- a/resources/js/components/allergens/AllergyProfileEditor.vue
+++ b/resources/js/components/allergens/AllergyProfileEditor.vue
@@ -77,7 +77,7 @@ const markNoAllergies = async () => {
       :disabled="!canEdit"
     />
 
-    <p v-if="lastError" class="text-xs text-status-error" role="alert">
+    <p v-if="lastError" class="text-xs text-status-failed" role="alert">
       {{ lastError }}
     </p>
 

--- a/resources/js/components/allergens/FamilyAllergenSettings.vue
+++ b/resources/js/components/allergens/FamilyAllergenSettings.vue
@@ -120,7 +120,7 @@ const remove = async (allergen) => {
                 <PencilSquareIcon class="w-4 h-4" />
               </button>
               <button
-                class="p-1.5 text-status-error hover:bg-status-error/10 rounded"
+                class="p-1.5 text-status-failed hover:bg-status-failed/10 rounded"
                 aria-label="Delete"
                 @click="remove(a)"
               >
@@ -130,7 +130,7 @@ const remove = async (allergen) => {
           </template>
         </li>
       </ul>
-      <p v-if="editError" class="text-xs text-status-error mt-2" role="alert">{{ editError }}</p>
+      <p v-if="editError" class="text-xs text-status-failed mt-2" role="alert">{{ editError }}</p>
     </div>
 
     <div v-if="isParent" class="pt-2 border-t border-border-subtle">
@@ -146,7 +146,7 @@ const remove = async (allergen) => {
           Add
         </KinButton>
       </div>
-      <p v-if="addError" class="text-xs text-status-error mt-2" role="alert">{{ addError }}</p>
+      <p v-if="addError" class="text-xs text-status-failed mt-2" role="alert">{{ addError }}</p>
     </div>
   </div>
 </template>

--- a/resources/js/components/allergens/MealPlannerAllergenWarning.vue
+++ b/resources/js/components/allergens/MealPlannerAllergenWarning.vue
@@ -42,8 +42,8 @@ const grouped = computed(() => {
   <KinModalSheet :model-value="show" @update:model-value="(v) => !v && emit('cancel')">
     <div class="space-y-4 p-1">
       <div class="flex items-start gap-3">
-        <div class="shrink-0 w-10 h-10 rounded-full bg-status-error/10 flex items-center justify-center">
-          <ShieldExclamationIcon class="w-5 h-5 text-status-error" />
+        <div class="shrink-0 w-10 h-10 rounded-full bg-status-failed/10 flex items-center justify-center">
+          <ShieldExclamationIcon class="w-5 h-5 text-status-failed" />
         </div>
         <div class="flex-1 min-w-0">
           <h2 class="text-base font-semibold text-ink-primary">Allergen warning</h2>
@@ -59,13 +59,13 @@ const grouped = computed(() => {
         <li
           v-for="entry in grouped"
           :key="entry.member_id"
-          class="p-3 rounded-lg bg-status-error/5 border border-status-error/20"
+          class="p-3 rounded-lg bg-status-failed/5 border border-status-failed/20"
         >
           <p class="text-sm font-semibold text-ink-primary">{{ entry.member_name }}</p>
           <p class="text-xs text-ink-secondary mt-0.5">
             <template v-for="(item, idx) in entry.items" :key="`${entry.member_id}-${item.allergen_name}-${item.presence}`">
               <span v-if="idx > 0">, </span>
-              <span :class="item.presence === 'may_contain' ? 'text-status-warning' : 'text-status-error font-medium'">
+              <span :class="item.presence === 'may_contain' ? 'text-status-warning' : 'text-status-failed font-medium'">
                 {{ item.presence === 'may_contain' ? 'may contain ' : '' }}{{ item.allergen_name.toLowerCase() }}
               </span>
             </template>

--- a/resources/js/components/allergens/MealPlannerAllergenWarning.vue
+++ b/resources/js/components/allergens/MealPlannerAllergenWarning.vue
@@ -1,0 +1,86 @@
+<!--
+  MealPlannerAllergenWarning — modal shown when adding a recipe to the meal
+  plan that contains allergens for one or more family members with reviewed
+  profiles. The user must explicitly acknowledge before the entry can land.
+-->
+<script setup>
+import { computed } from 'vue'
+import KinModalSheet from '@/components/design-system/KinModalSheet.vue'
+import KinButton from '@/components/design-system/KinButton.vue'
+import { ShieldExclamationIcon } from '@heroicons/vue/24/outline'
+
+const props = defineProps({
+  show: { type: Boolean, required: true },
+  hits: { type: Array, required: true },
+  recipeTitle: { type: String, default: '' },
+})
+
+const emit = defineEmits(['acknowledge', 'cancel'])
+
+// Group hits by member so the modal reads as "Bob can't have peanuts, milk"
+// rather than one line per (member, allergen) pair.
+const grouped = computed(() => {
+  const byMember = new Map()
+  for (const hit of props.hits) {
+    if (!byMember.has(hit.member_id)) {
+      byMember.set(hit.member_id, {
+        member_id: hit.member_id,
+        member_name: hit.member_name,
+        items: [],
+      })
+    }
+    byMember.get(hit.member_id).items.push({
+      allergen_name: hit.allergen_name,
+      presence: hit.presence,
+    })
+  }
+  return [...byMember.values()]
+})
+</script>
+
+<template>
+  <KinModalSheet :model-value="show" @update:model-value="(v) => !v && emit('cancel')">
+    <div class="space-y-4 p-1">
+      <div class="flex items-start gap-3">
+        <div class="shrink-0 w-10 h-10 rounded-full bg-status-error/10 flex items-center justify-center">
+          <ShieldExclamationIcon class="w-5 h-5 text-status-error" />
+        </div>
+        <div class="flex-1 min-w-0">
+          <h2 class="text-base font-semibold text-ink-primary">Allergen warning</h2>
+          <p class="text-xs text-ink-secondary mt-0.5">
+            <template v-if="recipeTitle">"{{ recipeTitle }}" contains</template>
+            <template v-else>This recipe contains</template>
+            allergens for one or more family members with reviewed profiles.
+          </p>
+        </div>
+      </div>
+
+      <ul class="space-y-2">
+        <li
+          v-for="entry in grouped"
+          :key="entry.member_id"
+          class="p-3 rounded-lg bg-status-error/5 border border-status-error/20"
+        >
+          <p class="text-sm font-semibold text-ink-primary">{{ entry.member_name }}</p>
+          <p class="text-xs text-ink-secondary mt-0.5">
+            <template v-for="(item, idx) in entry.items" :key="`${entry.member_id}-${item.allergen_name}-${item.presence}`">
+              <span v-if="idx > 0">, </span>
+              <span :class="item.presence === 'may_contain' ? 'text-status-warning' : 'text-status-error font-medium'">
+                {{ item.presence === 'may_contain' ? 'may contain ' : '' }}{{ item.allergen_name.toLowerCase() }}
+              </span>
+            </template>
+          </p>
+        </li>
+      </ul>
+
+      <p class="text-xs text-ink-tertiary">
+        If you'll prepare a separate dish or are aware of the risk, you can plan it anyway. Otherwise pick a different recipe.
+      </p>
+
+      <div class="flex flex-wrap gap-2 justify-end pt-2">
+        <KinButton variant="ghost" @click="emit('cancel')">Pick something else</KinButton>
+        <KinButton variant="primary" @click="emit('acknowledge')">I understand, plan anyway</KinButton>
+      </div>
+    </div>
+  </KinModalSheet>
+</template>

--- a/resources/js/components/allergens/SafeForMemberFilter.vue
+++ b/resources/js/components/allergens/SafeForMemberFilter.vue
@@ -1,0 +1,129 @@
+<!--
+  SafeForMemberFilter — chip that opens a small popover to pick one or more
+  family members to filter recipes by. Only members with a reviewed allergy
+  profile are listed; filtering against an unreviewed profile would be a false-
+  safe and is silently dropped on the API side anyway.
+-->
+<script setup>
+import { ref, computed, onMounted, onBeforeUnmount } from 'vue'
+import { useAuthStore } from '@/stores/auth'
+import { useAllergensStore } from '@/stores/allergens'
+import KinChip from '@/components/design-system/KinChip.vue'
+import { ShieldCheckIcon, ChevronDownIcon } from '@heroicons/vue/24/outline'
+
+const props = defineProps({
+  modelValue: { type: Array, required: true }, // selected member IDs
+})
+
+const emit = defineEmits(['update:modelValue'])
+
+const authStore = useAuthStore()
+const allergensStore = useAllergensStore()
+
+const open = ref(false)
+const rootRef = ref(null)
+
+const familyMembers = computed(() => authStore.familyMembers || [])
+
+const reviewedMembers = computed(() => {
+  return familyMembers.value
+    .map((m) => ({
+      id: m.id,
+      name: m.name,
+      reviewed: Boolean(allergensStore.profileFor(m.id)?.reviewed_at),
+    }))
+    .filter((m) => m.reviewed)
+})
+
+const selectedNames = computed(() => {
+  const map = new Map(familyMembers.value.map((m) => [m.id, m.name]))
+  return props.modelValue.map((id) => map.get(id)).filter(Boolean)
+})
+
+const label = computed(() => {
+  if (props.modelValue.length === 0) return 'Safe for…'
+  if (props.modelValue.length === 1) return `Safe for ${selectedNames.value[0]}`
+  return `Safe for ${props.modelValue.length} members`
+})
+
+const isSelected = (id) => props.modelValue.includes(id)
+
+const toggle = (id) => {
+  const next = isSelected(id)
+    ? props.modelValue.filter((x) => x !== id)
+    : [...props.modelValue, id]
+  emit('update:modelValue', next)
+}
+
+const clearAll = () => emit('update:modelValue', [])
+
+const onDocumentClick = (e) => {
+  if (!open.value) return
+  if (rootRef.value && !rootRef.value.contains(e.target)) open.value = false
+}
+
+onMounted(() => {
+  document.addEventListener('click', onDocumentClick)
+  // Lazy-load profiles for all family members so reviewed status is accurate
+  familyMembers.value.forEach((m) => {
+    if (!allergensStore.profileFor(m.id)) allergensStore.fetchMemberProfile(m.id)
+  })
+})
+
+onBeforeUnmount(() => {
+  document.removeEventListener('click', onDocumentClick)
+})
+</script>
+
+<template>
+  <div ref="rootRef" class="relative inline-block">
+    <KinChip
+      variant="filter"
+      size="sm"
+      color="mint"
+      :active="modelValue.length > 0"
+      class="flex-shrink-0 whitespace-nowrap"
+      @click="open = !open"
+    >
+      <template #leading>
+        <ShieldCheckIcon class="w-3 h-3" />
+      </template>
+      {{ label }}
+      <ChevronDownIcon class="w-3 h-3 ml-0.5" />
+    </KinChip>
+
+    <div
+      v-if="open"
+      class="absolute z-30 top-full left-0 mt-1 w-56 rounded-lg shadow-lg border border-border-subtle bg-surface-raised p-2"
+    >
+      <div v-if="reviewedMembers.length === 0" class="px-2 py-2 text-xs text-ink-secondary">
+        No family member has a reviewed allergy profile yet. Set one up in Settings → Allergens.
+      </div>
+      <template v-else>
+        <button
+          v-for="member in reviewedMembers"
+          :key="member.id"
+          type="button"
+          class="w-full flex items-center gap-2 px-2 py-1.5 text-sm text-left rounded hover:bg-surface-sunken"
+          @click="toggle(member.id)"
+        >
+          <input
+            type="checkbox"
+            class="rounded border-border-subtle"
+            :checked="isSelected(member.id)"
+            @click.stop="toggle(member.id)"
+          />
+          <span class="flex-1 text-ink-primary">{{ member.name }}</span>
+        </button>
+        <button
+          v-if="modelValue.length > 0"
+          type="button"
+          class="w-full mt-1 px-2 py-1.5 text-xs text-ink-tertiary hover:text-ink-primary text-left"
+          @click="clearAll"
+        >
+          Clear filter
+        </button>
+      </template>
+    </div>
+  </div>
+</template>

--- a/resources/js/components/meals/MealEntryPicker.vue
+++ b/resources/js/components/meals/MealEntryPicker.vue
@@ -192,6 +192,14 @@
       <p v-if="submitError" class="text-xs text-status-failed mt-2">{{ submitError }}</p>
     </template>
   </SlidePanel>
+
+  <MealPlannerAllergenWarning
+    :show="showAllergenWarning"
+    :hits="allergenHits"
+    :recipe-title="allergenRecipeTitle"
+    @acknowledge="onAllergenAcknowledge"
+    @cancel="onAllergenCancel"
+  />
 </template>
 
 <script setup>
@@ -213,6 +221,7 @@ import BaseInput from '@/components/common/BaseInput.vue'
 import BaseButton from '@/components/common/BaseButton.vue'
 import LoadingSpinner from '@/components/common/LoadingSpinner.vue'
 import UserAvatar from '@/components/common/UserAvatar.vue'
+import MealPlannerAllergenWarning from '@/components/allergens/MealPlannerAllergenWarning.vue'
 import IconRenderer from '@/components/common/IconRenderer.vue'
 
 const props = defineProps({
@@ -227,6 +236,13 @@ const recipesStore = useRecipesStore()
 const restaurantsStore = useRestaurantsStore()
 const mealsStore = useMealsStore()
 const authStore = useAuthStore()
+
+// Allergen-warning modal state. Declared here so submit() (defined below) has
+// stable references at evaluation time.
+const showAllergenWarning = ref(false)
+const allergenHits = ref([])
+const allergenRetry = ref(null)
+const allergenRecipeTitle = ref('')
 
 const familyMembers = computed(() => authStore.familyMembers || [])
 
@@ -343,8 +359,33 @@ const submit = async () => {
   if (result.success) {
     emit('added')
     emit('close')
+  } else if (result.requiresAllergenAck) {
+    allergenHits.value = result.hits
+    allergenRetry.value = result.retry
+    allergenRecipeTitle.value = activeSource.value === 'recipe' ? (selectedSource.value?.title || '') : ''
+    showAllergenWarning.value = true
   } else {
     submitError.value = result.error || 'Failed to add entry'
   }
+}
+
+const onAllergenAcknowledge = async () => {
+  showAllergenWarning.value = false
+  if (!allergenRetry.value) return
+  isSaving.value = true
+  const result = await allergenRetry.value(true)
+  isSaving.value = false
+  if (result.success) {
+    emit('added')
+    emit('close')
+  } else {
+    submitError.value = result.error || 'Failed to add entry'
+  }
+}
+
+const onAllergenCancel = () => {
+  showAllergenWarning.value = false
+  allergenHits.value = []
+  allergenRetry.value = null
 }
 </script>

--- a/resources/js/components/recipes/RecipeForm.vue
+++ b/resources/js/components/recipes/RecipeForm.vue
@@ -479,11 +479,11 @@ const cycleAllergen = (id) => {
 }
 
 const allergenChipClass = (id) => {
-  const base = 'px-3 py-1.5 text-xs font-medium rounded-full border transition-colors'
+  const base = 'px-3 py-1.5 text-xs font-semibold rounded-full border-2 transition-colors'
   const state = allergenState(id)
-  if (state === 'contains') return `${base} bg-status-error/10 text-status-error border-status-error/40`
-  if (state === 'may_contain') return `${base} bg-status-warning/10 text-status-warning border-status-warning/40 border-dashed`
-  return `${base} bg-surface-sunken text-ink-secondary border-transparent hover:bg-surface-overlay`
+  if (state === 'contains') return `${base} bg-status-failed text-white border-status-failed`
+  if (state === 'may_contain') return `${base} bg-status-warning/15 text-status-warning border-status-warning border-dashed`
+  return `${base} bg-surface-sunken text-ink-secondary border-transparent font-medium hover:bg-surface-overlay`
 }
 
 const allergenChipLabel = (allergen) => {

--- a/resources/js/stores/meals.js
+++ b/resources/js/stores/meals.js
@@ -161,8 +161,19 @@ export const useMealsStore = defineStore('meals', () => {
       if (idx !== -1) currentPlan.value.entries.splice(idx, 1, newEntry)
       return { success: true, data: newEntry }
     } catch (err) {
-      // Rollback
+      // Rollback optimistic add
       currentPlan.value.entries = currentPlan.value.entries.filter(e => e.id !== tempEntry.id)
+
+      // Allergen acknowledgement required — surface so caller can prompt user.
+      if (err.response?.status === 409 && err.response?.data?.requires_acknowledgement) {
+        return {
+          success: false,
+          requiresAllergenAck: true,
+          hits: err.response.data.hits || [],
+          retry: (acknowledged) => addEntry(planId, { ...data, acknowledge_allergens: !!acknowledged }),
+        }
+      }
+
       return { success: false, error: err.response?.data?.message || 'Failed to add entry' }
     }
   }

--- a/resources/js/stores/recipes.js
+++ b/resources/js/stores/recipes.js
@@ -16,6 +16,7 @@ export const useRecipesStore = defineStore('recipes', () => {
   const sortBy = ref('recent')
   const selectedTagIds = ref([])
   const showFavoritesOnly = ref(false)
+  const safeForMemberIds = ref([])
 
   // Computed
   const hasMore = computed(() => pagination.value.current_page < pagination.value.last_page)
@@ -57,6 +58,7 @@ export const useRecipesStore = defineStore('recipes', () => {
       if (sortBy.value && sortBy.value !== 'recent') params.sort = sortBy.value
       if (selectedTagIds.value.length === 1) params.tag = selectedTagIds.value[0]
       if (showFavoritesOnly.value) params.favorite = 1
+      if (safeForMemberIds.value.length > 0) params['safe_for_members'] = safeForMemberIds.value
 
       const response = await api.get('/recipes', { params })
       recipes.value = response.data.data
@@ -285,6 +287,7 @@ export const useRecipesStore = defineStore('recipes', () => {
     sortBy,
     selectedTagIds,
     showFavoritesOnly,
+    safeForMemberIds,
 
     // Computed
     hasMore,

--- a/resources/js/views/food/RecipesTab.vue
+++ b/resources/js/views/food/RecipesTab.vue
@@ -40,6 +40,9 @@
           Favorites
         </KinChip>
 
+        <!-- Safe-for-member filter (food module) -->
+        <SafeForMemberFilter v-if="foodEnabled" v-model="safeForMemberIds" />
+
         <!-- Divider -->
         <div class="w-px h-4 bg-border-subtle flex-shrink-0"></div>
 
@@ -234,6 +237,8 @@ import KinSelect from '@/components/design-system/KinSelect.vue'
 import KinChip from '@/components/design-system/KinChip.vue'
 import KinEmptyState from '@/components/design-system/KinEmptyState.vue'
 import KinModalSheet from '@/components/design-system/KinModalSheet.vue'
+import SafeForMemberFilter from '@/components/allergens/SafeForMemberFilter.vue'
+import { useAuthStore } from '@/stores/auth'
 import {
   HeartIcon,
   PencilSquareIcon,
@@ -248,8 +253,11 @@ import {
 import { HeartIcon as HeartIconSolid } from '@heroicons/vue/24/solid'
 
 const recipesStore = useRecipesStore()
-const { recipes, tags, isLoading, hasMore, searchQuery, sortBy, selectedTagIds, showFavoritesOnly } = storeToRefs(recipesStore)
+const authStore = useAuthStore()
+const { recipes, tags, isLoading, hasMore, searchQuery, sortBy, selectedTagIds, showFavoritesOnly, safeForMemberIds } = storeToRefs(recipesStore)
 const { success, error: notifyError } = useNotification()
+
+const foodEnabled = computed(() => authStore.userCanAccessModule('food'))
 
 const searchInput = ref('')
 const showAddMenu = ref(false)
@@ -355,6 +363,11 @@ const loadMore = () => {
 
 // Tag filter triggers refetch
 watch(selectedTagIds, () => {
+  recipesStore.fetchRecipes()
+}, { deep: true })
+
+// Safe-for-members filter triggers refetch
+watch(safeForMemberIds, () => {
   recipesStore.fetchRecipes()
 }, { deep: true })
 

--- a/tests/Feature/AllergenFilteringTest.php
+++ b/tests/Feature/AllergenFilteringTest.php
@@ -1,0 +1,274 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Enums\AllergenPresence;
+use App\Enums\AllergenSource;
+use App\Enums\FamilyRole;
+use App\Models\Allergen;
+use App\Models\Family;
+use App\Models\MealPlan;
+use App\Models\Recipe;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Str;
+use Laravel\Sanctum\Sanctum;
+use Tests\TestCase;
+
+class AllergenFilteringTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private Family $family;
+
+    private User $parent;
+
+    private User $childWithProfile;
+
+    private User $childWithoutProfile;
+
+    private Allergen $peanuts;
+
+    private Allergen $milk;
+
+    private Recipe $peanutCookies;
+
+    private Recipe $milkBread;
+
+    private Recipe $plainSalad;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->family = Family::create([
+            'name' => 'Test Family',
+            'slug' => 'test-family',
+            'invite_code' => 'TEST01',
+            'settings' => ['modules' => ['food' => true]],
+        ]);
+
+        $this->parent = User::create([
+            'name' => 'Parent',
+            'email' => 'parent@test.com',
+            'password' => bcrypt('password'),
+            'family_id' => $this->family->id,
+            'family_role' => FamilyRole::Parent,
+        ]);
+
+        $this->childWithProfile = User::create([
+            'name' => 'Reviewed Child',
+            'email' => 'reviewed@test.com',
+            'password' => bcrypt('password'),
+            'family_id' => $this->family->id,
+            'family_role' => FamilyRole::Child,
+            'allergen_profile_reviewed_at' => now(),
+        ]);
+
+        $this->childWithoutProfile = User::create([
+            'name' => 'Unreviewed Child',
+            'email' => 'unreviewed@test.com',
+            'password' => bcrypt('password'),
+            'family_id' => $this->family->id,
+            'family_role' => FamilyRole::Child,
+        ]);
+
+        $this->peanuts = Allergen::where('slug', 'peanuts')->whereNull('family_id')->firstOrFail();
+        $this->milk = Allergen::where('slug', 'milk')->whereNull('family_id')->firstOrFail();
+
+        $this->childWithProfile->allergens()->attach($this->peanuts->id);
+        $this->childWithoutProfile->allergens()->attach($this->milk->id); // ignored: profile not reviewed
+
+        $this->peanutCookies = $this->makeRecipeWithAllergen('Peanut Cookies', $this->peanuts, AllergenPresence::Contains);
+        $this->milkBread = $this->makeRecipeWithAllergen('Milk Bread', $this->milk, AllergenPresence::Contains);
+        $this->plainSalad = Recipe::create([
+            'family_id' => $this->family->id,
+            'created_by' => $this->parent->id,
+            'title' => 'Plain Salad',
+        ]);
+    }
+
+    // ── Filter param: safe_for_members[] ──
+
+    public function test_safe_for_members_excludes_recipes_containing_their_allergens(): void
+    {
+        Sanctum::actingAs($this->parent);
+
+        $response = $this->getJson('/api/v1/recipes?safe_for_members[]='.$this->childWithProfile->id)
+            ->assertOk();
+
+        $titles = collect($response->json('data'))->pluck('title')->all();
+        $this->assertNotContains('Peanut Cookies', $titles);
+        $this->assertContains('Milk Bread', $titles);
+        $this->assertContains('Plain Salad', $titles);
+    }
+
+    public function test_safe_for_members_treats_may_contain_as_unsafe(): void
+    {
+        $traceRecipe = $this->makeRecipeWithAllergen('Trace Peanut Granola', $this->peanuts, AllergenPresence::MayContain);
+
+        Sanctum::actingAs($this->parent);
+
+        $titles = collect(
+            $this->getJson('/api/v1/recipes?safe_for_members[]='.$this->childWithProfile->id)
+                ->assertOk()
+                ->json('data')
+        )->pluck('title')->all();
+
+        $this->assertNotContains('Trace Peanut Granola', $titles);
+    }
+
+    public function test_safe_for_all_uses_only_reviewed_member_profiles(): void
+    {
+        // Unreviewed child has milk on their profile, but it must be ignored —
+        // so Milk Bread should NOT be filtered out by safe_for=all.
+        Sanctum::actingAs($this->parent);
+
+        $titles = collect(
+            $this->getJson('/api/v1/recipes?safe_for=all')
+                ->assertOk()
+                ->json('data')
+        )->pluck('title')->all();
+
+        $this->assertNotContains('Peanut Cookies', $titles);
+        $this->assertContains('Milk Bread', $titles); // unreviewed profile is silently ignored
+        $this->assertContains('Plain Salad', $titles);
+    }
+
+    public function test_safe_for_member_with_no_allergens_returns_everything(): void
+    {
+        $cleanMember = User::create([
+            'name' => 'Clean',
+            'email' => 'clean@test.com',
+            'password' => bcrypt('password'),
+            'family_id' => $this->family->id,
+            'family_role' => FamilyRole::Child,
+            'allergen_profile_reviewed_at' => now(),
+        ]);
+
+        Sanctum::actingAs($this->parent);
+
+        $titles = collect(
+            $this->getJson('/api/v1/recipes?safe_for_members[]='.$cleanMember->id)
+                ->assertOk()
+                ->json('data')
+        )->pluck('title')->all();
+
+        $this->assertContains('Peanut Cookies', $titles);
+        $this->assertContains('Milk Bread', $titles);
+        $this->assertContains('Plain Salad', $titles);
+    }
+
+    public function test_unreviewed_member_id_in_safe_for_members_is_skipped(): void
+    {
+        // Pass the unreviewed child's ID; the filter should silently ignore it.
+        Sanctum::actingAs($this->parent);
+
+        $titles = collect(
+            $this->getJson('/api/v1/recipes?safe_for_members[]='.$this->childWithoutProfile->id)
+                ->assertOk()
+                ->json('data')
+        )->pluck('title')->all();
+
+        // No filter applied → everything returns
+        $this->assertContains('Peanut Cookies', $titles);
+        $this->assertContains('Milk Bread', $titles);
+    }
+
+    // ── Meal planner guard ──
+
+    public function test_planning_recipe_with_allergen_for_reviewed_member_requires_acknowledgement(): void
+    {
+        $plan = MealPlan::create([
+            'family_id' => $this->family->id,
+            'week_start' => now()->startOfWeek()->toDateString(),
+            'created_by' => $this->parent->id,
+        ]);
+
+        Sanctum::actingAs($this->parent);
+
+        $response = $this->postJson("/api/v1/meal-plans/{$plan->id}/entries", [
+            'date' => now()->toDateString(),
+            'meal_slot' => 'dinner',
+            'recipe_id' => $this->peanutCookies->id,
+        ])->assertStatus(409);
+
+        $response->assertJsonPath('requires_acknowledgement', true);
+        $hits = $response->json('hits');
+        $this->assertCount(1, $hits);
+        $this->assertEquals($this->childWithProfile->id, $hits[0]['member_id']);
+        $this->assertEquals('peanuts', Str::slug($hits[0]['allergen_name']));
+    }
+
+    public function test_planning_with_acknowledge_flag_succeeds_despite_allergen(): void
+    {
+        $plan = MealPlan::create([
+            'family_id' => $this->family->id,
+            'week_start' => now()->startOfWeek()->toDateString(),
+            'created_by' => $this->parent->id,
+        ]);
+
+        Sanctum::actingAs($this->parent);
+
+        $this->postJson("/api/v1/meal-plans/{$plan->id}/entries", [
+            'date' => now()->toDateString(),
+            'meal_slot' => 'dinner',
+            'recipe_id' => $this->peanutCookies->id,
+            'acknowledge_allergens' => true,
+        ])->assertCreated();
+    }
+
+    public function test_planning_recipe_with_no_matching_allergen_proceeds_without_ack(): void
+    {
+        $plan = MealPlan::create([
+            'family_id' => $this->family->id,
+            'week_start' => now()->startOfWeek()->toDateString(),
+            'created_by' => $this->parent->id,
+        ]);
+
+        Sanctum::actingAs($this->parent);
+
+        $this->postJson("/api/v1/meal-plans/{$plan->id}/entries", [
+            'date' => now()->toDateString(),
+            'meal_slot' => 'dinner',
+            'recipe_id' => $this->plainSalad->id,
+        ])->assertCreated();
+    }
+
+    public function test_planning_does_not_block_for_unreviewed_member_profile(): void
+    {
+        // Milk Bread has milk; unreviewed child has milk on profile. Since the
+        // profile is unreviewed, planner should NOT require acknowledgement.
+        $plan = MealPlan::create([
+            'family_id' => $this->family->id,
+            'week_start' => now()->startOfWeek()->toDateString(),
+            'created_by' => $this->parent->id,
+        ]);
+
+        Sanctum::actingAs($this->parent);
+
+        $this->postJson("/api/v1/meal-plans/{$plan->id}/entries", [
+            'date' => now()->toDateString(),
+            'meal_slot' => 'dinner',
+            'recipe_id' => $this->milkBread->id,
+        ])->assertCreated();
+    }
+
+    private function makeRecipeWithAllergen(string $title, Allergen $allergen, AllergenPresence $presence): Recipe
+    {
+        $recipe = Recipe::create([
+            'family_id' => $this->family->id,
+            'created_by' => $this->parent->id,
+            'title' => $title,
+        ]);
+        $recipe->allergens()->attach($allergen->id, [
+            'id' => (string) Str::uuid(),
+            'presence' => $presence->value,
+            'source' => AllergenSource::HumanConfirmed->value,
+            'confirmed_by' => $this->parent->id,
+            'confirmed_at' => now(),
+        ]);
+
+        return $recipe;
+    }
+}


### PR DESCRIPTION
## Summary
PR 3 of 4+1 toward v1.10.0. Adds the "Safe for X" recipe filter and the meal-planner blocker that refuses to silently plan unsafe meals — the part of v1.10.0 where the data shape from #314 + #315 turns into real-world safety.

## Linked Issues
Closes #316
Part of #312

## What ships

**Backend — recipe filter:**
- `RecipeService::searchRecipes()` accepts `safe_for_members[]` (one or more member IDs) and `safe_for=all` (shortcut for every reviewed member). Excludes any recipe carrying a `contains | may_contain` allergen for the given members.
- **Members without a reviewed profile are silently skipped.** Filtering against an unknown profile would be a false-safe and is worse than not filtering.
- `RecipeController@index` forwards the new params.

**Backend — meal planner guard:**
- New `AllergenAcknowledgementRequired` exception renders `409` with `requires_acknowledgement: true` + `hits[]` (member + allergen + presence).
- `MealPlanService::addEntry()` checks recipe allergens against reviewed family profiles. Throws unless `acknowledge_allergens === true` was sent.
- `StoreMealPlanEntryRequest` accepts the new flag.

**Frontend:**
- `SafeForMemberFilter.vue` — dropdown chip in the recipes toolbar listing reviewed members. Multi-select. Loads profiles lazily. Hidden when food module off.
- `MealPlannerAllergenWarning.vue` — modal grouping hits by member; severity-coded copy (contains red, may_contain yellow); explicit "I understand, plan anyway" CTA.
- `mealsStore.addEntry` catches the 409 and surfaces `{ requiresAllergenAck, hits, retry }` to the caller.
- `MealEntryPicker` renders the modal on 409 and re-submits with `acknowledge_allergens: true` on confirm.

## Test Plan
- [x] 9 new tests in `AllergenFilteringTest`: filter excludes correctly across contains × may_contain × single member × all-members, empty-allergen member returns everything, unreviewed member silently skipped, planner refuses without ack, acknowledged plan succeeds, no-allergen recipe proceeds without ack, unreviewed-profile match does not block
- [x] Full suite: 417 tests, 1098 assertions, green
- [x] Pint + PHPStan + ESLint clean
- [x] **Manual verification in preview env**: Adaeze (peanut allergy profile) + Chocolate Chip Cookies (peanuts). Recipes tab → "Safe for Adaeze" filter excludes the recipe (16 → 15). Meal planner add: API returns 409 with hit details; modal shows "Adaeze — peanuts"; "I understand, plan anyway" re-submits and the entry lands.

## Checklist
- [x] Tested locally + in preview
- [x] Mobile-first verified (filter chip dropdown + modal both work at 375px)
- [x] No credentials committed
- [x] Module gating enforced (filter chip + planner check hide when food off)
- [x] Defense-in-depth: unreviewed profiles never silently filter, planner requires explicit ack

## Target branch
`feature/allergens-v1.10.0`

## Blocked by
- #314 ✅ merged
- #315 ✅ merged

## Blocks
- #317 (AI integration — needs the filter + planner code paths in place to test against, especially for AI-tagged "unconfirmed" allergens)

## What's there for #317
- The `unconfirmed` prop on `AllergenBadge` (added in #315) is still reserved
- Backend treats ai_auto / ai_suggested / human_confirmed identically for filter + planner purposes — they're all "tagged", AI provenance just affects UI rendering. No backend change needed in #317 for filtering to work with AI tags.