### PR TITLE
feat: AI allergen extraction + confidence routing + backfill

### DIFF
--- a/app/Console/Commands/BackfillRecipeAllergens.php
+++ b/app/Console/Commands/BackfillRecipeAllergens.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Jobs\BackfillRecipeAllergens as BackfillJob;
+use App\Models\Recipe;
+use App\Services\RecipeImportService;
+use Illuminate\Console\Command;
+
+class BackfillRecipeAllergens extends Command
+{
+    protected $signature = 'recipes:backfill-allergens
+                            {--family= : Limit to a single family ID}
+                            {--force : Re-tag even recipes that already have allergens}
+                            {--sync : Run inline instead of dispatching to the queue}';
+
+    protected $description = 'Queue an AI allergen pass over recipes that have no allergen tags yet. Idempotent unless --force.';
+
+    public function handle(): int
+    {
+        $query = Recipe::query();
+
+        if ($familyId = $this->option('family')) {
+            $query->where('family_id', $familyId);
+        }
+
+        if (! $this->option('force')) {
+            $query->doesntHave('allergens');
+        }
+
+        $total = (clone $query)->count();
+        if ($total === 0) {
+            $this->info('No recipes need a backfill.');
+
+            return self::SUCCESS;
+        }
+
+        $this->info("Queueing {$total} recipe(s) for AI allergen backfill...");
+
+        $bar = $this->output->createProgressBar($total);
+        $bar->start();
+
+        $query->chunkById(100, function ($chunk) use ($bar) {
+            foreach ($chunk as $recipe) {
+                $job = new BackfillJob((string) $recipe->id, (bool) $this->option('force'));
+                if ($this->option('sync')) {
+                    $job->handle(app(RecipeImportService::class));
+                } else {
+                    BackfillJob::dispatch((string) $recipe->id, (bool) $this->option('force'));
+                }
+                $bar->advance();
+            }
+        });
+
+        $bar->finish();
+        $this->newLine(2);
+        $this->info($this->option('sync') ? 'Backfill complete.' : 'All jobs queued. Run your queue worker to process them.');
+
+        return self::SUCCESS;
+    }
+}

--- a/app/Http/Controllers/Api/V1/RecipeAllergenController.php
+++ b/app/Http/Controllers/Api/V1/RecipeAllergenController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers\Api\V1;
 
 use App\Enums\AllergenSource;
 use App\Http\Controllers\Controller;
+use App\Jobs\BackfillRecipeAllergens;
 use App\Models\Allergen;
 use App\Models\Recipe;
 use App\Models\RecipeAllergen;
@@ -13,6 +14,40 @@ use Illuminate\Support\Str;
 
 class RecipeAllergenController extends Controller
 {
+    /**
+     * Queue an AI allergen backfill for every recipe in the caller's family that
+     * has no allergen tags yet. Parent-only. Returns the count of jobs queued.
+     */
+    public function backfill(Request $request): JsonResponse
+    {
+        $user = $request->user();
+        if (! $user->isParent()) {
+            return response()->json(['message' => 'Only parents can run the allergen backfill.'], 403);
+        }
+
+        $family = $user->currentFamily()->firstOrFail();
+
+        $force = (bool) $request->input('force', false);
+
+        $recipes = Recipe::where('family_id', $family->id);
+        if (! $force) {
+            $recipes->doesntHave('allergens');
+        }
+
+        $count = 0;
+        $recipes->chunkById(100, function ($chunk) use (&$count, $force) {
+            foreach ($chunk as $recipe) {
+                BackfillRecipeAllergens::dispatch((string) $recipe->id, $force);
+                $count++;
+            }
+        });
+
+        return response()->json([
+            'queued' => $count,
+            'message' => "Queued {$count} recipe(s) for AI allergen tagging.",
+        ]);
+    }
+
     /**
      * Confirm or edit a single (recipe, allergen) row. Used by the recipe detail
      * view to confirm an AI-suggested tag, change presence, or remove an entry.

--- a/app/Http/Resources/RecipeResource.php
+++ b/app/Http/Resources/RecipeResource.php
@@ -44,6 +44,7 @@ class RecipeResource extends JsonResource
 
                 return [
                     'id' => $a->id,
+                    'pivot_id' => $pivot->id,
                     'name' => $a->name,
                     'slug' => $a->slug,
                     'is_big_nine' => (bool) $a->is_big_nine,

--- a/app/Jobs/BackfillRecipeAllergens.php
+++ b/app/Jobs/BackfillRecipeAllergens.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Models\Recipe;
+use App\Services\RecipeImportService;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * One-recipe AI allergen backfill. Idempotent: skips recipes that already have
+ * any allergen rows unless explicitly forced. Skips families without AI access.
+ */
+class BackfillRecipeAllergens implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    public function __construct(
+        public readonly string $recipeId,
+        public readonly bool $force = false,
+    ) {}
+
+    public function handle(RecipeImportService $service): void
+    {
+        $recipe = Recipe::with(['family', 'ingredients', 'allergens'])->find($this->recipeId);
+        if (! $recipe) {
+            return;
+        }
+
+        if (! $this->force && $recipe->allergens->isNotEmpty()) {
+            return;
+        }
+
+        $ingredients = $recipe->ingredients->map(fn ($i) => [
+            'name' => $i->name,
+            'quantity' => $i->quantity,
+            'unit' => $i->unit,
+            'preparation' => $i->preparation,
+        ])->all();
+
+        if (empty($ingredients)) {
+            return;
+        }
+
+        try {
+            $allergens = $service->extractAllergensFromIngredients($ingredients, $recipe->family);
+        } catch (\Throwable $e) {
+            Log::warning('BackfillRecipeAllergens: extraction failed', [
+                'recipe_id' => $recipe->id,
+                'reason' => $e->getMessage(),
+            ]);
+
+            return;
+        }
+
+        if (empty($allergens)) {
+            return;
+        }
+
+        // If forced, wipe existing rows before writing so old AI tags get refreshed.
+        if ($this->force) {
+            $recipe->allergens()->detach();
+        }
+
+        $service->persistAiAllergens($recipe, $allergens);
+    }
+}

--- a/app/Services/RecipeImportService.php
+++ b/app/Services/RecipeImportService.php
@@ -2,12 +2,15 @@
 
 namespace App\Services;
 
+use App\Enums\AllergenSource;
+use App\Models\Allergen;
 use App\Models\Family;
 use App\Models\Recipe;
 use App\Models\User;
 use App\Rules\FractionalQuantity;
 use Illuminate\Http\Client\ConnectionException;
 use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Storage;
@@ -22,7 +25,41 @@ class RecipeImportService
 
     private const MAX_TOKENS = 2048;
 
-    private const URL_SYSTEM_PROMPT = <<<'PROMPT'
+    private const ALLERGEN_THRESHOLD_AUTO = 0.95;
+
+    /**
+     * Allergen-extraction instructions injected into both prompts.
+     * Slugs are dynamic per family (Big 9 + custom rows).
+     */
+    private static function allergenPromptSection(array $allergenSlugs): string
+    {
+        $list = empty($allergenSlugs) ? '(none configured)' : '- '.implode("\n- ", $allergenSlugs);
+
+        return <<<PROMPT
+
+Also identify which of these allergens the recipe likely contains, based on the ingredients:
+{$list}
+
+Add to the JSON:
+"allergens": [
+  {"slug": "peanuts", "presence": "contains", "confidence": 0.98},
+  {"slug": "milk", "presence": "may_contain", "confidence": 0.6}
+]
+
+Allergen rules:
+- Only use slugs from the list above. Do not invent slugs.
+- presence: "contains" when the allergen is an explicit ingredient. "may_contain" only for clear cross-contamination cues (e.g. "made in a facility that also processes peanuts").
+- confidence: 0.0–1.0, your estimate of how likely the allergen is present given the ingredient list. Be conservative — a 1.0 means absolutely certain.
+- Omit anything below ~0.3 confidence. Empty array if none detected.
+- For wheat/gluten check explicitly: flour, bread, pasta, soy sauce, beer.
+- For milk check: butter, cream, cheese, yogurt, ghee.
+- For eggs check: mayo, custard, baked goods using eggs as a binder.
+PROMPT;
+    }
+
+    private static function urlSystemPrompt(array $allergenSlugs): string
+    {
+        return <<<'PROMPT'
 You are a recipe extraction assistant. Extract a structured recipe from the following web page content.
 
 Return a JSON object with EXACTLY these fields:
@@ -56,9 +93,13 @@ Other rules:
 - If a field is not found, set it to null (except title and instructions which are required).
 - Instructions should be clean step strings without numbering prefixes.
 - Return valid JSON only. No markdown, no explanation.
-PROMPT;
+PROMPT
+            .self::allergenPromptSection($allergenSlugs);
+    }
 
-    private const PHOTO_PROMPT = <<<'PROMPT'
+    private static function photoPrompt(array $allergenSlugs): string
+    {
+        return <<<'PROMPT'
 Extract a structured recipe from this image. Return JSON with:
 {
   "title": "Recipe title",
@@ -78,7 +119,9 @@ CRITICAL: The `name` field must contain ONLY the ingredient name — never the q
 Convert fractions to decimals: 1/2 → "0.5", 1/4 → "0.25", 3/4 → "0.75".
 If any field cannot be determined, set it to null.
 Return valid JSON only.
-PROMPT;
+PROMPT
+            .self::allergenPromptSection($allergenSlugs);
+    }
 
     public function __construct(
         private RecipeService $recipeService,
@@ -95,12 +138,26 @@ PROMPT;
         $html = $this->fetchUrl($url);
 
         $data = $this->parseJsonLd($html);
+        $usedLlm = false;
 
         if ($data === null) {
             $data = $this->extractViaLlm($html, $family);
+            $usedLlm = true;
         }
 
         $this->validateExtracted($data);
+
+        // JSON-LD paths skip the LLM entirely, so they have no allergen data.
+        // Run an ingredient-only allergen pass so the import is consistent.
+        // Silently no-ops if the family has no AI configured (BYOK off, etc.).
+        if (! $usedLlm && empty($data['allergens']) && ! empty($data['ingredients'])) {
+            try {
+                $data['allergens'] = $this->extractAllergensFromIngredients($data['ingredients'], $family);
+            } catch (\Throwable $e) {
+                Log::info('RecipeImportService: allergen pass skipped after JSON-LD', ['reason' => $e->getMessage()]);
+                $data['allergens'] = [];
+            }
+        }
 
         $data['source_url'] = $url;
         $data['source_type'] = 'url';
@@ -513,7 +570,7 @@ PROMPT;
         ])->timeout(60)->post(self::ANTHROPIC_API_URL, [
             'model' => $model,
             'max_tokens' => self::MAX_TOKENS,
-            'system' => self::URL_SYSTEM_PROMPT,
+            'system' => self::urlSystemPrompt($this->familyAllergenSlugs($family)),
             'messages' => [
                 ['role' => 'user', 'content' => $cleaned],
             ],
@@ -570,7 +627,7 @@ PROMPT;
                         ],
                         [
                             'type' => 'text',
-                            'text' => self::PHOTO_PROMPT,
+                            'text' => self::photoPrompt($this->familyAllergenSlugs($family)),
                         ],
                     ],
                 ],
@@ -587,6 +644,171 @@ PROMPT;
         $this->trackUsage($family, $response->json('usage'));
 
         return $this->parseLlmResponse($response->json());
+    }
+
+    /**
+     * Slugs available to this family for AI allergen tagging. Global Big 9 +
+     * the family's custom rows. Stable order so prompt caching has a chance.
+     */
+    private function familyAllergenSlugs(Family $family): array
+    {
+        return Allergen::availableToFamily((string) $family->id)
+            ->orderByDesc('is_big_nine')
+            ->orderBy('slug')
+            ->pluck('slug')
+            ->all();
+    }
+
+    /**
+     * Run AI allergen extraction over a free-form ingredient list. Used by the
+     * artisan backfill to scan existing recipes without re-fetching their HTML.
+     * Returns an array of `{slug, presence, confidence}` or [].
+     *
+     * @param  array<int, array{name?: string, quantity?: string, unit?: string, preparation?: string}>  $ingredients
+     * @return array<int, array{slug: string, presence: string, confidence: float}>
+     */
+    public function extractAllergensFromIngredients(array $ingredients, Family $family): array
+    {
+        $slugs = $this->familyAllergenSlugs($family);
+        if (empty($slugs) || empty($ingredients)) {
+            return [];
+        }
+
+        $apiKey = $this->resolveApiKey($family);
+        $model = $this->resolveModel($family);
+
+        $lines = collect($ingredients)
+            ->map(fn ($i) => trim(($i['quantity'] ?? '').' '.($i['unit'] ?? '').' '.($i['name'] ?? '').($i['preparation'] ? ', '.$i['preparation'] : '')))
+            ->filter()
+            ->implode("\n");
+
+        $system = 'You are an allergen-detection assistant. Identify allergens present in a recipe given its ingredient list. '.self::allergenPromptSection($slugs).
+            ' Return JSON with EXACTLY one field: {"allergens": [...]}';
+
+        $response = Http::withHeaders([
+            'x-api-key' => $apiKey,
+            'anthropic-version' => self::ANTHROPIC_VERSION,
+            'Content-Type' => 'application/json',
+        ])->timeout(60)->post(self::ANTHROPIC_API_URL, [
+            'model' => $model,
+            'max_tokens' => 512,
+            'system' => $system,
+            'messages' => [['role' => 'user', 'content' => $lines]],
+        ]);
+
+        if ($response->failed()) {
+            Log::error('RecipeImportService: allergen-only extraction failed', ['status' => $response->status()]);
+
+            return [];
+        }
+
+        $this->trackUsage($family, $response->json('usage'));
+
+        $parsed = $this->parseLlmResponse($response->json());
+
+        return $this->normalizeAllergens($parsed['allergens'] ?? [], $slugs);
+    }
+
+    /**
+     * Validate AI-returned allergens against the family's slug list. Drops
+     * unknown slugs, invalid presence values, malformed confidence scores.
+     *
+     * @param  array<mixed>  $raw
+     * @param  array<int, string>  $allowedSlugs
+     * @return array<int, array{slug: string, presence: string, confidence: float}>
+     */
+    private function normalizeAllergens(array $raw, array $allowedSlugs): array
+    {
+        $allowed = array_flip($allowedSlugs);
+        $out = [];
+
+        foreach ($raw as $entry) {
+            $slug = $entry['slug'] ?? null;
+            $presence = $entry['presence'] ?? null;
+            $confidence = $entry['confidence'] ?? null;
+
+            if (! is_string($slug) || ! isset($allowed[$slug])) {
+                continue;
+            }
+            if (! in_array($presence, ['contains', 'may_contain'], true)) {
+                continue;
+            }
+            if (! is_numeric($confidence)) {
+                continue;
+            }
+            $confidence = max(0.0, min(1.0, (float) $confidence));
+
+            $out[] = ['slug' => $slug, 'presence' => $presence, 'confidence' => $confidence];
+        }
+
+        return $out;
+    }
+
+    /**
+     * Persist a normalized allergen list onto a recipe with AI provenance.
+     * Confidence ≥ ALLERGEN_THRESHOLD_AUTO → source = ai_auto. Otherwise
+     * source = ai_suggested. Idempotent on (recipe, allergen, presence).
+     *
+     * Returns the number of rows written.
+     *
+     * @param  array<int, array{slug: string, presence: string, confidence: float}>  $allergens
+     */
+    public function persistAiAllergens(Recipe $recipe, array $allergens): int
+    {
+        if (empty($allergens)) {
+            return 0;
+        }
+
+        $slugToId = Allergen::availableToFamily($recipe->family_id)
+            ->pluck('id', 'slug');
+
+        $now = now();
+        $written = 0;
+        $seen = [];
+
+        foreach ($allergens as $entry) {
+            $allergenId = $slugToId[$entry['slug']] ?? null;
+            if (! $allergenId) {
+                continue;
+            }
+            $dedupeKey = $allergenId.'|'.$entry['presence'];
+            if (isset($seen[$dedupeKey])) {
+                continue;
+            }
+            $seen[$dedupeKey] = true;
+
+            $source = $entry['confidence'] >= self::ALLERGEN_THRESHOLD_AUTO
+                ? AllergenSource::AiAuto->value
+                : AllergenSource::AiSuggested->value;
+
+            // Skip if a row with this (recipe, allergen, presence) already exists —
+            // preserves human edits and keeps the operation safe to re-run.
+            $exists = DB::table('recipe_allergens')
+                ->where('recipe_id', $recipe->id)
+                ->where('allergen_id', $allergenId)
+                ->where('presence', $entry['presence'])
+                ->exists();
+
+            if ($exists) {
+                continue;
+            }
+
+            DB::table('recipe_allergens')->insert([
+                'id' => (string) Str::uuid(),
+                'recipe_id' => $recipe->id,
+                'allergen_id' => $allergenId,
+                'presence' => $entry['presence'],
+                'source' => $source,
+                'confidence' => $entry['confidence'],
+                'confirmed_by' => null,
+                'confirmed_at' => null,
+                'created_at' => $now,
+                'updated_at' => $now,
+            ]);
+            $written++;
+        }
+
+        return $written;
     }
 
     /**
@@ -671,6 +893,15 @@ PROMPT;
         ];
 
         $recipe = $this->recipeService->createRecipe($family, $user, $recipeData);
+
+        // AI-suggested allergens get persisted with their provenance. The recipe
+        // detail view surfaces them as "AI tagged" until a human confirms (or
+        // the user edits the recipe via the form, which rewrites as human_confirmed).
+        $allergens = $this->normalizeAllergens($data['allergens'] ?? [], $this->familyAllergenSlugs($family));
+        if (! empty($allergens)) {
+            $this->persistAiAllergens($recipe, $allergens);
+            $recipe->load('allergens');
+        }
 
         return ['recipe' => $recipe];
     }

--- a/resources/js/components/allergens/AllergenBadgeRow.vue
+++ b/resources/js/components/allergens/AllergenBadgeRow.vue
@@ -6,11 +6,17 @@
 <script setup>
 import { computed } from 'vue'
 import AllergenBadge from './AllergenBadge.vue'
+import { CheckIcon } from '@heroicons/vue/24/outline'
 
 const props = defineProps({
   allergens: { type: Array, required: true },
   limit: { type: Number, default: 0 }, // 0 = show all
+  // When true, unconfirmed (AI-tagged) badges get an inline "confirm" action.
+  // Used on the recipe detail view; cards are display-only.
+  editable: { type: Boolean, default: false },
 })
+
+const emit = defineEmits(['confirm'])
 
 const visible = computed(() => {
   if (!props.limit || props.allergens.length <= props.limit) return props.allergens
@@ -21,17 +27,32 @@ const overflow = computed(() => {
   if (!props.limit) return 0
   return Math.max(0, props.allergens.length - props.limit)
 })
+
+const isUnconfirmed = (row) => row.source && row.source !== 'human_confirmed'
 </script>
 
 <template>
-  <div v-if="allergens.length" class="flex flex-wrap gap-1.5">
-    <AllergenBadge
-      v-for="row in visible"
-      :key="`${row.id}-${row.presence}`"
-      :name="row.name"
-      :presence="row.presence"
-      :unconfirmed="row.source && row.source !== 'human_confirmed'"
-    />
+  <div v-if="allergens.length" class="flex flex-wrap gap-1.5 items-center">
+    <template v-for="row in visible" :key="`${row.id}-${row.presence}`">
+      <span v-if="editable && isUnconfirmed(row)" class="inline-flex items-center gap-0.5">
+        <AllergenBadge :name="row.name" :presence="row.presence" :unconfirmed="true" />
+        <button
+          type="button"
+          class="inline-flex items-center justify-center w-5 h-5 rounded-full bg-status-success/15 text-status-success hover:bg-status-success/30 transition-colors"
+          :aria-label="`Confirm ${row.name}`"
+          :title="`Confirm AI tag for ${row.name}`"
+          @click="emit('confirm', row)"
+        >
+          <CheckIcon class="w-3 h-3" />
+        </button>
+      </span>
+      <AllergenBadge
+        v-else
+        :name="row.name"
+        :presence="row.presence"
+        :unconfirmed="isUnconfirmed(row)"
+      />
+    </template>
     <span
       v-if="overflow"
       class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-surface-sunken text-ink-tertiary"

--- a/resources/js/components/recipes/RecipeForm.vue
+++ b/resources/js/components/recipes/RecipeForm.vue
@@ -414,7 +414,25 @@ const populateFromImportPreview = (data) => {
     typeof step === 'string' ? step : (step.text || '')
   )
   form.tag_ids = []
-  form.allergens = []
+
+  // AI-suggested allergens come in as {slug, presence, confidence}. Translate
+  // them to the form's shape using the loaded allergen list. If the allergens
+  // store hasn't loaded yet, do it now and re-populate when it arrives.
+  const mapAiAllergens = () => {
+    const bySlug = new Map((allergensStore.allergens || []).map((a) => [a.slug, a.id]))
+    form.allergens = (data.allergens || [])
+      .map((entry) => ({
+        allergen_id: bySlug.get(entry.slug),
+        presence: entry.presence || 'contains',
+      }))
+      .filter((entry) => entry.allergen_id)
+  }
+
+  if (foodEnabled.value && allergensStore.allergens.length === 0) {
+    allergensStore.fetchAllergens().then(mapAiAllergens)
+  } else {
+    mapAiAllergens()
+  }
 }
 
 // ── Ingredient actions ──

--- a/resources/js/stores/recipes.js
+++ b/resources/js/stores/recipes.js
@@ -145,6 +145,25 @@ export const useRecipesStore = defineStore('recipes', () => {
     }
   }
 
+  // Confirm an AI-tagged allergen (ai_auto / ai_suggested → human_confirmed).
+  // Updates the recipe in place so the badge re-renders without a refetch.
+  const confirmAllergen = async (recipeId, pivotId) => {
+    try {
+      await api.patch(`/recipes/${recipeId}/allergens/${pivotId}`)
+      const stamp = (recipe) => {
+        if (!recipe?.allergens) return
+        const hit = recipe.allergens.find((a) => a.id && a.pivot_id === pivotId)
+        if (hit) hit.source = 'human_confirmed'
+      }
+      stamp(currentRecipe.value)
+      const inList = recipes.value.find((r) => r.id === recipeId)
+      stamp(inList)
+      return { success: true }
+    } catch (err) {
+      return { success: false, error: err.response?.data?.message || 'Failed to confirm allergen' }
+    }
+  }
+
   const toggleFavorite = async (id) => {
     // Optimistic update
     const index = recipes.value.findIndex((r) => r.id === id)
@@ -288,6 +307,7 @@ export const useRecipesStore = defineStore('recipes', () => {
     selectedTagIds,
     showFavoritesOnly,
     safeForMemberIds,
+    confirmAllergen,
 
     // Computed
     hasMore,

--- a/resources/js/views/food/RecipeDetailView.vue
+++ b/resources/js/views/food/RecipeDetailView.vue
@@ -113,6 +113,8 @@
         <AllergenBadgeRow
           v-if="recipe.allergens?.length"
           :allergens="recipe.allergens"
+          :editable="isParent"
+          @confirm="onConfirmAllergen"
         />
 
         <!-- Source -->
@@ -333,6 +335,11 @@ const loadRecipe = async () => {
 
 const handleToggleFavorite = async () => {
   const result = await recipesStore.toggleFavorite(recipe.value.id)
+  if (!result.success) notifyError(result.error)
+}
+
+const onConfirmAllergen = async (row) => {
+  const result = await recipesStore.confirmAllergen(recipe.value.id, row.pivot_id)
   if (!result.success) notifyError(result.error)
 }
 

--- a/routes/api.php
+++ b/routes/api.php
@@ -235,6 +235,9 @@ Route::prefix('v1')->group(function () {
                 // Fine-grained allergen edits (single-row confirm / change presence / remove)
                 Route::post('/{recipe}/allergens', [RecipeAllergenController::class, 'store']);
                 Route::patch('/{recipe}/allergens/{allergen}', [RecipeAllergenController::class, 'update']);
+
+                // Family-wide AI allergen backfill (parent only)
+                Route::post('/allergens/backfill', [RecipeAllergenController::class, 'backfill']);
             });
 
             // Allergens (module: food)

--- a/tests/Feature/AllergenAiIntegrationTest.php
+++ b/tests/Feature/AllergenAiIntegrationTest.php
@@ -1,0 +1,307 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Enums\AllergenPresence;
+use App\Enums\AllergenSource;
+use App\Enums\FamilyRole;
+use App\Jobs\BackfillRecipeAllergens as BackfillJob;
+use App\Models\Allergen;
+use App\Models\Family;
+use App\Models\Recipe;
+use App\Models\RecipeAllergen;
+use App\Models\RecipeIngredient;
+use App\Models\User;
+use App\Services\RecipeImportService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Queue;
+use Illuminate\Support\Str;
+use Laravel\Sanctum\Sanctum;
+use Mockery;
+use Tests\TestCase;
+
+class AllergenAiIntegrationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private Family $family;
+
+    private User $parent;
+
+    private User $child;
+
+    private Allergen $peanuts;
+
+    private Allergen $milk;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->family = Family::create([
+            'name' => 'Test Family',
+            'slug' => 'test-family',
+            'invite_code' => 'TEST01',
+            'settings' => ['modules' => ['food' => true]],
+        ]);
+
+        $this->parent = User::create([
+            'name' => 'Parent',
+            'email' => 'parent@test.com',
+            'password' => bcrypt('password'),
+            'family_id' => $this->family->id,
+            'family_role' => FamilyRole::Parent,
+        ]);
+
+        $this->child = User::create([
+            'name' => 'Child',
+            'email' => 'child@test.com',
+            'password' => bcrypt('password'),
+            'family_id' => $this->family->id,
+            'family_role' => FamilyRole::Child,
+        ]);
+
+        $this->peanuts = Allergen::where('slug', 'peanuts')->whereNull('family_id')->firstOrFail();
+        $this->milk = Allergen::where('slug', 'milk')->whereNull('family_id')->firstOrFail();
+    }
+
+    protected function tearDown(): void
+    {
+        Mockery::close();
+        parent::tearDown();
+    }
+
+    // ── persistAiAllergens (confidence routing + idempotency) ──
+
+    public function test_high_confidence_writes_ai_auto_low_writes_ai_suggested(): void
+    {
+        $recipe = $this->makeRecipe('PB&J');
+        $service = app(RecipeImportService::class);
+
+        $service->persistAiAllergens($recipe, [
+            ['slug' => 'peanuts', 'presence' => 'contains', 'confidence' => 0.99],
+            ['slug' => 'milk', 'presence' => 'may_contain', 'confidence' => 0.6],
+        ]);
+
+        $peanutRow = RecipeAllergen::where('recipe_id', $recipe->id)->where('allergen_id', $this->peanuts->id)->firstOrFail();
+        $milkRow = RecipeAllergen::where('recipe_id', $recipe->id)->where('allergen_id', $this->milk->id)->firstOrFail();
+
+        $this->assertEquals(AllergenSource::AiAuto, $peanutRow->source);
+        $this->assertEquals(0.99, (float) $peanutRow->confidence);
+        $this->assertNull($peanutRow->confirmed_by);
+
+        $this->assertEquals(AllergenSource::AiSuggested, $milkRow->source);
+        $this->assertEquals(AllergenPresence::MayContain, $milkRow->presence);
+    }
+
+    public function test_persist_is_idempotent_and_preserves_existing_human_rows(): void
+    {
+        $recipe = $this->makeRecipe('PB&J');
+        // Existing human-confirmed peanut tag
+        $existing = RecipeAllergen::create([
+            'id' => (string) Str::uuid(),
+            'recipe_id' => $recipe->id,
+            'allergen_id' => $this->peanuts->id,
+            'presence' => 'contains',
+            'source' => AllergenSource::HumanConfirmed->value,
+            'confirmed_by' => $this->parent->id,
+            'confirmed_at' => now(),
+        ]);
+
+        $service = app(RecipeImportService::class);
+        $service->persistAiAllergens($recipe, [
+            ['slug' => 'peanuts', 'presence' => 'contains', 'confidence' => 0.99],
+            ['slug' => 'milk', 'presence' => 'contains', 'confidence' => 0.85],
+        ]);
+
+        // Existing row untouched
+        $existing->refresh();
+        $this->assertEquals(AllergenSource::HumanConfirmed, $existing->source);
+
+        // Milk added as new
+        $this->assertEquals(2, RecipeAllergen::where('recipe_id', $recipe->id)->count());
+    }
+
+    public function test_persist_drops_unknown_slugs_and_bad_confidence(): void
+    {
+        $recipe = $this->makeRecipe('PB&J');
+        $service = app(RecipeImportService::class);
+
+        // Bypassing normalize means we feed garbage directly; the slug→id map
+        // ignores anything not in the family's allergen list.
+        $service->persistAiAllergens($recipe, [
+            ['slug' => 'unobtainium', 'presence' => 'contains', 'confidence' => 0.99],
+            ['slug' => 'peanuts', 'presence' => 'contains', 'confidence' => 0.99],
+        ]);
+
+        $this->assertEquals(1, RecipeAllergen::where('recipe_id', $recipe->id)->count());
+    }
+
+    // ── One-click confirm ──
+
+    public function test_patch_confirms_ai_tag_to_human_confirmed(): void
+    {
+        $recipe = $this->makeRecipe('PB&J');
+        $row = RecipeAllergen::create([
+            'id' => (string) Str::uuid(),
+            'recipe_id' => $recipe->id,
+            'allergen_id' => $this->peanuts->id,
+            'presence' => 'contains',
+            'source' => AllergenSource::AiAuto->value,
+            'confidence' => 0.97,
+        ]);
+
+        Sanctum::actingAs($this->parent);
+
+        $this->patchJson("/api/v1/recipes/{$recipe->id}/allergens/{$row->id}", [])
+            ->assertOk();
+
+        $row->refresh();
+        $this->assertEquals(AllergenSource::HumanConfirmed, $row->source);
+        $this->assertEquals($this->parent->id, $row->confirmed_by);
+        $this->assertNotNull($row->confirmed_at);
+    }
+
+    public function test_recipe_resource_exposes_pivot_id_for_confirm_action(): void
+    {
+        $recipe = $this->makeRecipe('PB&J');
+        $row = RecipeAllergen::create([
+            'id' => (string) Str::uuid(),
+            'recipe_id' => $recipe->id,
+            'allergen_id' => $this->peanuts->id,
+            'presence' => 'contains',
+            'source' => AllergenSource::AiSuggested->value,
+            'confidence' => 0.6,
+        ]);
+
+        Sanctum::actingAs($this->parent);
+
+        $payload = $this->getJson("/api/v1/recipes/{$recipe->id}")
+            ->assertOk()
+            ->json('recipe.allergens');
+
+        $this->assertCount(1, $payload);
+        $this->assertEquals($row->id, $payload[0]['pivot_id']);
+        $this->assertEquals('ai_suggested', $payload[0]['source']);
+    }
+
+    // ── Backfill ──
+
+    public function test_backfill_endpoint_is_parent_only(): void
+    {
+        Sanctum::actingAs($this->child);
+
+        $this->postJson('/api/v1/recipes/allergens/backfill')->assertForbidden();
+    }
+
+    public function test_backfill_endpoint_queues_jobs_only_for_untagged_recipes(): void
+    {
+        Queue::fake();
+
+        $untagged1 = $this->makeRecipe('Untagged 1');
+        $untagged2 = $this->makeRecipe('Untagged 2');
+        $tagged = $this->makeRecipe('Tagged');
+        $tagged->allergens()->attach($this->peanuts->id, [
+            'id' => (string) Str::uuid(),
+            'presence' => 'contains',
+            'source' => AllergenSource::HumanConfirmed->value,
+        ]);
+
+        Sanctum::actingAs($this->parent);
+
+        $response = $this->postJson('/api/v1/recipes/allergens/backfill')->assertOk();
+        $this->assertEquals(2, $response->json('queued'));
+
+        Queue::assertPushed(BackfillJob::class, 2);
+    }
+
+    public function test_backfill_endpoint_with_force_re_tags_everything(): void
+    {
+        Queue::fake();
+
+        $tagged = $this->makeRecipe('Tagged');
+        $tagged->allergens()->attach($this->peanuts->id, [
+            'id' => (string) Str::uuid(),
+            'presence' => 'contains',
+            'source' => AllergenSource::HumanConfirmed->value,
+        ]);
+
+        Sanctum::actingAs($this->parent);
+
+        $response = $this->postJson('/api/v1/recipes/allergens/backfill', ['force' => true])->assertOk();
+        $this->assertEquals(1, $response->json('queued'));
+    }
+
+    public function test_backfill_job_skips_already_tagged_recipe_without_force(): void
+    {
+        $recipe = $this->makeRecipe('PB&J', withIngredients: true);
+        $recipe->allergens()->attach($this->milk->id, [
+            'id' => (string) Str::uuid(),
+            'presence' => 'contains',
+            'source' => AllergenSource::HumanConfirmed->value,
+        ]);
+
+        $service = Mockery::mock(RecipeImportService::class);
+        $service->shouldNotReceive('extractAllergensFromIngredients');
+        $service->shouldNotReceive('persistAiAllergens');
+
+        (new BackfillJob($recipe->id))->handle($service);
+
+        $this->assertEquals(1, RecipeAllergen::where('recipe_id', $recipe->id)->count());
+    }
+
+    public function test_backfill_job_skips_recipes_with_no_ingredients(): void
+    {
+        $recipe = $this->makeRecipe('Empty');
+
+        $service = Mockery::mock(RecipeImportService::class);
+        $service->shouldNotReceive('extractAllergensFromIngredients');
+
+        (new BackfillJob($recipe->id))->handle($service);
+
+        $this->assertEquals(0, RecipeAllergen::where('recipe_id', $recipe->id)->count());
+    }
+
+    public function test_backfill_job_writes_ai_allergens_when_extraction_returns_data(): void
+    {
+        $recipe = $this->makeRecipe('PB&J', withIngredients: true);
+
+        $service = Mockery::mock(RecipeImportService::class)->makePartial();
+        $service->shouldReceive('extractAllergensFromIngredients')
+            ->once()
+            ->andReturn([
+                ['slug' => 'peanuts', 'presence' => 'contains', 'confidence' => 0.97],
+            ]);
+        $service->shouldReceive('persistAiAllergens')
+            ->once()
+            ->andReturnUsing(function ($r, $allergens) {
+                $this->assertEquals('peanuts', $allergens[0]['slug']);
+
+                return 1;
+            });
+
+        (new BackfillJob($recipe->id))->handle($service);
+    }
+
+    private function makeRecipe(string $title, bool $withIngredients = false): Recipe
+    {
+        $recipe = Recipe::create([
+            'family_id' => $this->family->id,
+            'created_by' => $this->parent->id,
+            'title' => $title,
+        ]);
+
+        if ($withIngredients) {
+            RecipeIngredient::create([
+                'id' => (string) Str::uuid(),
+                'recipe_id' => $recipe->id,
+                'name' => 'Peanut butter',
+                'quantity' => '2',
+                'unit' => 'tbsp',
+                'sort_order' => 0,
+            ]);
+        }
+
+        return $recipe;
+    }
+}


### PR DESCRIPTION
## Summary
PR 4 of 4+1 toward v1.10.0. Layers AI on top of the manual allergen system from #314–#316. URL/photo imports now extract allergens with confidence, a queued backfill catches existing recipes, and parents can one-click confirm AI tags into human-confirmed.

## Linked Issues
Closes #317
Part of #312

## What ships

**AI extraction on import:**
- URL + photo prompts built dynamically per family (Big 9 + customs) so the model returns slug-anchored tags.
- New `allergens: [{slug, presence, confidence}]` field in the extraction schema with conservative rules + sneaky-case guidance (wheat in soy sauce, milk in butter, eggs in mayo).
- JSON-LD imports run a secondary `extractAllergensFromIngredients()` pass so coverage is consistent across import methods.

**Confidence routing:**
- `persistAiAllergens()`: ≥ 0.95 → `ai_auto`; else `ai_suggested`. Idempotent on (recipe, allergen, presence). Never overwrites human-confirmed rows.

**Frontend:**
- `RecipeForm` import-preview path now translates AI suggestions to the form's allergen shape — chips land pre-checked.
- `AllergenBadgeRow` gains an `editable` mode. Unconfirmed badges render with an inline `✓` button.
- `RecipeDetailView` enables editable mode for parents; clicking confirms via PATCH → row flips to `human_confirmed` and the badge becomes solid.
- `RecipeResource` exposes `pivot_id` so the frontend can target the pivot row.
- `recipesStore.confirmAllergen()` mutates local state on success so no refetch is needed.

**Backfill:**
- `php artisan recipes:backfill-allergens` with `--family`, `--force`, `--sync` flags.
- `POST /api/v1/recipes/allergens/backfill` — parent-only endpoint queues `BackfillRecipeAllergens` jobs per untagged recipe.
- Job is idempotent: skips already-tagged recipes (unless `--force`), skips empty-ingredient recipes, swallows extraction failures with a warning log (no retry loops eating API budget).

**No-AI fallback:**
- Everything additive. JSON-LD imports work without AI; secondary allergen pass returns `[]` if AI is disabled. Manual tagging from PR2 is unchanged.

## Test Plan
- [x] 11 new tests in `AllergenAiIntegrationTest`: confidence routing (≥0.95 → ai_auto, else ai_suggested), idempotency (preserves human-confirmed rows + skips duplicates), drops unknown slugs, PATCH confirms to human_confirmed with parent stamp + timestamp, `pivot_id` exposed on resource, backfill endpoint parent-only, queues jobs only for untagged recipes (or all with `--force`), job skips already-tagged + empty-ingredient recipes, end-to-end extraction flow with mocked service
- [x] Full suite: 419 tests, 1098 assertions, green
- [x] Pint + PHPStan + ESLint clean
- [x] **Manual verification in preview**: parent → recipe detail with one row manually flipped to `ai_suggested` via SQL → page rendered dashed "unconfirmed" badge with green ✓ button → click → API PATCH → source becomes `human_confirmed` → ✓ disappears, badge becomes solid

## Checklist
- [x] Tested locally + in preview
- [x] Mobile-first verified (badge + confirm button wrap cleanly)
- [x] No credentials committed
- [x] AI cost discipline: backfill is queued + idempotent; secondary JSON-LD pass uses a smaller max_tokens budget
- [x] Defense-in-depth: backfill endpoint parent-only, family-scoped slug list, confirmed_by stamped on PATCH

## Target branch
`feature/allergens-v1.10.0`

## Blocked by
- #314 ✅ merged
- #315 ✅ merged
- #316 ✅ merged

## What's next
After this merges, only PR5 (#311 public recipe sharing) remains before the integration → main PR that bumps to v1.10.0.