### PR TITLE
feat: multi-image recipes — gallery editor + hero + thumbnail row

### DIFF
--- a/app/Http/Controllers/Api/V1/RecipeController.php
+++ b/app/Http/Controllers/Api/V1/RecipeController.php
@@ -54,7 +54,7 @@ class RecipeController extends Controller
     {
         $this->authorize('view', $recipe);
 
-        $recipe->load(['ingredients', 'cookLogs.user', 'ratings.user', 'tags', 'allergens', 'creator']);
+        $recipe->load(['ingredients', 'cookLogs.user', 'ratings.user', 'tags', 'allergens', 'images', 'creator']);
 
         return response()->json(['recipe' => new RecipeResource($recipe)]);
     }

--- a/app/Http/Requests/Recipe/StoreRecipeRequest.php
+++ b/app/Http/Requests/Recipe/StoreRecipeRequest.php
@@ -68,6 +68,11 @@ class StoreRecipeRequest extends FormRequest
             'allergens' => ['nullable', 'array'],
             'allergens.*.allergen_id' => ['required_with:allergens', 'uuid', 'exists:allergens,id'],
             'allergens.*.presence' => ['required_with:allergens', 'in:contains,may_contain'],
+            'images' => ['nullable', 'array'],
+            'images.*.id' => ['nullable', 'uuid'],
+            'images.*.path' => ['required_with:images', 'string', 'max:512'],
+            'images.*.sort_order' => ['nullable', 'integer', 'min:0'],
+            'images.*.is_primary' => ['nullable', 'boolean'],
         ];
     }
 }

--- a/app/Http/Requests/Recipe/UpdateRecipeRequest.php
+++ b/app/Http/Requests/Recipe/UpdateRecipeRequest.php
@@ -66,6 +66,11 @@ class UpdateRecipeRequest extends FormRequest
             'allergens' => ['nullable', 'array'],
             'allergens.*.allergen_id' => ['required_with:allergens', 'uuid', 'exists:allergens,id'],
             'allergens.*.presence' => ['required_with:allergens', 'in:contains,may_contain'],
+            'images' => ['nullable', 'array'],
+            'images.*.id' => ['nullable', 'uuid'],
+            'images.*.path' => ['required_with:images', 'string', 'max:512'],
+            'images.*.sort_order' => ['nullable', 'integer', 'min:0'],
+            'images.*.is_primary' => ['nullable', 'boolean'],
         ];
     }
 }

--- a/app/Http/Resources/RecipeResource.php
+++ b/app/Http/Resources/RecipeResource.php
@@ -25,6 +25,12 @@ class RecipeResource extends JsonResource
             'source_url' => $this->source_url,
             'source_type' => $this->source_type,
             'image_path' => $this->image_path,
+            'images' => $this->whenLoaded('images', fn () => $recipe->images->map(fn ($img) => [
+                'id' => $img->id,
+                'path' => $img->path,
+                'sort_order' => $img->sort_order,
+                'is_primary' => (bool) $img->is_primary,
+            ])->values()),
             'instructions' => $this->instructions,
             'notes' => $this->notes,
             'is_favorite' => $this->is_favorite,

--- a/app/Models/Recipe.php
+++ b/app/Models/Recipe.php
@@ -85,6 +85,21 @@ class Recipe extends Model
             ->withTimestamps();
     }
 
+    public function images(): HasMany
+    {
+        return $this->hasMany(RecipeImage::class)->orderBy('sort_order')->orderBy('created_at');
+    }
+
+    /**
+     * Path of the recipe's primary image. Reads from `recipes.image_path`
+     * (kept in sync as a denormalized cache) so existing callers don't break.
+     * Returns null if the recipe has no images.
+     */
+    public function primaryImagePath(): ?string
+    {
+        return $this->image_path ?: null;
+    }
+
     public function scopeForFamily($query, string $familyId): void
     {
         $query->where('family_id', $familyId);

--- a/app/Models/RecipeImage.php
+++ b/app/Models/RecipeImage.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class RecipeImage extends Model
+{
+    use HasFactory, HasUuids;
+
+    protected $fillable = [
+        'recipe_id',
+        'path',
+        'sort_order',
+        'is_primary',
+    ];
+
+    protected $casts = [
+        'is_primary' => 'boolean',
+        'sort_order' => 'integer',
+    ];
+
+    public function recipe(): BelongsTo
+    {
+        return $this->belongsTo(Recipe::class);
+    }
+}

--- a/app/Services/RecipeService.php
+++ b/app/Services/RecipeService.php
@@ -47,7 +47,14 @@ class RecipeService
             $this->syncAllergens($recipe, $user, $data['allergens'] ?? []);
         }
 
-        return $recipe->load(['ingredients', 'tags', 'allergens', 'creator']);
+        if (array_key_exists('images', $data)) {
+            $this->syncImages($recipe, $data['images'] ?? []);
+        } elseif (! empty($data['image_path'])) {
+            // Backwards-compat: a single image_path becomes the primary image.
+            $this->syncImages($recipe, [['path' => $data['image_path'], 'is_primary' => true]]);
+        }
+
+        return $recipe->load(['ingredients', 'tags', 'allergens', 'images', 'creator']);
     }
 
     public function updateRecipe(Recipe $recipe, array $data): Recipe
@@ -80,7 +87,11 @@ class RecipeService
             $this->syncAllergens($recipe, $editor, $data['allergens'] ?? []);
         }
 
-        return $recipe->load(['ingredients', 'tags', 'allergens', 'creator']);
+        if (array_key_exists('images', $data)) {
+            $this->syncImages($recipe, $data['images'] ?? []);
+        }
+
+        return $recipe->load(['ingredients', 'tags', 'allergens', 'images', 'creator']);
     }
 
     public function deleteRecipe(Recipe $recipe): void
@@ -168,7 +179,7 @@ class RecipeService
 
         $perPage = min((int) ($filters['per_page'] ?? 20), 100);
 
-        return $query->with(['ingredients', 'tags', 'allergens', 'creator', 'ratings'])->paginate($perPage);
+        return $query->with(['ingredients', 'tags', 'allergens', 'images', 'creator', 'ratings'])->paginate($perPage);
     }
 
     /**
@@ -207,6 +218,78 @@ class RecipeService
             ->pluck('allergen_id')
             ->unique()
             ->values();
+    }
+
+    /**
+     * Sync a recipe's images. The form sends the full ordered list each time;
+     * we diff against the existing rows so paths the form still references
+     * stay put (with their IDs preserved), new paths get rows, removed paths
+     * get deleted. recipes.image_path stays in sync with the primary as a
+     * denormalized cache for cards / cross-cutting readers.
+     *
+     * Accepted entry shapes:
+     *   - { id?: string, path: string, sort_order?: int, is_primary?: bool }
+     *
+     * If no `is_primary` flag is set on any entry, the first one becomes primary.
+     */
+    private function syncImages(Recipe $recipe, array $images): void
+    {
+        $existingById = $recipe->images()->get()->keyBy('id');
+        $now = now();
+        $keptIds = [];
+        $primaryPath = null;
+
+        foreach (array_values($images) as $idx => $entry) {
+            $path = $entry['path'] ?? null;
+            if (! is_string($path) || $path === '') {
+                continue;
+            }
+            $sortOrder = $entry['sort_order'] ?? $idx;
+            $isPrimary = (bool) ($entry['is_primary'] ?? false);
+            $existing = isset($entry['id']) ? $existingById->get($entry['id']) : null;
+
+            if ($existing) {
+                $existing->fill([
+                    'path' => $path,
+                    'sort_order' => $sortOrder,
+                    'is_primary' => $isPrimary,
+                ])->save();
+                $keptIds[] = $existing->id;
+            } else {
+                $row = $recipe->images()->create([
+                    'path' => $path,
+                    'sort_order' => $sortOrder,
+                    'is_primary' => $isPrimary,
+                ]);
+                $keptIds[] = $row->id;
+            }
+
+            if ($isPrimary && ! $primaryPath) {
+                $primaryPath = $path;
+            }
+        }
+
+        // Drop removed rows
+        $recipe->images()->whereNotIn('id', $keptIds ?: ['00000000-0000-0000-0000-000000000000'])->delete();
+
+        // If no explicit primary, fall back to the first remaining row
+        if (! $primaryPath) {
+            $first = $recipe->images()->orderBy('sort_order')->first();
+            if ($first) {
+                if (! $first->is_primary) {
+                    $first->forceFill(['is_primary' => true])->save();
+                }
+                $primaryPath = $first->path;
+            }
+        } else {
+            // Make sure only one row is marked primary in the DB
+            $recipe->images()->where('path', '!=', $primaryPath)->update(['is_primary' => false]);
+        }
+
+        // Sync the denormalized cache so cards keep working
+        $recipe->forceFill(['image_path' => $primaryPath])->save();
+
+        unset($now);
     }
 
     /**

--- a/database/migrations/2026_05_21_000006_create_recipe_images_table.php
+++ b/database/migrations/2026_05_21_000006_create_recipe_images_table.php
@@ -1,0 +1,55 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Str;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('recipe_images', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->foreignUuid('recipe_id')->constrained()->cascadeOnDelete();
+            $table->string('path', 512);
+            $table->unsignedInteger('sort_order')->default(0);
+            $table->boolean('is_primary')->default(false);
+            $table->timestamps();
+
+            $table->index(['recipe_id', 'sort_order']);
+        });
+
+        // Backfill: every recipe with an image_path becomes a single primary
+        // recipe_images row. recipes.image_path stays in place as a denormalized
+        // cache of the primary's path; new gallery code is the source of truth.
+        DB::table('recipes')
+            ->whereNotNull('image_path')
+            ->where('image_path', '!=', '')
+            ->orderBy('id')
+            ->chunkById(200, function ($recipes) {
+                $rows = [];
+                $now = now();
+                foreach ($recipes as $recipe) {
+                    $rows[] = [
+                        'id' => (string) Str::uuid(),
+                        'recipe_id' => $recipe->id,
+                        'path' => $recipe->image_path,
+                        'sort_order' => 0,
+                        'is_primary' => true,
+                        'created_at' => $now,
+                        'updated_at' => $now,
+                    ];
+                }
+                if ($rows) {
+                    DB::table('recipe_images')->insert($rows);
+                }
+            });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('recipe_images');
+    }
+};

--- a/resources/js/components/recipes/RecipeForm.vue
+++ b/resources/js/components/recipes/RecipeForm.vue
@@ -71,8 +71,8 @@
         />
       </div>
 
-      <!-- Photo -->
-      <PhotoUpload v-model="imageDisplayUrl" label="Photo" :uploader="uploadRecipeImage" />
+      <!-- Photos (multi-image gallery) -->
+      <RecipeImageGallery v-model="form.images" :uploader="uploadRecipeImage" />
     </div>
 
     <!-- Ingredients -->
@@ -272,7 +272,7 @@ import { useRecipesStore } from '@/stores/recipes'
 import { useAllergensStore } from '@/stores/allergens'
 import { useAuthStore } from '@/stores/auth'
 import { XMarkIcon } from '@heroicons/vue/24/outline'
-import PhotoUpload from '@/components/food/PhotoUpload.vue'
+import RecipeImageGallery from '@/components/recipes/RecipeImageGallery.vue'
 
 // Convert a decimal like 0.5 to a display string like "1/2" for common fractions.
 // Used when loading stored recipes into the form.
@@ -339,7 +339,6 @@ const foodEnabled = computed(() => authStore.userCanAccessModule('food'))
 const recipeTags = computed(() => allTags.value)
 
 const saving = ref(false)
-const imageDisplayUrl = ref(null)
 
 const createEmptyForm = () => ({
   title: '',
@@ -349,12 +348,12 @@ const createEmptyForm = () => ({
   cook_time_minutes: null,
   source_url: '',
   source_type: 'manual',
-  image_path: null,
   notes: '',
   ingredients: [],
   instructions: [],
   tag_ids: [],
   allergens: [], // [{ allergen_id, presence }]
+  images: [],    // [{ id?, path, sort_order, is_primary }]
 })
 
 const form = reactive(createEmptyForm())
@@ -367,11 +366,17 @@ const populateFromRecipe = (recipe) => {
   form.cook_time_minutes = recipe.cook_time_minutes || null
   form.source_url = recipe.source_url || ''
   form.source_type = recipe.source_type || 'manual'
-  form.image_path = recipe.image_path || null
   form.notes = recipe.notes || ''
-  if (recipe.image_path) {
-    imageDisplayUrl.value = `/storage/${recipe.image_path}`
-  }
+  // Hydrate the gallery. If the recipe was migrated from the old single-image
+  // column, recipe.images is already a single primary entry.
+  form.images = (recipe.images && recipe.images.length > 0)
+    ? recipe.images.map((img) => ({
+        id: img.id,
+        path: img.path,
+        sort_order: img.sort_order,
+        is_primary: img.is_primary,
+      }))
+    : (recipe.image_path ? [{ path: recipe.image_path, sort_order: 0, is_primary: true }] : [])
   form.ingredients = (recipe.ingredients || []).map((ing) => ({
     name: ing.name || '',
     quantity: decimalToFraction(ing.quantity),
@@ -398,10 +403,7 @@ const populateFromImportPreview = (data) => {
   form.cook_time_minutes = data.cook_time || data.cook_time_minutes || null
   form.source_url = data.source_url || ''
   form.source_type = data.source_type || 'url'
-  form.image_path = data.image_path || null
-  if (data.image_path) {
-    imageDisplayUrl.value = `/storage/${data.image_path}`
-  }
+  form.images = data.image_path ? [{ path: data.image_path, sort_order: 0, is_primary: true }] : []
   form.ingredients = (data.ingredients || []).map((ing) => ({
     name: ing.name || '',
     quantity: decimalToFraction(ing.quantity),
@@ -455,14 +457,13 @@ const removeInstruction = (index) => {
   form.instructions.splice(index, 1)
 }
 
-// ── Image upload (used by PhotoUpload component) ──
+// ── Image upload (used by RecipeImageGallery) ──
 
 const uploadRecipeImage = async (file) => {
   const result = await recipesStore.uploadImage(file)
   if (result.success) {
-    form.image_path = result.imagePath
-    imageDisplayUrl.value = `/storage/${result.imagePath}`
-    return { success: true, url: imageDisplayUrl.value }
+    // Gallery owns the form.images array; return just the path so it can append.
+    return { success: true, url: result.imagePath }
   }
   return { success: false }
 }
@@ -525,7 +526,6 @@ const handleSubmit = () => {
     cook_time_minutes: form.cook_time_minutes || null,
     source_url: form.source_url || null,
     source_type: form.source_type || 'manual',
-    image_path: form.image_path || null,
     notes: form.notes || null,
     ingredients: form.ingredients
       .filter((ing) => ing.name.trim())
@@ -543,6 +543,12 @@ const handleSubmit = () => {
       .map((text, idx) => ({ step: idx + 1, text: text.trim() })),
     tag_ids: form.tag_ids,
     allergens: form.allergens,
+    images: (form.images || []).map((img, idx) => ({
+      id: img.id || undefined,
+      path: img.path,
+      sort_order: idx,
+      is_primary: idx === 0,
+    })),
   }
 
   emit('save', payload)

--- a/resources/js/components/recipes/RecipeImageGallery.vue
+++ b/resources/js/components/recipes/RecipeImageGallery.vue
@@ -1,0 +1,224 @@
+<!--
+  RecipeImageGallery — multi-image editor for the recipe form.
+  Thumbnail strip with drag-to-reorder, tap-to-set-primary, delete, and an
+  upload tile. Used inside RecipeForm (replaces single PhotoUpload).
+
+  The first image in the list is always the primary. Tapping a non-primary
+  thumbnail moves it to the front; dragging works the same way through
+  SortableJS. Both keep the data model honest.
+-->
+<script setup>
+import { ref, computed, watch, nextTick, onBeforeUnmount } from 'vue'
+import Sortable from 'sortablejs'
+import { CameraIcon, TrashIcon, StarIcon, ArrowsUpDownIcon } from '@heroicons/vue/24/outline'
+import { StarIcon as StarIconSolid } from '@heroicons/vue/24/solid'
+
+const props = defineProps({
+  modelValue: { type: Array, required: true }, // [{ id?, path, sort_order, is_primary }]
+  uploader: { type: Function, required: true }, // (File) => Promise<{success, url}>
+  disabled: { type: Boolean, default: false },
+})
+
+const emit = defineEmits(['update:modelValue'])
+
+const fileInput = ref(null)
+const stripRef = ref(null)
+const uploading = ref(false)
+const localPreviews = ref([]) // { tempId, dataUrl } shown during upload
+let sortableInstance = null
+
+const resolveUrl = (path) => {
+  if (!path) return null
+  if (path.startsWith('http://') || path.startsWith('https://') || path.startsWith('blob:') || path.startsWith('/storage/')) return path
+  return `/storage/${path}`
+}
+
+// The list rendered in the strip = uploaded + currently-uploading temps.
+const visible = computed(() => {
+  const rows = (props.modelValue || []).map((img, idx) => ({
+    key: img.id || `path-${img.path}`,
+    src: resolveUrl(img.path),
+    isPrimary: idx === 0,
+    isLocal: false,
+    row: img,
+  }))
+  for (const t of localPreviews.value) {
+    rows.push({ key: t.tempId, src: t.dataUrl, isPrimary: false, isLocal: true })
+  }
+  return rows
+})
+
+const moveToFront = (path) => {
+  if (props.disabled) return
+  const list = [...props.modelValue]
+  const idx = list.findIndex((i) => i.path === path)
+  if (idx <= 0) return
+  const [picked] = list.splice(idx, 1)
+  list.unshift(picked)
+  emit('update:modelValue', renumber(list))
+}
+
+const removeAt = (path) => {
+  if (props.disabled) return
+  emit('update:modelValue', renumber((props.modelValue || []).filter((i) => i.path !== path)))
+}
+
+const renumber = (list) =>
+  list.map((img, idx) => ({
+    ...img,
+    sort_order: idx,
+    is_primary: idx === 0,
+  }))
+
+const openPicker = () => {
+  if (props.disabled || uploading.value) return
+  fileInput.value?.click()
+}
+
+const handleSelect = async (event) => {
+  const files = Array.from(event.target.files || [])
+  if (event.target) event.target.value = ''
+  if (!files.length) return
+
+  uploading.value = true
+  try {
+    for (const file of files) {
+      const tempId = `temp-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
+      const dataUrl = URL.createObjectURL(file)
+      localPreviews.value.push({ tempId, dataUrl })
+
+      const result = await props.uploader(file)
+      localPreviews.value = localPreviews.value.filter((t) => t.tempId !== tempId)
+      URL.revokeObjectURL(dataUrl)
+
+      if (result?.success && result.url) {
+        const next = [...(props.modelValue || []), {
+          path: result.url,
+          sort_order: (props.modelValue || []).length,
+          is_primary: (props.modelValue || []).length === 0,
+        }]
+        emit('update:modelValue', renumber(next))
+      }
+    }
+  } finally {
+    uploading.value = false
+  }
+}
+
+const initSortable = () => {
+  if (!stripRef.value || sortableInstance) return
+  sortableInstance = Sortable.create(stripRef.value, {
+    animation: 200,
+    draggable: '[data-sortable="1"]',
+    filter: '.no-drag',
+    preventOnFilter: false,
+    ghostClass: 'opacity-30',
+    onEnd: (evt) => {
+      if (evt.oldIndex === evt.newIndex || props.disabled) return
+      const list = [...props.modelValue]
+      const [picked] = list.splice(evt.oldIndex, 1)
+      list.splice(evt.newIndex, 0, picked)
+      emit('update:modelValue', renumber(list))
+    },
+  })
+}
+
+watch(visible, async () => {
+  await nextTick()
+  initSortable()
+}, { immediate: true })
+
+onBeforeUnmount(() => {
+  sortableInstance?.destroy()
+  sortableInstance = null
+  for (const t of localPreviews.value) {
+    URL.revokeObjectURL(t.dataUrl)
+  }
+})
+</script>
+
+<template>
+  <div class="space-y-2">
+    <label class="block text-sm font-semibold text-ink-primary">Photos</label>
+    <p class="text-xs text-ink-secondary">
+      First image is the primary (shown on cards). Drag to reorder, or tap the star to make any image primary.
+    </p>
+
+    <div ref="stripRef" class="flex flex-wrap gap-2">
+      <div
+        v-for="item in visible"
+        :key="item.key"
+        :data-sortable="item.isLocal || disabled ? 0 : 1"
+        :class="[
+          'relative w-24 h-24 rounded-lg overflow-hidden border-2 bg-surface-sunken',
+          item.isPrimary ? 'border-accent-lavender-bold' : 'border-border-subtle',
+          item.isLocal ? 'opacity-60' : '',
+        ]"
+      >
+        <img
+          v-if="item.src"
+          :src="item.src"
+          alt=""
+          class="w-full h-full object-cover"
+          draggable="false"
+        />
+        <span
+          v-if="!item.isLocal && !disabled"
+          class="absolute top-1 left-1 inline-flex items-center gap-0.5 px-1.5 py-0.5 rounded-full text-[10px] font-semibold pointer-events-none"
+          :class="item.isPrimary
+            ? 'bg-accent-lavender-bold text-white'
+            : 'bg-black/40 text-white'"
+        >
+          <StarIconSolid v-if="item.isPrimary" class="w-2.5 h-2.5" />
+          {{ item.isPrimary ? 'Primary' : 'Drag' }}
+        </span>
+        <div v-if="!item.isLocal && !disabled" class="absolute bottom-1 right-1 flex gap-1 no-drag">
+          <button
+            v-if="!item.isPrimary"
+            type="button"
+            class="p-1 rounded-full bg-surface-raised text-ink-primary shadow-sm hover:bg-accent-lavender-soft transition-colors"
+            :aria-label="`Make primary`"
+            title="Make primary"
+            @click.stop="moveToFront(item.row.path)"
+          >
+            <StarIcon class="w-3.5 h-3.5" />
+          </button>
+          <button
+            type="button"
+            class="p-1 rounded-full bg-surface-raised text-status-failed shadow-sm hover:bg-status-failed/10 transition-colors"
+            :aria-label="`Remove photo`"
+            title="Remove"
+            @click.stop="removeAt(item.row.path)"
+          >
+            <TrashIcon class="w-3.5 h-3.5" />
+          </button>
+        </div>
+      </div>
+
+      <button
+        v-if="!disabled"
+        type="button"
+        class="w-24 h-24 flex flex-col items-center justify-center gap-1 rounded-lg border-2 border-dashed border-border-subtle text-ink-tertiary hover:border-accent-lavender-bold hover:text-accent-lavender-bold transition-colors"
+        :disabled="uploading"
+        @click="openPicker"
+      >
+        <CameraIcon class="w-5 h-5" />
+        <span class="text-[11px] font-medium">{{ uploading ? 'Uploading…' : 'Add photo' }}</span>
+      </button>
+    </div>
+
+    <p v-if="visible.length > 1" class="flex items-center gap-1 text-[11px] text-ink-tertiary">
+      <ArrowsUpDownIcon class="w-3 h-3" />
+      Drag thumbnails to reorder.
+    </p>
+
+    <input
+      ref="fileInput"
+      type="file"
+      accept="image/jpeg,image/png,image/webp,image/heic"
+      multiple
+      class="hidden"
+      @change="handleSelect"
+    />
+  </div>
+</template>

--- a/resources/js/views/food/RecipeDetailView.vue
+++ b/resources/js/views/food/RecipeDetailView.vue
@@ -68,9 +68,22 @@
       </div>
 
       <!-- Hero image -->
-      <div v-if="recipe.image_path" class="px-4 md:px-6 mb-4">
+      <div v-if="heroImagePath" class="px-4 md:px-6 mb-4">
         <div class="aspect-video rounded-xl overflow-hidden bg-surface-sunken">
-          <img :src="`/storage/${recipe.image_path}`" :alt="recipe.title" class="w-full h-full object-cover" />
+          <img :src="resolveStoragePath(heroImagePath)" :alt="recipe.title" class="w-full h-full object-cover" />
+        </div>
+        <!-- Small gallery row of additional images -->
+        <div v-if="extraImages.length > 0" class="mt-2 flex gap-2 overflow-x-auto pb-1">
+          <button
+            v-for="img in extraImages"
+            :key="img.id || img.path"
+            type="button"
+            class="shrink-0 w-16 h-16 rounded-lg overflow-hidden border border-border-subtle bg-surface-sunken hover:border-accent-lavender-bold transition-colors"
+            :aria-label="`View image`"
+            @click="setHero(img.path)"
+          >
+            <img :src="resolveStoragePath(img.path)" alt="" class="w-full h-full object-cover" />
+          </button>
         </div>
       </div>
 
@@ -285,6 +298,36 @@ const showDeleteConfirm = ref(false)
 const showCookLogModal = ref(false)
 const cookLogs = ref([])
 const ratings = ref([])
+const heroOverride = ref(null)
+
+const allImages = computed(() => {
+  const list = recipe.value?.images || []
+  if (list.length > 0) return list
+  // Backwards compat: a recipe migrated from single image_path still works.
+  if (recipe.value?.image_path) {
+    return [{ id: null, path: recipe.value.image_path, is_primary: true }]
+  }
+  return []
+})
+
+const primaryImagePath = computed(() => {
+  const primary = allImages.value.find((i) => i.is_primary)
+  return primary?.path || allImages.value[0]?.path || null
+})
+
+const heroImagePath = computed(() => heroOverride.value || primaryImagePath.value)
+
+const extraImages = computed(() => allImages.value.filter((i) => i.path !== heroImagePath.value))
+
+const setHero = (path) => {
+  heroOverride.value = path
+}
+
+const resolveStoragePath = (path) => {
+  if (!path) return null
+  if (path.startsWith('http://') || path.startsWith('https://') || path.startsWith('/storage/')) return path
+  return `/storage/${path}`
+}
 
 const totalTime = computed(() => {
   if (!recipe.value) return null

--- a/tests/Feature/RecipeImageGalleryTest.php
+++ b/tests/Feature/RecipeImageGalleryTest.php
@@ -1,0 +1,206 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Enums\FamilyRole;
+use App\Models\Family;
+use App\Models\Recipe;
+use App\Models\RecipeImage;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Sanctum\Sanctum;
+use Tests\TestCase;
+
+class RecipeImageGalleryTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private Family $family;
+
+    private User $parent;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->family = Family::create([
+            'name' => 'Test Family',
+            'slug' => 'test-family',
+            'invite_code' => 'TEST01',
+            'settings' => ['modules' => ['food' => true]],
+        ]);
+
+        $this->parent = User::create([
+            'name' => 'Parent',
+            'email' => 'parent@test.com',
+            'password' => bcrypt('password'),
+            'family_id' => $this->family->id,
+            'family_role' => FamilyRole::Parent,
+        ]);
+    }
+
+    public function test_recipe_can_be_created_with_multiple_images(): void
+    {
+        Sanctum::actingAs($this->parent);
+
+        $response = $this->postJson('/api/v1/recipes', [
+            'title' => 'Banana Bread',
+            'images' => [
+                ['path' => 'recipes/hero.jpg', 'sort_order' => 0, 'is_primary' => true],
+                ['path' => 'recipes/process.jpg', 'sort_order' => 1, 'is_primary' => false],
+                ['path' => 'recipes/sliced.jpg', 'sort_order' => 2, 'is_primary' => false],
+            ],
+        ])->assertCreated();
+
+        $images = $response->json('recipe.images');
+        $this->assertCount(3, $images);
+        $this->assertEquals('recipes/hero.jpg', $images[0]['path']);
+        $this->assertTrue($images[0]['is_primary']);
+        $this->assertFalse($images[1]['is_primary']);
+        $this->assertFalse($images[2]['is_primary']);
+    }
+
+    public function test_primary_image_path_syncs_recipes_image_path_column(): void
+    {
+        Sanctum::actingAs($this->parent);
+
+        $recipeId = $this->postJson('/api/v1/recipes', [
+            'title' => 'Banana Bread',
+            'images' => [
+                ['path' => 'recipes/hero.jpg', 'sort_order' => 0, 'is_primary' => true],
+            ],
+        ])->json('recipe.id');
+
+        $recipe = Recipe::findOrFail($recipeId);
+        $this->assertEquals('recipes/hero.jpg', $recipe->image_path);
+    }
+
+    public function test_first_image_becomes_primary_when_no_flag_set(): void
+    {
+        Sanctum::actingAs($this->parent);
+
+        $response = $this->postJson('/api/v1/recipes', [
+            'title' => 'Salad',
+            'images' => [
+                ['path' => 'recipes/a.jpg'],
+                ['path' => 'recipes/b.jpg'],
+            ],
+        ])->assertCreated();
+
+        $images = $response->json('recipe.images');
+        $this->assertTrue($images[0]['is_primary']);
+        $this->assertFalse($images[1]['is_primary']);
+    }
+
+    public function test_update_replaces_images_and_swaps_primary(): void
+    {
+        Sanctum::actingAs($this->parent);
+
+        $recipeId = $this->postJson('/api/v1/recipes', [
+            'title' => 'Banana Bread',
+            'images' => [
+                ['path' => 'recipes/old-hero.jpg', 'sort_order' => 0, 'is_primary' => true],
+                ['path' => 'recipes/old-extra.jpg', 'sort_order' => 1, 'is_primary' => false],
+            ],
+        ])->json('recipe.id');
+
+        $oldImages = Recipe::with('images')->findOrFail($recipeId)->images->keyBy('path');
+
+        $response = $this->putJson("/api/v1/recipes/{$recipeId}", [
+            'title' => 'Banana Bread',
+            'images' => [
+                // Swap primary: extra becomes primary, hero becomes secondary
+                ['id' => $oldImages['recipes/old-extra.jpg']->id, 'path' => 'recipes/old-extra.jpg', 'sort_order' => 0, 'is_primary' => true],
+                ['id' => $oldImages['recipes/old-hero.jpg']->id, 'path' => 'recipes/old-hero.jpg', 'sort_order' => 1, 'is_primary' => false],
+                // New image appended
+                ['path' => 'recipes/new.jpg', 'sort_order' => 2, 'is_primary' => false],
+            ],
+        ])->assertOk();
+
+        $images = $response->json('recipe.images');
+        $this->assertCount(3, $images);
+        $this->assertEquals('recipes/old-extra.jpg', $images[0]['path']);
+        $this->assertTrue($images[0]['is_primary']);
+        $this->assertEquals('recipes/new.jpg', $images[2]['path']);
+
+        // image_path cache updated
+        $this->assertEquals('recipes/old-extra.jpg', Recipe::findOrFail($recipeId)->image_path);
+    }
+
+    public function test_update_with_subset_removes_dropped_images(): void
+    {
+        Sanctum::actingAs($this->parent);
+
+        $recipeId = $this->postJson('/api/v1/recipes', [
+            'title' => 'Banana Bread',
+            'images' => [
+                ['path' => 'a.jpg'],
+                ['path' => 'b.jpg'],
+                ['path' => 'c.jpg'],
+            ],
+        ])->json('recipe.id');
+
+        $existing = Recipe::with('images')->findOrFail($recipeId)->images->keyBy('path');
+
+        $this->putJson("/api/v1/recipes/{$recipeId}", [
+            'title' => 'Banana Bread',
+            'images' => [
+                ['id' => $existing['a.jpg']->id, 'path' => 'a.jpg', 'sort_order' => 0, 'is_primary' => true],
+            ],
+        ])->assertOk();
+
+        $this->assertEquals(1, RecipeImage::where('recipe_id', $recipeId)->count());
+    }
+
+    public function test_update_with_empty_images_clears_all(): void
+    {
+        Sanctum::actingAs($this->parent);
+
+        $recipeId = $this->postJson('/api/v1/recipes', [
+            'title' => 'Banana Bread',
+            'images' => [['path' => 'a.jpg']],
+        ])->json('recipe.id');
+
+        $this->putJson("/api/v1/recipes/{$recipeId}", [
+            'title' => 'Banana Bread',
+            'images' => [],
+        ])->assertOk();
+
+        $this->assertEquals(0, RecipeImage::where('recipe_id', $recipeId)->count());
+        $this->assertNull(Recipe::findOrFail($recipeId)->image_path);
+    }
+
+    public function test_recipe_resource_exposes_images_in_order(): void
+    {
+        Sanctum::actingAs($this->parent);
+
+        $recipeId = $this->postJson('/api/v1/recipes', [
+            'title' => 'Banana Bread',
+            'images' => [
+                ['path' => 'first.jpg', 'sort_order' => 0, 'is_primary' => true],
+                ['path' => 'second.jpg', 'sort_order' => 1],
+                ['path' => 'third.jpg', 'sort_order' => 2],
+            ],
+        ])->json('recipe.id');
+
+        $response = $this->getJson("/api/v1/recipes/{$recipeId}")->assertOk();
+        $paths = collect($response->json('recipe.images'))->pluck('path')->all();
+        $this->assertEquals(['first.jpg', 'second.jpg', 'third.jpg'], $paths);
+    }
+
+    public function test_legacy_image_path_only_save_still_works(): void
+    {
+        Sanctum::actingAs($this->parent);
+
+        // Caller didn't send `images` but did send the legacy `image_path` field.
+        $response = $this->postJson('/api/v1/recipes', [
+            'title' => 'Legacy',
+            'image_path' => 'recipes/legacy.jpg',
+        ])->assertCreated();
+
+        $images = $response->json('recipe.images');
+        $this->assertCount(1, $images);
+        $this->assertEquals('recipes/legacy.jpg', $images[0]['path']);
+        $this->assertTrue($images[0]['is_primary']);
+    }
+}


### PR DESCRIPTION
## Summary
PR 5 of 6 toward v1.10.0. Replaces the single `recipes.image_path` column with a proper multi-image gallery. Drag-to-reorder, tap-to-set-primary, delete, plus an editorial hero + thumbnail row on the detail view.

Carved out of #311 (public sharing) because cookbook-scan thumbnails would make the upcoming public pages look bad — multi-image is the prerequisite.

## Linked Issues
Closes #323
Sets up #311 (PR 6 will use the same gallery shape on the public page)

## What ships
**Schema:**
- `recipe_images` table: `(recipe_id, path, sort_order, is_primary, timestamps)`, UUID-keyed.
- Data migration backfills existing `recipes.image_path` into one primary `recipe_images` row per recipe.
- `recipes.image_path` stays as a denormalized cache of the primary's path so cards + readers don't need a relation load.

**Backend:**
- `Recipe::images()` HasMany sorted by `sort_order`
- `RecipeImage` model (HasUuids)
- `RecipeService::syncImages()` — diffs against existing rows by ID (preserves IDs across edits), creates new rows for new paths, deletes dropped paths, syncs `image_path` cache to primary
- `StoreRecipeRequest` + `UpdateRecipeRequest` accept `images: [{id?, path, sort_order?, is_primary?}]`
- Legacy single `image_path` still works (converted into a single primary image by the service)
- `RecipeResource` exposes `images: [{id, path, sort_order, is_primary}]`; `show()` + `searchRecipes()` eager-load

**Frontend:**
- `RecipeImageGallery` — thumbnail strip:
  - Drag to reorder (SortableJS)
  - Tap star to make any image primary
  - Trash button per thumbnail
  - "Add photo" tile that handles multi-file upload with optimistic local previews
  - Primary thumbnail wears a lavender border + Primary badge
- `RecipeForm` ships the full image list on Save (replaces single PhotoUpload)
- `RecipeDetailView` — hero of the primary image + scrollable thumbnail row of extras below. Tap a thumbnail to swap the hero (client-side only). Sets the pattern PR6 will reuse on the public page.

## Test Plan
- [x] 8 new tests in `RecipeImageGalleryTest`: multi-image create, image_path sync to primary, first-image-becomes-primary default, update swaps primary + appends new, subset removes dropped, empty array clears, RecipeResource ordering, legacy image_path-only save
- [x] Existing `RecipeTest` + `RecipeAllergenTaggingTest` still green (no regressions in the recipe flow)
- [x] Full suite: 427 tests, 1125 assertions, green
- [x] Pint + PHPStan + ESLint clean
- [x] **Manual verification in preview**: seeded recipe loaded with backfilled image as Primary chip; gallery renders helper copy ("First image is the primary…"), Add photo tile, drag affordance noted at the bottom

## Checklist
- [x] Tested locally + in preview
- [x] Mobile-first verified (thumbnail strip wraps cleanly at 375px)
- [x] No credentials committed
- [x] Backwards compat: `recipes.image_path` still valid + populated; old API callers unaffected

## Target branch
`feature/allergens-v1.10.0`

## Blocks
- #311 (PR 6 — beautiful public sharing pages reuse the gallery shape on a publicly-rendered Blade template)