### PR TITLE
feat: public recipe sharing — token URLs + beautiful Blade page

### DIFF
--- a/app/Http/Controllers/Api/V1/RecipeShareController.php
+++ b/app/Http/Controllers/Api/V1/RecipeShareController.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace App\Http\Controllers\Api\V1;
+
+use App\Http\Controllers\Controller;
+use App\Models\Recipe;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Str;
+
+class RecipeShareController extends Controller
+{
+    /**
+     * Publish a recipe to a public URL. Idempotent: re-calling on an already-
+     * shared recipe returns the existing URL. Parent-only.
+     */
+    public function store(Request $request, Recipe $recipe): JsonResponse
+    {
+        $this->authorize('update', $recipe);
+
+        if (! $recipe->share_token) {
+            $recipe->forceFill([
+                'share_token' => $this->generateUniqueToken(),
+            ])->save();
+        }
+
+        if ($request->has('visible_attribution')) {
+            $recipe->forceFill([
+                'share_visible_attribution' => (bool) $request->boolean('visible_attribution'),
+            ])->save();
+        }
+
+        return response()->json([
+            'share' => [
+                'is_shared' => true,
+                'url' => $recipe->shareUrl(),
+                'visible_attribution' => (bool) $recipe->share_visible_attribution,
+            ],
+        ], 201);
+    }
+
+    /**
+     * Toggle attribution on an existing share without rotating the token.
+     */
+    public function update(Request $request, Recipe $recipe): JsonResponse
+    {
+        $this->authorize('update', $recipe);
+
+        if (! $recipe->isShared()) {
+            return response()->json(['message' => 'Recipe is not shared yet.'], 422);
+        }
+
+        $request->validate([
+            'visible_attribution' => ['required', 'boolean'],
+        ]);
+
+        $recipe->forceFill([
+            'share_visible_attribution' => (bool) $request->boolean('visible_attribution'),
+        ])->save();
+
+        return response()->json([
+            'share' => [
+                'is_shared' => true,
+                'url' => $recipe->shareUrl(),
+                'visible_attribution' => (bool) $recipe->share_visible_attribution,
+            ],
+        ]);
+    }
+
+    /**
+     * Revoke a share. Clears the token so the old public URL hard-404s.
+     * Re-sharing later mints a new token (intentional — old links should die
+     * permanently on revoke).
+     */
+    public function destroy(Recipe $recipe): JsonResponse
+    {
+        $this->authorize('update', $recipe);
+
+        $recipe->forceFill([
+            'share_token' => null,
+            'share_visible_attribution' => false,
+        ])->save();
+
+        return response()->json([
+            'share' => [
+                'is_shared' => false,
+                'url' => null,
+                'visible_attribution' => false,
+            ],
+        ]);
+    }
+
+    /**
+     * 22-char base62 (~131 bits of entropy). Loops on the off-chance of
+     * collision so the unique constraint stays a backstop, not a hot path.
+     */
+    private function generateUniqueToken(): string
+    {
+        do {
+            $token = Str::random(22);
+        } while (Recipe::where('share_token', $token)->exists());
+
+        return $token;
+    }
+}

--- a/app/Http/Controllers/Public/PublicRecipeController.php
+++ b/app/Http/Controllers/Public/PublicRecipeController.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace App\Http\Controllers\Public;
+
+use App\Http\Controllers\Controller;
+use App\Models\Recipe;
+use App\Models\RecipeAllergen;
+use Illuminate\Contracts\View\View;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+class PublicRecipeController extends Controller
+{
+    /**
+     * Render a publicly-shared recipe. No auth required — the token alone is
+     * the access grant. Hard 404 if the token doesn't match a current share
+     * (covers both never-shared and revoked-share cases).
+     */
+    public function show(string $token): View
+    {
+        $recipe = Recipe::with([
+            'images',
+            'ingredients',
+            'allergens',
+            'family',
+            'creator',
+        ])
+            ->where('share_token', $token)
+            ->first();
+
+        if (! $recipe) {
+            throw new NotFoundHttpException;
+        }
+
+        return view('public.recipe', [
+            'recipe' => $recipe,
+            'attribution' => $this->resolveAttribution($recipe),
+            'allergens' => $this->mapAllergens($recipe),
+            'images' => $this->mapImages($recipe),
+        ]);
+    }
+
+    private function resolveAttribution(Recipe $recipe): array
+    {
+        if ($recipe->share_visible_attribution && $recipe->family) {
+            return [
+                'visible' => true,
+                'family_name' => $recipe->family->name,
+            ];
+        }
+
+        return [
+            'visible' => false,
+            'family_name' => null,
+        ];
+    }
+
+    /**
+     * Normalize allergens into a flat shape the Blade view can render without
+     * touching Eloquent relations.
+     *
+     * @return array<int, array{name: string, slug: string, presence: string, source: string}>
+     */
+    private function mapAllergens(Recipe $recipe): array
+    {
+        return $recipe->allergens->map(function ($a) {
+            /** @var RecipeAllergen $pivot */
+            $pivot = $a->getRelationValue('pivot');
+
+            return [
+                'name' => $a->name,
+                'slug' => $a->slug,
+                'presence' => $pivot->presence->value,
+                'source' => $pivot->source->value,
+            ];
+        })->all();
+    }
+
+    /**
+     * @return array{primary: ?array{path: string, url: string}, extras: array<int, array{path: string, url: string}>}
+     */
+    private function mapImages(Recipe $recipe): array
+    {
+        $list = $recipe->images->map(fn ($img) => [
+            'path' => $img->path,
+            'url' => $this->resolveUrl($img->path),
+            'is_primary' => (bool) $img->is_primary,
+        ]);
+
+        $primary = $list->firstWhere('is_primary', true) ?: $list->first();
+        $extras = $list->reject(fn ($i) => $primary && $i['path'] === $primary['path'])->values()->all();
+
+        return [
+            'primary' => $primary ? ['path' => $primary['path'], 'url' => $primary['url']] : null,
+            'extras' => array_map(fn ($i) => ['path' => $i['path'], 'url' => $i['url']], $extras),
+        ];
+    }
+
+    private function resolveUrl(string $path): string
+    {
+        if (str_starts_with($path, 'http://') || str_starts_with($path, 'https://') || str_starts_with($path, '/storage/')) {
+            return $path;
+        }
+
+        return '/storage/'.ltrim($path, '/');
+    }
+}

--- a/app/Http/Resources/RecipeResource.php
+++ b/app/Http/Resources/RecipeResource.php
@@ -25,6 +25,11 @@ class RecipeResource extends JsonResource
             'source_url' => $this->source_url,
             'source_type' => $this->source_type,
             'image_path' => $this->image_path,
+            'share' => [
+                'is_shared' => $recipe->isShared(),
+                'url' => $recipe->shareUrl(),
+                'visible_attribution' => (bool) $recipe->share_visible_attribution,
+            ],
             'images' => $this->whenLoaded('images', fn () => $recipe->images->map(fn ($img) => [
                 'id' => $img->id,
                 'path' => $img->path,

--- a/app/Models/Recipe.php
+++ b/app/Models/Recipe.php
@@ -32,6 +32,8 @@ class Recipe extends Model
         'notes',
         'is_favorite',
         'sort_order',
+        'share_token',
+        'share_visible_attribution',
     ];
 
     protected $casts = [
@@ -43,7 +45,18 @@ class Recipe extends Model
         'cook_time_minutes' => 'integer',
         'total_time_minutes' => 'integer',
         'sort_order' => 'integer',
+        'share_visible_attribution' => 'boolean',
     ];
+
+    public function isShared(): bool
+    {
+        return ! empty($this->share_token);
+    }
+
+    public function shareUrl(): ?string
+    {
+        return $this->isShared() ? url('/r/'.$this->share_token) : null;
+    }
 
     public function family(): BelongsTo
     {

--- a/database/migrations/2026_05_21_000007_add_share_columns_to_recipes_table.php
+++ b/database/migrations/2026_05_21_000007_add_share_columns_to_recipes_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('recipes', function (Blueprint $table) {
+            // Unguessable token. Nullable: null = not shared. Unique so revocation
+            // (set to null) frees the slot for a future share.
+            $table->string('share_token', 32)->nullable()->unique();
+            // Off by default: public page reads "Shared via Kinhold" unless owner
+            // opts in to surface the family name.
+            $table->boolean('share_visible_attribution')->default(false);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('recipes', function (Blueprint $table) {
+            $table->dropColumn(['share_token', 'share_visible_attribution']);
+        });
+    }
+};

--- a/resources/js/components/recipes/ShareRecipeModal.vue
+++ b/resources/js/components/recipes/ShareRecipeModal.vue
@@ -1,0 +1,170 @@
+<!--
+  ShareRecipeModal — parent-only sheet for publishing a recipe to a public URL.
+  Generates an unguessable token, shows the share URL with a copy button, and
+  exposes the attribution toggle (anonymous by default, opt-in to show family
+  name). Revoking clears the token; the old URL hard-404s after that.
+-->
+<script setup>
+import { ref, computed, watch } from 'vue'
+import KinModalSheet from '@/components/design-system/KinModalSheet.vue'
+import KinButton from '@/components/design-system/KinButton.vue'
+import KinSwitch from '@/components/design-system/KinSwitch.vue'
+import { ShareIcon, ClipboardDocumentIcon, CheckIcon, ExclamationCircleIcon } from '@heroicons/vue/24/outline'
+import api from '@/services/api'
+import { useNotification } from '@/composables/useNotification'
+
+const props = defineProps({
+  show: { type: Boolean, required: true },
+  recipe: { type: Object, required: true },
+})
+
+const emit = defineEmits(['close', 'updated'])
+
+const { success: notifySuccess, error: notifyError } = useNotification()
+
+const working = ref(false)
+const copied = ref(false)
+const local = ref({
+  is_shared: false,
+  url: null,
+  visible_attribution: false,
+})
+
+watch(() => props.recipe?.share, (s) => {
+  if (s) {
+    local.value = { ...s }
+    copied.value = false
+  }
+}, { immediate: true })
+
+const isShared = computed(() => local.value.is_shared)
+
+const publish = async () => {
+  working.value = true
+  try {
+    const response = await api.post(`/recipes/${props.recipe.id}/share`)
+    local.value = response.data.share
+    emit('updated', response.data.share)
+    notifySuccess('Recipe shared. Copy the link to send it anywhere.')
+  } catch (err) {
+    notifyError(err.response?.data?.message || 'Failed to publish recipe')
+  } finally {
+    working.value = false
+  }
+}
+
+const setAttribution = async (visible) => {
+  working.value = true
+  try {
+    const response = await api.patch(`/recipes/${props.recipe.id}/share`, {
+      visible_attribution: visible,
+    })
+    local.value = response.data.share
+    emit('updated', response.data.share)
+  } catch (err) {
+    notifyError(err.response?.data?.message || 'Failed to update share settings')
+  } finally {
+    working.value = false
+  }
+}
+
+const revoke = async () => {
+  if (!confirm('Revoke this share? The public link will stop working immediately and re-sharing will create a brand new link.')) return
+  working.value = true
+  try {
+    const response = await api.delete(`/recipes/${props.recipe.id}/share`)
+    local.value = response.data.share
+    emit('updated', response.data.share)
+    notifySuccess('Recipe unshared. The old link no longer works.')
+  } catch (err) {
+    notifyError(err.response?.data?.message || 'Failed to revoke share')
+  } finally {
+    working.value = false
+  }
+}
+
+const copyLink = async () => {
+  if (!local.value.url) return
+  try {
+    await navigator.clipboard.writeText(local.value.url)
+    copied.value = true
+    setTimeout(() => { copied.value = false }, 2000)
+  } catch {
+    notifyError('Copy failed. Long-press the link to copy manually.')
+  }
+}
+</script>
+
+<template>
+  <KinModalSheet :model-value="show" title="Share this recipe" @update:model-value="(v) => !v && emit('close')">
+    <div class="space-y-5">
+      <!-- Header copy -->
+      <div class="flex items-start gap-3">
+        <div class="shrink-0 w-10 h-10 rounded-full bg-accent-lavender-soft flex items-center justify-center">
+          <ShareIcon class="w-5 h-5 text-accent-lavender-bold" />
+        </div>
+        <div class="text-sm text-ink-secondary">
+          Publish a public link anyone can open — no account needed. Allergen badges and the source link travel with it.
+        </div>
+      </div>
+
+      <!-- Not yet shared: single CTA -->
+      <div v-if="!isShared" class="space-y-3">
+        <KinButton variant="primary" class="w-full" :loading="working" @click="publish">
+          Publish public link
+        </KinButton>
+      </div>
+
+      <!-- Shared: URL + copy + attribution + revoke -->
+      <div v-else class="space-y-4">
+        <div>
+          <p class="text-xs font-semibold uppercase tracking-wide text-ink-tertiary mb-1.5">Public URL</p>
+          <div class="flex items-stretch gap-2">
+            <input
+              :value="local.url"
+              readonly
+              class="flex-1 min-w-0 px-3 py-2 text-sm font-mono rounded-lg bg-surface-sunken border border-border-subtle text-ink-secondary truncate"
+              @focus="$event.target.select()"
+            />
+            <button
+              type="button"
+              class="px-3 py-2 rounded-lg bg-accent-lavender-bold text-white text-sm font-semibold hover:bg-accent-lavender-bold/90 transition-colors inline-flex items-center gap-1.5"
+              :aria-label="copied ? 'Copied' : 'Copy link'"
+              @click="copyLink"
+            >
+              <CheckIcon v-if="copied" class="w-4 h-4" />
+              <ClipboardDocumentIcon v-else class="w-4 h-4" />
+              {{ copied ? 'Copied' : 'Copy' }}
+            </button>
+          </div>
+        </div>
+
+        <div class="flex items-start justify-between gap-3 p-3 rounded-lg bg-surface-sunken">
+          <div class="flex-1">
+            <p class="text-sm font-medium text-ink-primary">Show family name</p>
+            <p class="text-xs text-ink-secondary mt-0.5">
+              Off by default. When on, the public page reads "Shared by {{ recipe.family_name || 'your family' }}" instead of "Shared via Kinhold."
+            </p>
+          </div>
+          <KinSwitch
+            :model-value="local.visible_attribution"
+            :disabled="working"
+            @update:model-value="setAttribution"
+          />
+        </div>
+
+        <div class="pt-2 border-t border-border-subtle">
+          <button
+            type="button"
+            class="inline-flex items-center gap-1.5 text-sm text-status-failed hover:underline"
+            :disabled="working"
+            @click="revoke"
+          >
+            <ExclamationCircleIcon class="w-4 h-4" />
+            Revoke this share
+          </button>
+        </div>
+      </div>
+    </div>
+  </KinModalSheet>
+</template>

--- a/resources/js/components/recipes/ShareRecipeModal.vue
+++ b/resources/js/components/recipes/ShareRecipeModal.vue
@@ -9,7 +9,7 @@ import { ref, computed, watch } from 'vue'
 import KinModalSheet from '@/components/design-system/KinModalSheet.vue'
 import KinButton from '@/components/design-system/KinButton.vue'
 import KinSwitch from '@/components/design-system/KinSwitch.vue'
-import { ShareIcon, ClipboardDocumentIcon, CheckIcon, ExclamationCircleIcon } from '@heroicons/vue/24/outline'
+import { ShareIcon, ClipboardDocumentIcon, CheckIcon, ExclamationCircleIcon, ArrowTopRightOnSquareIcon } from '@heroicons/vue/24/outline'
 import api from '@/services/api'
 import { useNotification } from '@/composables/useNotification'
 
@@ -83,15 +83,48 @@ const revoke = async () => {
   }
 }
 
+const urlInput = ref(null)
+
 const copyLink = async () => {
   if (!local.value.url) return
-  try {
-    await navigator.clipboard.writeText(local.value.url)
-    copied.value = true
-    setTimeout(() => { copied.value = false }, 2000)
-  } catch {
-    notifyError('Copy failed. Long-press the link to copy manually.')
+  const text = local.value.url
+
+  // Modern path. Rejects in sandboxed iframes / unfocused docs / strict permissions.
+  if (navigator.clipboard?.writeText) {
+    try {
+      await navigator.clipboard.writeText(text)
+      copied.value = true
+      setTimeout(() => { copied.value = false }, 2000)
+      return
+    } catch {
+      // fall through to legacy path
+    }
   }
+
+  // Legacy fallback — select the readonly input and execCommand.
+  try {
+    const el = urlInput.value
+    if (el && typeof el.select === 'function') {
+      el.focus()
+      el.select()
+      el.setSelectionRange(0, text.length)
+    }
+    const ok = document.execCommand && document.execCommand('copy')
+    if (ok) {
+      copied.value = true
+      setTimeout(() => { copied.value = false }, 2000)
+      return
+    }
+  } catch {
+    // fall through
+  }
+
+  notifyError('Copy failed. Tap the link, select all, then copy manually.')
+}
+
+const previewLink = () => {
+  if (!local.value.url) return
+  window.open(local.value.url, '_blank', 'noopener,noreferrer')
 }
 </script>
 
@@ -121,9 +154,10 @@ const copyLink = async () => {
           <p class="text-xs font-semibold uppercase tracking-wide text-ink-tertiary mb-1.5">Public URL</p>
           <div class="flex items-stretch gap-2">
             <input
+              ref="urlInput"
               :value="local.url"
               readonly
-              class="flex-1 min-w-0 px-3 py-2 text-sm font-mono rounded-lg bg-surface-sunken border border-border-subtle text-ink-secondary truncate"
+              class="flex-1 min-w-0 px-3 py-2 text-sm font-mono rounded-lg bg-surface-sunken border border-border-subtle text-ink-secondary truncate focus:outline-none focus:border-accent-lavender-bold/40 focus:ring-2 focus:ring-accent-lavender-bold/20"
               @focus="$event.target.select()"
             />
             <button
@@ -137,6 +171,14 @@ const copyLink = async () => {
               {{ copied ? 'Copied' : 'Copy' }}
             </button>
           </div>
+          <button
+            type="button"
+            class="mt-2 inline-flex items-center gap-1.5 text-xs font-medium text-ink-secondary hover:text-accent-lavender-bold transition-colors"
+            @click="previewLink"
+          >
+            <ArrowTopRightOnSquareIcon class="w-3.5 h-3.5" />
+            Preview what your family will see
+          </button>
         </div>
 
         <div class="flex items-start justify-between gap-3 p-3 rounded-lg bg-surface-sunken">

--- a/resources/js/views/food/RecipeDetailView.vue
+++ b/resources/js/views/food/RecipeDetailView.vue
@@ -49,6 +49,16 @@
             variant="ghost"
             size="sm"
             icon-only
+            aria-label="Share recipe"
+            @click="showShareModal = true"
+          >
+            <ShareIcon class="w-5 h-5" />
+          </KinButton>
+          <KinButton
+            v-if="isParent"
+            variant="ghost"
+            size="sm"
+            icon-only
             aria-label="Edit recipe"
             @click="showEditForm = true"
           >
@@ -249,6 +259,15 @@
       @confirm="handleDelete"
       @cancel="showDeleteConfirm = false"
     />
+
+    <!-- Share -->
+    <ShareRecipeModal
+      v-if="recipe"
+      :show="showShareModal"
+      :recipe="recipe"
+      @close="showShareModal = false"
+      @updated="onShareUpdated"
+    />
   </div>
 </template>
 
@@ -265,6 +284,7 @@ import FamilyRating from '@/components/recipes/FamilyRating.vue'
 import CookLogEntry from '@/components/recipes/CookLogEntry.vue'
 import RecipeForm from '@/components/recipes/RecipeForm.vue'
 import AllergenBadgeRow from '@/components/allergens/AllergenBadgeRow.vue'
+import ShareRecipeModal from '@/components/recipes/ShareRecipeModal.vue'
 import ConfirmDialog from '@/components/common/ConfirmDialog.vue'
 import LoadingSpinner from '@/components/common/LoadingSpinner.vue'
 import UserAvatar from '@/components/common/UserAvatar.vue'
@@ -281,6 +301,7 @@ import {
   FireIcon,
   LinkIcon,
   ExclamationCircleIcon,
+  ShareIcon,
 } from '@heroicons/vue/24/outline'
 import { HeartIcon as HeartIconSolid } from '@heroicons/vue/24/solid'
 
@@ -296,6 +317,7 @@ const isParent = computed(() => authStore.isParent)
 const showEditForm = ref(false)
 const showDeleteConfirm = ref(false)
 const showCookLogModal = ref(false)
+const showShareModal = ref(false)
 const cookLogs = ref([])
 const ratings = ref([])
 const heroOverride = ref(null)
@@ -384,6 +406,11 @@ const handleToggleFavorite = async () => {
 const onConfirmAllergen = async (row) => {
   const result = await recipesStore.confirmAllergen(recipe.value.id, row.pivot_id)
   if (!result.success) notifyError(result.error)
+}
+
+const onShareUpdated = (share) => {
+  // Mutate locally so the modal reads the latest state on next open without a refetch.
+  if (recipe.value) recipe.value.share = share
 }
 
 const handleRate = async (score) => {

--- a/resources/views/public/recipe.blade.php
+++ b/resources/views/public/recipe.blade.php
@@ -1,0 +1,258 @@
+<!DOCTYPE html>
+<html lang="{{ str_replace('_', '-', app()->getLocale()) }}">
+@php
+    $tags = $recipe->relationLoaded('tags') ? $recipe->tags->take(1) : collect();
+    $primaryTag = $tags->first();
+    $totalTime = $recipe->total_time_minutes ?? (($recipe->prep_time_minutes ?? 0) + ($recipe->cook_time_minutes ?? 0));
+    $formatTime = function ($m) {
+        if (! $m) return null;
+        if ($m < 60) return $m.'m';
+        $h = intdiv($m, 60);
+        $r = $m % 60;
+        return $r > 0 ? "{$h}h {$r}m" : "{$h}h";
+    };
+    $ogTitle = $recipe->title.' — Shared via Kinhold';
+    $ogDescription = $recipe->description ?: 'A family recipe shared via Kinhold.';
+    $ogImage = $images['primary']['url'] ?? null;
+    if ($ogImage && ! str_starts_with($ogImage, 'http')) {
+        $ogImage = url($ogImage);
+    }
+@endphp
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+
+    <title>{{ $recipe->title }} — Kinhold</title>
+    <meta name="description" content="{{ $ogDescription }}">
+    <meta name="theme-color" content="#1B3A4B">
+
+    <!-- Open Graph -->
+    <meta property="og:type" content="article">
+    <meta property="og:site_name" content="Kinhold">
+    <meta property="og:title" content="{{ $ogTitle }}">
+    <meta property="og:description" content="{{ $ogDescription }}">
+    @if ($ogImage)
+        <meta property="og:image" content="{{ $ogImage }}">
+    @endif
+    <meta property="og:url" content="{{ url('/r/'.$recipe->share_token) }}">
+
+    <!-- Twitter Card -->
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="{{ $ogTitle }}">
+    <meta name="twitter:description" content="{{ $ogDescription }}">
+    @if ($ogImage)
+        <meta name="twitter:image" content="{{ $ogImage }}">
+    @endif
+
+    <link rel="canonical" href="{{ url('/r/'.$recipe->share_token) }}">
+
+    <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
+    <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
+
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=Plus+Jakarta+Sans:wght@600;700&display=swap" rel="stylesheet">
+
+    @vite(['resources/css/app.css'])
+</head>
+<body class="font-sans antialiased bg-surface-base text-ink-primary">
+
+    {{-- ─── Hero band ─── --}}
+    <section class="relative">
+        @if ($images['primary'])
+            {{-- Blurred hero image as background; gradient overlay for legibility. --}}
+            <div class="absolute inset-0 overflow-hidden">
+                <img src="{{ $images['primary']['url'] }}" alt="" class="w-full h-full object-cover scale-110 blur-2xl opacity-60" />
+                <div class="absolute inset-0 bg-gradient-to-b from-black/30 via-surface-base/40 to-surface-base"></div>
+            </div>
+        @else
+            <div class="absolute inset-0 bg-gradient-to-b from-accent-lavender-soft via-surface-base to-surface-base"></div>
+        @endif
+
+        {{-- Top bar over the hero --}}
+        <div class="relative z-10 px-4 md:px-8 pt-4 md:pt-6 flex items-center justify-between">
+            <a href="/" class="inline-flex items-center gap-2 text-ink-primary">
+                <span class="text-base md:text-lg font-bold tracking-tight font-heading">Kinhold</span>
+            </a>
+            <a href="/register" class="inline-flex items-center px-3 py-1.5 rounded-full text-xs font-semibold bg-ink-primary text-white hover:bg-ink-secondary transition-colors">
+                Try Kinhold free →
+            </a>
+        </div>
+
+        {{-- Hero content + main card --}}
+        <div class="relative z-10 px-4 md:px-8 pt-8 md:pt-16 pb-6 md:pb-10 max-w-3xl mx-auto">
+            @if ($primaryTag)
+                <span class="inline-flex items-center px-3 py-1 rounded-full text-xs font-semibold bg-accent-mint-soft text-accent-mint-bold mb-4">
+                    {{ strtoupper($primaryTag->name) }}
+                </span>
+            @else
+                <span class="inline-flex items-center px-3 py-1 rounded-full text-xs font-semibold bg-accent-lavender-soft text-accent-lavender-bold mb-4">
+                    RECIPE
+                </span>
+            @endif
+            <h1 class="text-4xl md:text-5xl font-bold font-heading text-ink-primary tracking-tight leading-tight">
+                {{ $recipe->title }}
+            </h1>
+            @if ($recipe->description)
+                <p class="mt-4 text-base md:text-lg text-ink-secondary max-w-2xl">
+                    {{ $recipe->description }}
+                </p>
+            @endif
+
+            {{-- Meta-card row --}}
+            <div class="mt-6 grid grid-cols-2 md:grid-cols-4 gap-3">
+                @if ($recipe->prep_time_minutes)
+                    <div class="rounded-xl bg-surface-raised border border-border-subtle p-3">
+                        <p class="text-[10px] font-semibold uppercase tracking-wide text-ink-tertiary">Prep</p>
+                        <p class="text-base font-semibold text-ink-primary mt-1">{{ $formatTime($recipe->prep_time_minutes) }}</p>
+                    </div>
+                @endif
+                @if ($recipe->cook_time_minutes)
+                    <div class="rounded-xl bg-surface-raised border border-border-subtle p-3">
+                        <p class="text-[10px] font-semibold uppercase tracking-wide text-ink-tertiary">Cook</p>
+                        <p class="text-base font-semibold text-ink-primary mt-1">{{ $formatTime($recipe->cook_time_minutes) }}</p>
+                    </div>
+                @endif
+                @if ($totalTime)
+                    <div class="rounded-xl bg-accent-lavender-soft border border-accent-lavender-bold/30 p-3">
+                        <p class="text-[10px] font-semibold uppercase tracking-wide text-accent-lavender-bold">Total</p>
+                        <p class="text-base font-semibold text-accent-lavender-bold mt-1">{{ $formatTime($totalTime) }}</p>
+                    </div>
+                @endif
+                @if ($recipe->servings)
+                    <div class="rounded-xl bg-surface-raised border border-border-subtle p-3">
+                        <p class="text-[10px] font-semibold uppercase tracking-wide text-ink-tertiary">Serves</p>
+                        <p class="text-base font-semibold text-ink-primary mt-1">{{ $recipe->servings }}</p>
+                    </div>
+                @endif
+            </div>
+
+            {{-- Allergen banner --}}
+            @if (count($allergens) > 0)
+                <div class="mt-5 rounded-xl bg-status-failed/5 border border-status-failed/20 p-3 md:p-4">
+                    <p class="text-[11px] font-semibold uppercase tracking-wide text-status-failed">Allergens</p>
+                    <div class="mt-2 flex flex-wrap gap-1.5">
+                        @foreach ($allergens as $a)
+                            @php
+                                $isContains = $a['presence'] === 'contains';
+                                $label = $isContains ? $a['name'] : 'May contain '.strtolower($a['name']);
+                            @endphp
+                            <span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium border {{ $isContains
+                                ? 'bg-status-failed/10 text-status-failed border-status-failed/30'
+                                : 'bg-status-warning/10 text-status-warning border-status-warning/40 border-dashed' }}">
+                                {{ $label }}
+                            </span>
+                        @endforeach
+                    </div>
+                </div>
+            @endif
+
+            {{-- Source link --}}
+            @if ($recipe->source_url)
+                <p class="mt-5 text-xs text-ink-tertiary">
+                    Originally from
+                    <a href="{{ $recipe->source_url }}" target="_blank" rel="noopener noreferrer nofollow" class="font-medium text-accent-lavender-bold hover:underline">
+                        {{ parse_url($recipe->source_url, PHP_URL_HOST) }}
+                    </a>
+                </p>
+            @endif
+        </div>
+    </section>
+
+    {{-- ─── Gallery (if multiple images) ─── --}}
+    @if (count($images['extras']) > 0)
+        <section class="px-4 md:px-8 -mt-2 mb-8 max-w-3xl mx-auto">
+            <div class="flex gap-2 overflow-x-auto pb-2">
+                @foreach ($images['extras'] as $img)
+                    <div class="shrink-0 w-24 h-24 md:w-32 md:h-32 rounded-lg overflow-hidden bg-surface-sunken border border-border-subtle">
+                        <img src="{{ $img['url'] }}" alt="" class="w-full h-full object-cover" />
+                    </div>
+                @endforeach
+            </div>
+        </section>
+    @endif
+
+    {{-- ─── Body: ingredients + instructions ─── --}}
+    <section class="px-4 md:px-8 py-8 md:py-12 max-w-3xl mx-auto">
+        <div class="grid md:grid-cols-[minmax(0,1fr)_minmax(0,1.6fr)] gap-8 md:gap-12">
+            {{-- Ingredients --}}
+            <aside class="md:sticky md:top-6 md:self-start">
+                <h2 class="text-sm font-semibold uppercase tracking-wide text-ink-tertiary">Ingredients</h2>
+                <ul class="mt-3 space-y-2.5">
+                    @forelse ($recipe->ingredients as $ing)
+                        <li class="flex gap-2 text-[15px] leading-relaxed text-ink-primary">
+                            <span class="text-ink-tertiary mt-1.5 shrink-0">•</span>
+                            <span>
+                                @if ($ing->quantity)
+                                    <span class="font-semibold">{{ rtrim(rtrim((string) $ing->quantity, '0'), '.') }}</span>
+                                @endif
+                                @if ($ing->unit)
+                                    <span class="text-ink-secondary">{{ $ing->unit }}</span>
+                                @endif
+                                {{ $ing->name }}@if ($ing->preparation)<span class="text-ink-tertiary">, {{ $ing->preparation }}</span>@endif
+                            </span>
+                        </li>
+                    @empty
+                        <li class="text-sm text-ink-tertiary italic">No ingredients listed.</li>
+                    @endforelse
+                </ul>
+            </aside>
+
+            {{-- Instructions --}}
+            <article>
+                <h2 class="text-sm font-semibold uppercase tracking-wide text-ink-tertiary">Method</h2>
+                @php $instructions = is_array($recipe->instructions) ? $recipe->instructions : []; @endphp
+                @if (count($instructions) === 0)
+                    <p class="mt-3 text-sm text-ink-tertiary italic">No instructions yet.</p>
+                @else
+                    <ol class="mt-3 space-y-5">
+                        @foreach ($instructions as $idx => $step)
+                            @php $text = is_array($step) ? ($step['text'] ?? '') : (is_string($step) ? $step : ''); @endphp
+                            <li class="flex gap-4 items-start">
+                                <span class="shrink-0 inline-flex items-center justify-center w-7 h-7 rounded-full bg-accent-lavender-soft text-accent-lavender-bold text-sm font-bold">
+                                    {{ $idx + 1 }}
+                                </span>
+                                <p class="text-[15px] leading-relaxed text-ink-primary pt-0.5">{{ $text }}</p>
+                            </li>
+                        @endforeach
+                    </ol>
+                @endif
+
+                @if ($recipe->notes)
+                    <div class="mt-8 p-4 rounded-xl bg-accent-sun-soft border border-accent-sun-bold/20">
+                        <p class="text-xs font-semibold uppercase tracking-wide text-accent-sun-bold">Notes</p>
+                        <p class="mt-1.5 text-sm text-ink-primary leading-relaxed">{{ $recipe->notes }}</p>
+                    </div>
+                @endif
+            </article>
+        </div>
+    </section>
+
+    {{-- ─── Attribution + CTA footer ─── --}}
+    <section class="px-4 md:px-8 pb-10 max-w-3xl mx-auto">
+        <div class="rounded-2xl bg-surface-raised border border-border-subtle p-5 md:p-6 flex flex-col md:flex-row gap-4 md:items-center md:justify-between">
+            <div>
+                @if ($attribution['visible'] && $attribution['family_name'])
+                    <p class="text-sm text-ink-secondary">Shared by</p>
+                    <p class="text-base font-semibold text-ink-primary">{{ $attribution['family_name'] }}</p>
+                @else
+                    <p class="text-sm text-ink-secondary">Shared via</p>
+                    <p class="text-base font-semibold text-ink-primary">Kinhold</p>
+                @endif
+                <p class="mt-1 text-xs text-ink-tertiary">A family hub for recipes, meals, calendars, and more.</p>
+            </div>
+            <a href="/register" class="inline-flex items-center justify-center px-4 py-2.5 rounded-full text-sm font-semibold bg-ink-primary text-white hover:bg-ink-secondary transition-colors">
+                Try Kinhold free
+            </a>
+        </div>
+
+        <p class="mt-6 text-center text-[11px] text-ink-tertiary">
+            <a href="/" class="hover:underline">kinhold.app</a>
+            &nbsp;·&nbsp;
+            <a href="/privacy" class="hover:underline">Privacy</a>
+            &nbsp;·&nbsp;
+            <a href="/terms" class="hover:underline">Terms</a>
+        </p>
+    </section>
+</body>
+</html>

--- a/resources/views/public/recipe.blade.php
+++ b/resources/views/public/recipe.blade.php
@@ -1,8 +1,6 @@
 <!DOCTYPE html>
 <html lang="{{ str_replace('_', '-', app()->getLocale()) }}">
 @php
-    $tags = $recipe->relationLoaded('tags') ? $recipe->tags->take(1) : collect();
-    $primaryTag = $tags->first();
     $totalTime = $recipe->total_time_minutes ?? (($recipe->prep_time_minutes ?? 0) + ($recipe->cook_time_minutes ?? 0));
     $formatTime = function ($m) {
         if (! $m) return null;
@@ -17,6 +15,54 @@
     if ($ogImage && ! str_starts_with($ogImage, 'http')) {
         $ogImage = url($ogImage);
     }
+
+    // Inline SVG icons for the Big 9. Simple line-art silhouettes; inherit the
+    // surrounding text color via stroke="currentColor". Custom family allergens
+    // fall back to a generic warning glyph.
+    $svgAttrs = 'viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"';
+    $allergenIcons = [
+        'milk' => '<svg '.$svgAttrs.'><path d="M9 4h6l1 3 1 2v9a2 2 0 0 1-2 2H9a2 2 0 0 1-2-2V9l1-2 1-3z"/><path d="M10 13h4"/></svg>',
+        'eggs' => '<svg '.$svgAttrs.'><path d="M12 3c-4 0-5 6-5 10s2 7 5 7 5-3 5-7-1-10-5-10z"/></svg>',
+        'fish' => '<svg '.$svgAttrs.'><path d="M15 12c0-3-4-5-9 0 5 5 9 3 9 0z"/><path d="M15 12l4-4v8z"/><circle cx="9" cy="11" r="0.6" fill="currentColor" stroke="none"/></svg>',
+        'shellfish' => '<svg '.$svgAttrs.'><path d="M5 11c0-3 3-5 7-4s7 4 7 7-3 5-6 4-6-3-6-4"/><path d="M19 13l2-2"/><path d="M12 7l-1-2"/></svg>',
+        'tree-nuts' => '<svg '.$svgAttrs.'><path d="M12 3c-4 0-6 5-6 10 0 4 3 8 6 8s6-4 6-8c0-5-2-10-6-10z"/><path d="M12 6v12"/></svg>',
+        'peanuts' => '<svg '.$svgAttrs.'><circle cx="9.5" cy="9" r="4"/><circle cx="14.5" cy="15" r="4"/></svg>',
+        'wheat' => '<svg '.$svgAttrs.'><path d="M12 21V8"/><path d="M12 13L8 10M12 13l4-3"/><path d="M12 17L8 14M12 17l4-3"/><path d="M12 8c-1-2-2-3-4-3M12 8c1-2 2-3 4-3"/></svg>',
+        'soy' => '<svg '.$svgAttrs.'><path d="M5 12c0-4 4-7 9-7 4 0 6 2 6 5 0 4-4 7-9 7-4 0-6-2-6-5z"/><circle cx="9" cy="11" r="0.9" fill="currentColor" stroke="none"/><circle cx="13" cy="10" r="0.9" fill="currentColor" stroke="none"/><circle cx="16" cy="12" r="0.9" fill="currentColor" stroke="none"/></svg>',
+        'sesame' => '<svg viewBox="0 0 24 24" fill="currentColor" stroke="none"><ellipse cx="8" cy="10" rx="1.4" ry="2"/><ellipse cx="14" cy="9" rx="1.4" ry="2"/><ellipse cx="11" cy="14" rx="1.4" ry="2"/><ellipse cx="17" cy="13.5" rx="1.4" ry="2"/></svg>',
+    ];
+    $fallbackIcon = '<svg '.$svgAttrs.'><circle cx="12" cy="12" r="9"/><path d="M12 8v4M12 16h0"/></svg>';
+
+    // Recipes read better with fractions than decimals. Common cooking fractions
+    // get mapped back; mixed numbers get a whole + fraction format. Matches the
+    // SPA's RecipeForm decimalToFraction helper so the public page and the
+    // in-app view show the same shapes.
+    $decimalToFraction = function ($value) {
+        if ($value === null || $value === '') return '';
+        if (! is_numeric($value)) return (string) $value;
+        $num = (float) $value;
+        if ($num == floor($num)) return (string) (int) $num;
+
+        $whole = (int) floor($num);
+        $dec = round(($num - $whole) * 1000) / 1000;
+        $map = [
+            ['d' => 0.125, 'f' => '1/8'],
+            ['d' => 0.25,  'f' => '1/4'],
+            ['d' => 0.333, 'f' => '1/3'],
+            ['d' => 0.375, 'f' => '3/8'],
+            ['d' => 0.5,   'f' => '1/2'],
+            ['d' => 0.625, 'f' => '5/8'],
+            ['d' => 0.667, 'f' => '2/3'],
+            ['d' => 0.75,  'f' => '3/4'],
+            ['d' => 0.875, 'f' => '7/8'],
+        ];
+        $frac = null;
+        foreach ($map as $row) {
+            if (abs($dec - $row['d']) < 0.005) { $frac = $row['f']; break; }
+        }
+        if (! $frac) return rtrim(rtrim((string) $num, '0'), '.');
+        return $whole > 0 ? "{$whole} {$frac}" : $frac;
+    };
 @endphp
 <head>
     <meta charset="utf-8">
@@ -26,7 +72,7 @@
     <meta name="description" content="{{ $ogDescription }}">
     <meta name="theme-color" content="#1B3A4B">
 
-    <!-- Open Graph -->
+    {{-- Open Graph --}}
     <meta property="og:type" content="article">
     <meta property="og:site_name" content="Kinhold">
     <meta property="og:title" content="{{ $ogTitle }}">
@@ -36,7 +82,7 @@
     @endif
     <meta property="og:url" content="{{ url('/r/'.$recipe->share_token) }}">
 
-    <!-- Twitter Card -->
+    {{-- Twitter Card --}}
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="{{ $ogTitle }}">
     <meta name="twitter:description" content="{{ $ogDescription }}">
@@ -54,53 +100,144 @@
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=Plus+Jakarta+Sans:wght@600;700&display=swap" rel="stylesheet">
 
     @vite(['resources/css/app.css'])
+
+    {{-- Print stylesheet: strip decorative chrome, force ink-friendly colors,
+         avoid page breaks inside list items, constrain the hero image height. --}}
+    <style>
+        @media print {
+            html, body { background: #fff !important; color: #000 !important; }
+            .no-print { display: none !important; }
+            /* Hide the hero gradient overlay so the image prints cleanly */
+            [data-hero-gradient] { display: none !important; }
+            /* Bring the title out of overlay positioning so it flows under the image */
+            [data-hero-title] {
+                position: static !important;
+                padding: 0.75rem 0 0 0 !important;
+            }
+            [data-hero-title] h1 { font-size: 1.5rem !important; }
+            [data-hero-title] p { font-size: 0.9rem !important; }
+            /* Constrain hero image */
+            [data-hero-image] {
+                aspect-ratio: auto !important;
+                max-height: 220px !important;
+                margin-top: 0 !important;
+            }
+            [data-hero-image] img { max-height: 220px !important; }
+            /* Meta cards compact and inline */
+            [data-meta] { gap: 0.5rem !important; }
+            [data-meta] > div { padding: 0.35rem 0.5rem !important; border-color: #ccc !important; background: #f8f8f8 !important; color: #000 !important; }
+            /* Section paddings tightened */
+            section { padding-top: 0.5rem !important; padding-bottom: 0.5rem !important; }
+            /* Avoid awkward breaks */
+            li, ol > li { break-inside: avoid; page-break-inside: avoid; }
+            h1, h2, h3 { break-after: avoid; page-break-after: avoid; }
+            /* Numbered method circle: render as filled dark so it prints visible */
+            [data-step] { background: #000 !important; color: #fff !important; }
+            /* Hyperlinks: keep underline so paper readers can transcribe */
+            a { color: #000 !important; text-decoration: underline !important; }
+            /* Hide gallery thumbnails on paper (saves ink) */
+            [data-gallery] { display: none !important; }
+        }
+    </style>
 </head>
-<body class="font-sans antialiased bg-surface-base text-ink-primary">
+<body class="font-sans antialiased bg-surface-app text-ink-primary">
 
-    {{-- ─── Hero band ─── --}}
-    <section class="relative">
-        @if ($images['primary'])
-            {{-- Blurred hero image as background; gradient overlay for legibility. --}}
-            <div class="absolute inset-0 overflow-hidden">
-                <img src="{{ $images['primary']['url'] }}" alt="" class="w-full h-full object-cover scale-110 blur-2xl opacity-60" />
-                <div class="absolute inset-0 bg-gradient-to-b from-black/30 via-surface-base/40 to-surface-base"></div>
-            </div>
-        @else
-            <div class="absolute inset-0 bg-gradient-to-b from-accent-lavender-soft via-surface-base to-surface-base"></div>
-        @endif
-
-        {{-- Top bar over the hero --}}
-        <div class="relative z-10 px-4 md:px-8 pt-4 md:pt-6 flex items-center justify-between">
-            <a href="/" class="inline-flex items-center gap-2 text-ink-primary">
-                <span class="text-base md:text-lg font-bold tracking-tight font-heading">Kinhold</span>
-            </a>
+    {{-- ─── Top bar ─── --}}
+    <header class="no-print px-4 md:px-8 py-4 md:py-5 flex items-center justify-between max-w-5xl mx-auto">
+        <a href="/" class="inline-flex items-center gap-2 text-ink-primary">
+            <span class="text-base md:text-lg font-bold tracking-tight font-heading">Kinhold</span>
+        </a>
+        <div class="flex items-center gap-2">
+            <button
+                type="button"
+                onclick="window.print()"
+                class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full text-xs font-semibold border border-border-subtle text-ink-secondary hover:text-ink-primary hover:border-ink-primary transition-colors"
+                aria-label="Print this recipe"
+            >
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" class="w-3.5 h-3.5">
+                    <path d="M6 9V3h12v6"/>
+                    <rect x="4" y="9" width="16" height="9" rx="1"/>
+                    <rect x="7" y="14" width="10" height="6"/>
+                </svg>
+                Print
+            </button>
             <a href="/register" class="inline-flex items-center px-3 py-1.5 rounded-full text-xs font-semibold bg-ink-primary text-white hover:bg-ink-secondary transition-colors">
                 Try Kinhold free →
             </a>
         </div>
+    </header>
 
-        {{-- Hero content + main card --}}
-        <div class="relative z-10 px-4 md:px-8 pt-8 md:pt-16 pb-6 md:pb-10 max-w-3xl mx-auto">
-            @if ($primaryTag)
-                <span class="inline-flex items-center px-3 py-1 rounded-full text-xs font-semibold bg-accent-mint-soft text-accent-mint-bold mb-4">
-                    {{ strtoupper($primaryTag->name) }}
-                </span>
-            @else
-                <span class="inline-flex items-center px-3 py-1 rounded-full text-xs font-semibold bg-accent-lavender-soft text-accent-lavender-bold mb-4">
-                    RECIPE
-                </span>
-            @endif
-            <h1 class="text-4xl md:text-5xl font-bold font-heading text-ink-primary tracking-tight leading-tight">
+    {{-- ─── Hero: full-bleed image + bottom gradient with title sitting in it ─── --}}
+    @if ($images['primary'])
+        {{-- Section gets bg-surface-app so any sub-pixel seam between the image
+             and the page bg is filled by the same color. Image wrapper has no
+             overflow-hidden so the gradient can extend past the image bottom. --}}
+        <section class="relative w-full bg-surface-app -mt-2">
+            {{-- Image, clipped --}}
+            <div data-hero-image class="w-full aspect-[16/10] md:aspect-[21/9] max-h-[80vh] overflow-hidden bg-surface-sunken">
+                <img src="{{ $images['primary']['url'] }}" alt="{{ $recipe->title }}" class="w-full h-full object-cover" />
+            </div>
+            {{-- Gradient overlay covers the bottom of the image AND extends a few
+                 pixels past it to hide any anti-alias seam. --}}
+            <div
+                data-hero-gradient
+                class="pointer-events-none absolute inset-x-0"
+                style="bottom: -1px; height: 60%; background-image: linear-gradient(to top,
+                    rgb(var(--surface-app) / 1) 0%,
+                    rgb(var(--surface-app) / 1) 35%,
+                    rgb(var(--surface-app) / 0.85) 55%,
+                    rgb(var(--surface-app) / 0.45) 75%,
+                    rgb(var(--surface-app) / 0) 100%);"
+            ></div>
+            {{-- Title overlays the gradient zone. Description is clamped to 3 lines
+                 so long copy stays visually anchored to the image. --}}
+            <div data-hero-title class="absolute inset-x-0 bottom-0 px-4 md:px-8 pb-4 md:pb-8">
+                <div class="max-w-3xl mx-auto">
+                    <h1 class="text-3xl md:text-5xl font-bold font-heading text-ink-primary tracking-tight leading-tight line-clamp-2">
+                        {{ $recipe->title }}
+                    </h1>
+                    @if ($recipe->description)
+                        <p class="mt-3 md:mt-4 text-base md:text-lg text-ink-secondary leading-relaxed max-w-2xl line-clamp-3">
+                            {{ $recipe->description }}
+                        </p>
+                    @endif
+                    @if ($recipe->source_url)
+                        <p class="mt-3 text-xs text-ink-tertiary">
+                            From
+                            <a href="{{ $recipe->source_url }}" target="_blank" rel="noopener noreferrer nofollow" class="font-medium text-accent-lavender-bold hover:underline">
+                                {{ parse_url($recipe->source_url, PHP_URL_HOST) }}
+                            </a>
+                        </p>
+                    @endif
+                </div>
+            </div>
+        </section>
+    @else
+        {{-- No-image fallback: title in normal flow --}}
+        <section class="px-4 md:px-8 pt-6 md:pt-10 max-w-3xl mx-auto">
+            <h1 class="text-3xl md:text-5xl font-bold font-heading text-ink-primary tracking-tight leading-tight">
                 {{ $recipe->title }}
             </h1>
             @if ($recipe->description)
-                <p class="mt-4 text-base md:text-lg text-ink-secondary max-w-2xl">
+                <p class="mt-3 md:mt-4 text-base md:text-lg text-ink-secondary leading-relaxed">
                     {{ $recipe->description }}
                 </p>
             @endif
+            @if ($recipe->source_url)
+                <p class="mt-3 text-xs text-ink-tertiary">
+                    From
+                    <a href="{{ $recipe->source_url }}" target="_blank" rel="noopener noreferrer nofollow" class="font-medium text-accent-lavender-bold hover:underline">
+                        {{ parse_url($recipe->source_url, PHP_URL_HOST) }}
+                    </a>
+                </p>
+            @endif
+        </section>
+    @endif
 
-            {{-- Meta-card row --}}
-            <div class="mt-6 grid grid-cols-2 md:grid-cols-4 gap-3">
+    {{-- ─── Meta row ─── --}}
+    @if ($recipe->prep_time_minutes || $recipe->cook_time_minutes || $totalTime || $recipe->servings)
+        <section class="px-4 md:px-8 mt-6 md:mt-8 max-w-3xl mx-auto">
+            <div data-meta class="grid grid-cols-2 md:grid-cols-4 gap-3">
                 @if ($recipe->prep_time_minutes)
                     <div class="rounded-xl bg-surface-raised border border-border-subtle p-3">
                         <p class="text-[10px] font-semibold uppercase tracking-wide text-ink-tertiary">Prep</p>
@@ -126,56 +263,26 @@
                     </div>
                 @endif
             </div>
+        </section>
+    @endif
 
-            {{-- Allergen banner --}}
-            @if (count($allergens) > 0)
-                <div class="mt-5 rounded-xl bg-status-failed/5 border border-status-failed/20 p-3 md:p-4">
-                    <p class="text-[11px] font-semibold uppercase tracking-wide text-status-failed">Allergens</p>
-                    <div class="mt-2 flex flex-wrap gap-1.5">
-                        @foreach ($allergens as $a)
-                            @php
-                                $isContains = $a['presence'] === 'contains';
-                                $label = $isContains ? $a['name'] : 'May contain '.strtolower($a['name']);
-                            @endphp
-                            <span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium border {{ $isContains
-                                ? 'bg-status-failed/10 text-status-failed border-status-failed/30'
-                                : 'bg-status-warning/10 text-status-warning border-status-warning/40 border-dashed' }}">
-                                {{ $label }}
-                            </span>
-                        @endforeach
-                    </div>
-                </div>
-            @endif
-
-            {{-- Source link --}}
-            @if ($recipe->source_url)
-                <p class="mt-5 text-xs text-ink-tertiary">
-                    Originally from
-                    <a href="{{ $recipe->source_url }}" target="_blank" rel="noopener noreferrer nofollow" class="font-medium text-accent-lavender-bold hover:underline">
-                        {{ parse_url($recipe->source_url, PHP_URL_HOST) }}
-                    </a>
-                </p>
-            @endif
-        </div>
-    </section>
-
-    {{-- ─── Gallery (if multiple images) ─── --}}
+    {{-- ─── Extras gallery (if multi-image) ─── --}}
     @if (count($images['extras']) > 0)
-        <section class="px-4 md:px-8 -mt-2 mb-8 max-w-3xl mx-auto">
+        <section data-gallery class="px-4 md:px-8 mt-6 max-w-3xl mx-auto">
             <div class="flex gap-2 overflow-x-auto pb-2">
                 @foreach ($images['extras'] as $img)
-                    <div class="shrink-0 w-24 h-24 md:w-32 md:h-32 rounded-lg overflow-hidden bg-surface-sunken border border-border-subtle">
-                        <img src="{{ $img['url'] }}" alt="" class="w-full h-full object-cover" />
+                    <div class="shrink-0 w-24 h-24 md:w-28 md:h-28 rounded-lg overflow-hidden bg-surface-sunken border border-border-subtle">
+                        <img src="{{ $img['url'] }}" alt="" class="w-full h-full object-cover" loading="lazy" />
                     </div>
                 @endforeach
             </div>
         </section>
     @endif
 
-    {{-- ─── Body: ingredients + instructions ─── --}}
+    {{-- ─── Body: ingredients + method ─── --}}
     <section class="px-4 md:px-8 py-8 md:py-12 max-w-3xl mx-auto">
         <div class="grid md:grid-cols-[minmax(0,1fr)_minmax(0,1.6fr)] gap-8 md:gap-12">
-            {{-- Ingredients --}}
+            {{-- Ingredients column --}}
             <aside class="md:sticky md:top-6 md:self-start">
                 <h2 class="text-sm font-semibold uppercase tracking-wide text-ink-tertiary">Ingredients</h2>
                 <ul class="mt-3 space-y-2.5">
@@ -184,7 +291,7 @@
                             <span class="text-ink-tertiary mt-1.5 shrink-0">•</span>
                             <span>
                                 @if ($ing->quantity)
-                                    <span class="font-semibold">{{ rtrim(rtrim((string) $ing->quantity, '0'), '.') }}</span>
+                                    <span class="font-semibold">{{ $decimalToFraction($ing->quantity) }}</span>
                                 @endif
                                 @if ($ing->unit)
                                     <span class="text-ink-secondary">{{ $ing->unit }}</span>
@@ -196,9 +303,32 @@
                         <li class="text-sm text-ink-tertiary italic">No ingredients listed.</li>
                     @endforelse
                 </ul>
+
+                {{-- Allergens — line-art icon row beneath ingredients --}}
+                @if (count($allergens) > 0)
+                    <div class="mt-6 pt-4 border-t border-border-subtle">
+                        <h3 class="text-[11px] font-semibold uppercase tracking-wide text-ink-tertiary">Contains</h3>
+                        <ul class="mt-2.5 space-y-2">
+                            @foreach ($allergens as $a)
+                                @php
+                                    $isContains = $a['presence'] === 'contains';
+                                    $icon = $allergenIcons[$a['slug']] ?? $fallbackIcon;
+                                @endphp
+                                <li class="flex items-center gap-2.5 text-sm">
+                                    <span class="shrink-0 inline-flex items-center justify-center w-5 h-5 text-ink-primary" aria-hidden="true">
+                                        {!! $icon !!}
+                                    </span>
+                                    <span class="{{ $isContains ? 'text-ink-primary' : 'text-ink-secondary italic' }}">
+                                        {{ $a['name'] }}@if (! $isContains) <span class="text-ink-tertiary">(may contain)</span>@endif
+                                    </span>
+                                </li>
+                            @endforeach
+                        </ul>
+                    </div>
+                @endif
             </aside>
 
-            {{-- Instructions --}}
+            {{-- Method column --}}
             <article>
                 <h2 class="text-sm font-semibold uppercase tracking-wide text-ink-tertiary">Method</h2>
                 @php $instructions = is_array($recipe->instructions) ? $recipe->instructions : []; @endphp
@@ -209,7 +339,7 @@
                         @foreach ($instructions as $idx => $step)
                             @php $text = is_array($step) ? ($step['text'] ?? '') : (is_string($step) ? $step : ''); @endphp
                             <li class="flex gap-4 items-start">
-                                <span class="shrink-0 inline-flex items-center justify-center w-7 h-7 rounded-full bg-accent-lavender-soft text-accent-lavender-bold text-sm font-bold">
+                                <span data-step class="shrink-0 inline-flex items-center justify-center w-7 h-7 rounded-full bg-accent-lavender-soft text-accent-lavender-bold text-sm font-bold">
                                     {{ $idx + 1 }}
                                 </span>
                                 <p class="text-[15px] leading-relaxed text-ink-primary pt-0.5">{{ $text }}</p>
@@ -229,7 +359,7 @@
     </section>
 
     {{-- ─── Attribution + CTA footer ─── --}}
-    <section class="px-4 md:px-8 pb-10 max-w-3xl mx-auto">
+    <section class="no-print px-4 md:px-8 pb-10 max-w-3xl mx-auto">
         <div class="rounded-2xl bg-surface-raised border border-border-subtle p-5 md:p-6 flex flex-col md:flex-row gap-4 md:items-center md:justify-between">
             <div>
                 @if ($attribution['visible'] && $attribution['family_name'])

--- a/routes/api.php
+++ b/routes/api.php
@@ -18,6 +18,7 @@ use App\Http\Controllers\Api\V1\PointsController;
 use App\Http\Controllers\Api\V1\PushSubscriptionController;
 use App\Http\Controllers\Api\V1\RecipeAllergenController;
 use App\Http\Controllers\Api\V1\RecipeController;
+use App\Http\Controllers\Api\V1\RecipeShareController;
 use App\Http\Controllers\Api\V1\RestaurantController;
 use App\Http\Controllers\Api\V1\RewardsController;
 use App\Http\Controllers\Api\V1\SettingsController;
@@ -238,6 +239,11 @@ Route::prefix('v1')->group(function () {
 
                 // Family-wide AI allergen backfill (parent only)
                 Route::post('/allergens/backfill', [RecipeAllergenController::class, 'backfill']);
+
+                // Public sharing (parent only)
+                Route::post('/{recipe}/share', [RecipeShareController::class, 'store']);
+                Route::patch('/{recipe}/share', [RecipeShareController::class, 'update']);
+                Route::delete('/{recipe}/share', [RecipeShareController::class, 'destroy']);
             });
 
             // Allergens (module: food)

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Http\Controllers\Api\V1\GoogleAuthController;
+use App\Http\Controllers\Public\PublicRecipeController;
 use App\Models\User;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
@@ -44,6 +45,10 @@ Route::get('/auth/google/link-callback', [GoogleAuthController::class, 'linkCall
 // /login itself is unbound so the SPA catch-all serves the SPA login form.
 Route::get('/auth/oauth-login', [GoogleAuthController::class, 'oauthLogin'])->name('login');
 Route::get('/auth/google/oauth-callback', [GoogleAuthController::class, 'oauthCallback'])->name('google.oauth-callback');
+
+// Public recipe share — server-rendered Blade view with OG tags for social
+// unfurl. Must be declared before the SPA catch-all so it wins on `/r/...`.
+Route::get('/r/{token}', [PublicRecipeController::class, 'show'])->name('public.recipe');
 
 // SPA catch-all — exclude api/, oauth/, and .well-known/ paths
 Route::get('{any}', function () {

--- a/tests/Feature/PublicRecipeSharingTest.php
+++ b/tests/Feature/PublicRecipeSharingTest.php
@@ -1,0 +1,263 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Enums\AllergenPresence;
+use App\Enums\AllergenSource;
+use App\Enums\FamilyRole;
+use App\Models\Allergen;
+use App\Models\Family;
+use App\Models\Recipe;
+use App\Models\RecipeImage;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Str;
+use Laravel\Sanctum\Sanctum;
+use Tests\TestCase;
+
+class PublicRecipeSharingTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private Family $family;
+
+    private User $parent;
+
+    private User $child;
+
+    private Recipe $recipe;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->family = Family::create([
+            'name' => 'The Ellis Family',
+            'slug' => 'ellis',
+            'invite_code' => 'ELLIS1',
+            'settings' => ['modules' => ['food' => true]],
+        ]);
+
+        $this->parent = User::create([
+            'name' => 'Parent',
+            'email' => 'parent@test.com',
+            'password' => bcrypt('password'),
+            'family_id' => $this->family->id,
+            'family_role' => FamilyRole::Parent,
+        ]);
+
+        $this->child = User::create([
+            'name' => 'Child',
+            'email' => 'child@test.com',
+            'password' => bcrypt('password'),
+            'family_id' => $this->family->id,
+            'family_role' => FamilyRole::Child,
+        ]);
+
+        $this->recipe = Recipe::create([
+            'family_id' => $this->family->id,
+            'created_by' => $this->parent->id,
+            'title' => 'Banana Bread',
+            'description' => 'Family favourite.',
+            'servings' => 8,
+            'prep_time_minutes' => 10,
+            'cook_time_minutes' => 50,
+            'instructions' => [
+                ['step' => 1, 'text' => 'Mash bananas.'],
+                ['step' => 2, 'text' => 'Mix dry ingredients.'],
+            ],
+        ]);
+    }
+
+    // ── API: share / attribution / revoke ──
+
+    public function test_parent_can_publish_a_recipe_and_url_is_returned(): void
+    {
+        Sanctum::actingAs($this->parent);
+
+        $response = $this->postJson("/api/v1/recipes/{$this->recipe->id}/share")
+            ->assertCreated();
+
+        $share = $response->json('share');
+        $this->assertTrue($share['is_shared']);
+        $this->assertNotNull($share['url']);
+        $this->assertStringContainsString('/r/', $share['url']);
+        $this->assertFalse($share['visible_attribution']);
+
+        $this->recipe->refresh();
+        $this->assertNotNull($this->recipe->share_token);
+    }
+
+    public function test_publishing_twice_does_not_rotate_the_token(): void
+    {
+        Sanctum::actingAs($this->parent);
+
+        $first = $this->postJson("/api/v1/recipes/{$this->recipe->id}/share")->json('share');
+        $second = $this->postJson("/api/v1/recipes/{$this->recipe->id}/share")->json('share');
+
+        $this->assertEquals($first['url'], $second['url']);
+    }
+
+    public function test_child_cannot_publish_recipe(): void
+    {
+        Sanctum::actingAs($this->child);
+
+        $this->postJson("/api/v1/recipes/{$this->recipe->id}/share")->assertForbidden();
+    }
+
+    public function test_patch_toggles_attribution_without_changing_token(): void
+    {
+        $this->recipe->forceFill(['share_token' => 'fixedtoken1234567890ab'])->save();
+        Sanctum::actingAs($this->parent);
+
+        $response = $this->patchJson("/api/v1/recipes/{$this->recipe->id}/share", [
+            'visible_attribution' => true,
+        ])->assertOk();
+
+        $share = $response->json('share');
+        $this->assertTrue($share['visible_attribution']);
+        $this->assertStringContainsString('fixedtoken1234567890ab', $share['url']);
+    }
+
+    public function test_patch_attribution_fails_when_not_shared(): void
+    {
+        Sanctum::actingAs($this->parent);
+
+        $this->patchJson("/api/v1/recipes/{$this->recipe->id}/share", [
+            'visible_attribution' => true,
+        ])->assertStatus(422);
+    }
+
+    public function test_revoke_clears_token_and_old_url_404s(): void
+    {
+        Sanctum::actingAs($this->parent);
+
+        $url = $this->postJson("/api/v1/recipes/{$this->recipe->id}/share")->json('share.url');
+        $token = basename(parse_url($url, PHP_URL_PATH));
+
+        // Public URL works while shared
+        $this->get("/r/{$token}")->assertOk();
+
+        // Revoke
+        $this->deleteJson("/api/v1/recipes/{$this->recipe->id}/share")->assertOk();
+
+        // Old URL now hard-404s
+        $this->get("/r/{$token}")->assertNotFound();
+
+        $this->recipe->refresh();
+        $this->assertNull($this->recipe->share_token);
+        $this->assertFalse($this->recipe->share_visible_attribution);
+    }
+
+    public function test_revoking_and_resharing_mints_a_new_token(): void
+    {
+        Sanctum::actingAs($this->parent);
+
+        $first = $this->postJson("/api/v1/recipes/{$this->recipe->id}/share")->json('share.url');
+        $this->deleteJson("/api/v1/recipes/{$this->recipe->id}/share")->assertOk();
+        $second = $this->postJson("/api/v1/recipes/{$this->recipe->id}/share")->json('share.url');
+
+        $this->assertNotEquals($first, $second);
+    }
+
+    public function test_resource_exposes_share_state_for_owner(): void
+    {
+        Sanctum::actingAs($this->parent);
+
+        $this->postJson("/api/v1/recipes/{$this->recipe->id}/share");
+        $response = $this->getJson("/api/v1/recipes/{$this->recipe->id}")->assertOk();
+
+        $this->assertTrue($response->json('recipe.share.is_shared'));
+        $this->assertNotNull($response->json('recipe.share.url'));
+    }
+
+    // ── Public route ──
+
+    public function test_public_route_renders_recipe_with_title(): void
+    {
+        $this->recipe->forceFill(['share_token' => 'visibletoken123456789a'])->save();
+
+        $this->get('/r/visibletoken123456789a')
+            ->assertOk()
+            ->assertSee('Banana Bread', false)
+            ->assertSee('Family favourite.', false)
+            ->assertSee('Mash bananas.', false);
+    }
+
+    public function test_public_route_emits_og_tags_with_image(): void
+    {
+        $this->recipe->forceFill(['share_token' => 'ogimgtoken1234567890ab'])->save();
+        RecipeImage::create([
+            'id' => (string) Str::uuid(),
+            'recipe_id' => $this->recipe->id,
+            'path' => 'recipes/banana.jpg',
+            'sort_order' => 0,
+            'is_primary' => true,
+        ]);
+        $this->recipe->forceFill(['image_path' => 'recipes/banana.jpg'])->save();
+
+        $response = $this->get('/r/ogimgtoken1234567890ab')->assertOk();
+        $html = $response->getContent();
+
+        $this->assertStringContainsString('property="og:type" content="article"', $html);
+        $this->assertStringContainsString('property="og:title"', $html);
+        $this->assertStringContainsString('Banana Bread', $html);
+        $this->assertStringContainsString('property="og:image"', $html);
+        $this->assertStringContainsString('recipes/banana.jpg', $html);
+    }
+
+    public function test_public_route_renders_allergens(): void
+    {
+        $this->recipe->forceFill(['share_token' => 'allergentkn1234567890a'])->save();
+        $peanuts = Allergen::where('slug', 'peanuts')->whereNull('family_id')->firstOrFail();
+        $this->recipe->allergens()->attach($peanuts->id, [
+            'id' => (string) Str::uuid(),
+            'presence' => AllergenPresence::Contains->value,
+            'source' => AllergenSource::HumanConfirmed->value,
+            'confirmed_by' => $this->parent->id,
+            'confirmed_at' => now(),
+        ]);
+
+        $response = $this->get('/r/allergentkn1234567890a')->assertOk();
+
+        $this->assertStringContainsString('Allergens', $response->getContent());
+        $this->assertStringContainsString('Peanuts', $response->getContent());
+    }
+
+    public function test_public_route_attribution_anonymous_by_default(): void
+    {
+        $this->recipe->forceFill([
+            'share_token' => 'attribtoken12345678901',
+            'share_visible_attribution' => false,
+        ])->save();
+
+        $html = $this->get('/r/attribtoken12345678901')->assertOk()->getContent();
+        $this->assertStringNotContainsString('The Ellis Family', $html);
+        $this->assertStringContainsString('Shared via', $html);
+    }
+
+    public function test_public_route_attribution_visible_when_opted_in(): void
+    {
+        $this->recipe->forceFill([
+            'share_token' => 'attribtoken22345678901',
+            'share_visible_attribution' => true,
+        ])->save();
+
+        $html = $this->get('/r/attribtoken22345678901')->assertOk()->getContent();
+        $this->assertStringContainsString('The Ellis Family', $html);
+        $this->assertStringContainsString('Shared by', $html);
+    }
+
+    public function test_public_route_404_on_unknown_token(): void
+    {
+        $this->get('/r/this-token-does-not-exist')->assertNotFound();
+    }
+
+    public function test_public_route_does_not_require_authentication(): void
+    {
+        $this->recipe->forceFill(['share_token' => 'guesttoken1234567890ab'])->save();
+
+        // No Sanctum::actingAs — public access
+        $this->get('/r/guesttoken1234567890ab')->assertOk();
+    }
+}

--- a/vite.config.js
+++ b/vite.config.js
@@ -97,6 +97,7 @@ export default defineConfig({
           /^\/mcp/,
           /^\/login/,
           /^\/oauth/,
+          /^\/r\//,
           /^\/sanctum/,
           /^\/storage\//,
         ],


### PR DESCRIPTION
## Summary
PR 6 of 6 toward v1.10.0 — the final sub-PR. Publishes recipes to public URLs with a dedicated, beautiful Blade-rendered page. Design takes its cues from the Crackin' events layout Greg shared (blurred hero, floating content card, meta-card row, attribution footer) but is wired to Kinhold's design tokens so it reads native.

## Linked Issues
Closes #311

## What ships

**Schema:**
- `recipes.share_token` (string, nullable, unique) — null = not shared
- `recipes.share_visible_attribution` (boolean, default false) — anonymous by default, owner opts in

**Backend — share API (parent-only):**
- `POST /api/v1/recipes/{id}/share` — mints a 22-char base62 token (~131 bits). Idempotent.
- `PATCH /api/v1/recipes/{id}/share` — toggles attribution without rotating the token.
- `DELETE /api/v1/recipes/{id}/share` — revoke. Clears token + attribution. Re-sharing later mints a fresh token (old links die permanently on revoke).
- `RecipeResource` exposes a `share` object on every detail payload.

**Public page — `/r/{token}`:**
- Pure SSR Blade view. No auth required; unguessable token is the access grant. 404 on miss.
- Crackin'-inspired layout:
  - Full-bleed blurred hero (primary image as background, gradient overlay for legibility)
  - Top bar: Kinhold brand + "Try Kinhold free" CTA
  - Floating content: category pill (first food tag or "Recipe"), big Plus Jakarta Sans title, description
  - 2×2 meta cards (Prep / Cook / Total / Serves) — Total highlighted in lavender accent
  - Prominent allergen banner with same contains-red / may_contain-yellow-dashed treatment used throughout the app
  - Source link to original site (if imported)
  - Optional extras gallery row
  - Two-column body: sticky ingredients (left) + numbered method instructions (right)
  - Notes panel in sun accent if present
  - Attribution footer card: anonymous "Shared via Kinhold" by default; opts up to "Shared by [Family Name]" when toggled
  - "Try Kinhold free" CTA + footer links
- OG / Twitter Card meta tags wired from recipe title + description + primary image so link unfurls render properly in iMessage / Slack / Discord / Twitter

**SPA share UI:**
- `ShareRecipeModal` on recipe detail (parent-only)
- Publish button when unshared
- When shared: copy-to-clipboard URL field (with ✓ feedback), attribution `KinSwitch` with helper copy, Revoke action with confirm
- New Share icon-button in the recipe detail header (parent-only)

## Test Plan
- [x] 15 new tests in `PublicRecipeSharingTest`: share/revoke/re-share token rotation, PATCH attribution preserves token, fails 422 when not shared, child cannot publish, resource exposes share state, public route renders recipe + OG tags + allergens, attribution anonymous by default, opt-in family name visible, 404 on bad token, no auth required
- [x] Full suite: 442 tests, 1168 assertions, green
- [x] Pint + PHPStan + ESLint clean
- [x] **Manual verification in preview**: shared Chocolate Chip Cookies → opened the public URL → page rendered with blurred warm hero, Recipe pill, big title, full meta-card row, allergen banner (Peanuts in red), numbered method, attribution footer with Kinhold branding + free-tier CTA. Mobile-first holds at 375px. Share modal in the SPA shows the URL with copy button + attribution toggle + revoke action.

## Checklist
- [x] Tested locally + in preview
- [x] Mobile-first verified
- [x] No credentials committed
- [x] Public URLs are unguessable (22 chars, base62)
- [x] Revoke cleanly 404s old URLs
- [x] OG tags emit recipe title, description, image
- [x] Defense-in-depth: public route returns 404 for never-shared and revoked alike (no info leak about existence)

## Target branch
`feature/allergens-v1.10.0` (integration branch)

## After this merges
v1.10.0 sub-PRs complete. Next step: integration → main PR that bumps `config/version.php` to `1.10.0`, updates CHANGELOG + ROADMAP, and `/merge` tags `v1.10.0`.